### PR TITLE
Add type annotations to pyoxigraph

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --no-cache-dir \
-    "maturin>=0.9,<0.10" \
+    maturin \
     sphinx \
     sphinx-autobuild \
     furo

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/rust/.devcontainer/base.Dockerfile
+
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        python3-venv \
+        libclang-dev
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip3 install maturin
+
+# Change owner to the devcontainer user
+RUN chown -R 1001:1001 $VIRTUAL_ENV

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,13 +7,18 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 # [Optional] Uncomment this section to install additional packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+        python3 \
         python3-venv \
+        python-is-python3 \
         libclang-dev
 
 ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
+RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip3 install maturin
+RUN pip install --no-cache-dir \
+    maturin \
+    sphinx \
+    sphinx-autobuild
 
 # Change owner to the devcontainer user
 RUN chown -R 1000:1000 $VIRTUAL_ENV

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,4 +16,4 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install maturin
 
 # Change owner to the devcontainer user
-RUN chown -R 1001:1001 $VIRTUAL_ENV
+RUN chown -R 1000:1000 $VIRTUAL_ENV

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --no-cache-dir \
-    maturin \
+    "maturin>=0.9,<0.10" \
     sphinx \
     sphinx-autobuild
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/rust
+{
+	"name": "Rust",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+			// Use bullseye when on local on arm64/Apple Silicon.
+			"VARIANT": "bullseye"
+		}
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"lldb.executable": "/usr/bin/lldb",
+				// VS Code don't watch files under ./target
+				"files.watcherExclude": {
+					"**/target/**": true
+				},
+				"rust-analyzer.checkOnSave.command": "clippy"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"vadimcn.vscode-lldb",
+				"mutantdino.resourcemonitor",
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml",
+				"serayuzgur.crates"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"python": "3.10"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,73 +1,69 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/rust
 {
-	"name": "Rust",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
-			// Use bullseye when on local on arm64/Apple Silicon.
-			"VARIANT": "bullseye"
-		}
-	},
-	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined"
-	],
+  "name": "Rust",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+      // Use bullseye when on local on arm64/Apple Silicon.
+      "VARIANT": "bullseye"
+    }
+  },
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 
-	// Configure tool-specific properties.
-	"customizations": {
-		// Configure properties specific to VS Code.
-		"vscode": {
-			// Set *default* container specific settings.json values on container create.
-			"settings": { 
-				"lldb.executable": "/usr/bin/lldb",
-				// VS Code don't watch files under ./target
-				"files.watcherExclude": {
-					"**/target/**": true
-				},
-				"rust-analyzer.checkOnSave.command": "clippy",
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "lldb.executable": "/usr/bin/lldb",
+        // VS Code don't watch files under ./target
+        "files.watcherExclude": {
+          "**/target/**": true
+        },
+        "rust-analyzer.checkOnSave.command": "clippy",
 
-				"python.defaultInterpreterPath": "/opt/venv/bin/python",
-				"python.linting.enabled": true,
-				"python.linting.pylintEnabled": true,
-				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-				"python.linting.pylintPath": "/opt/venv/bin/pylint",
-				"python.testing.pytestPath": "/opt/venv/bin/pytest"
-			},
-			
-			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"vadimcn.vscode-lldb",
-				"mutantdino.resourcemonitor",
-				"rust-lang.rust-analyzer",
-				"tamasfe.even-better-toml",
-				"serayuzgur.crates",
-				"ms-python.python",
-				"ms-python.vscode-pylance",
-				"esbenp.prettier-vscode",
-				"stardog-union.stardog-rdf-grammars"
-			]
-		}
-	},
+        "python.defaultInterpreterPath": "/opt/venv/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/opt/venv/bin/pylint",
+        "python.testing.pytestPath": "/opt/venv/bin/pytest"
+      },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "vadimcn.vscode-lldb",
+        "mutantdino.resourcemonitor",
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "serayuzgur.crates",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "esbenp.prettier-vscode",
+        "stardog-union.stardog-rdf-grammars"
+      ]
+    }
+  },
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "git submodule update --init && cargo build",
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
-	"features": {
-		"python": "3.10"
-	}
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "git submodule update --init && cargo build",
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "python": "3.10"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,21 @@
 				"files.watcherExclude": {
 					"**/target/**": true
 				},
-				"rust-analyzer.checkOnSave.command": "clippy"
+				"rust-analyzer.checkOnSave.command": "clippy",
+
+				"python.defaultInterpreterPath": "/opt/venv/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/opt/venv/bin/pylint",
+				"python.testing.pytestPath": "/opt/venv/bin/pytest"
 			},
 			
 			// Add the IDs of extensions you want installed when the container is created.
@@ -36,7 +50,11 @@
 				"mutantdino.resourcemonitor",
 				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
-				"serayuzgur.crates"
+				"serayuzgur.crates",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"esbenp.prettier-vscode",
+				"stardog-union.stardog-rdf-grammars"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "",
+	"postCreateCommand": "git submodule update --init && cargo build",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - run: pip install --upgrade maturin sphinx
+      - run: pip install --upgrade maturin sphinx furo
       - run: maturin sdist -m python/Cargo.toml
       - run: pip install target/wheels/*.tar.gz
       - run: python -m unittest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ venv
 .env
 data/
 .htpasswd
+**/docs/_build
+**/docs/build
+*.so
+*.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.defaultInterpreterPath": "/opt/venv/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.defaultInterpreterPath": "/opt/venv/bin/python"
-}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-Oxigraph
-========
+# Oxigraph
 
-[![Latest Version](https://img.shields.io/crates/v/oxigraph.svg)](https://crates.io/crates/oxigraph) 
+[![Latest Version](https://img.shields.io/crates/v/oxigraph.svg)](https://crates.io/crates/oxigraph)
 [![Released API docs](https://docs.rs/oxigraph/badge.svg)](https://docs.rs/oxigraph)
 [![PyPI](https://img.shields.io/pypi/v/pyoxigraph)](https://pypi.org/project/pyoxigraph/)
 [![npm](https://img.shields.io/npm/v/oxigraph)](https://www.npmjs.com/package/oxigraph)
@@ -21,23 +20,32 @@ The development roadmap is using [GitHub milestones](https://github.com/oxigraph
 Oxigraph internal design [is described on the wiki](https://github.com/oxigraph/oxigraph/wiki/Architecture).
 
 It is split into multiple parts:
-* [The database written as a Rust library](https://crates.io/crates/oxigraph). Its source code is in the `lib` directory.
-[![Latest Version](https://img.shields.io/crates/v/oxigraph.svg)](https://crates.io/crates/oxigraph) 
-[![Released API docs](https://docs.rs/oxigraph/badge.svg)](https://docs.rs/oxigraph)
-* [`pyoxigraph` that exposes Oxigraph to the Python world](https://oxigraph.org/pyoxigraph/). Its source code is in the `python` directory. [![PyPI](https://img.shields.io/pypi/v/pyoxigraph)](https://pypi.org/project/pyoxigraph/)
-* [JavaScript bindings for Oxigraph](https://www.npmjs.com/package/oxigraph). WebAssembly is used to package Oxigraph into a NodeJS compatible NPM package. Its source code is in the `js` directory.
-[![npm](https://img.shields.io/npm/v/oxigraph)](https://www.npmjs.com/package/oxigraph)
-* [Oxigraph server](https://crates.io/crates/oxigraph_server) that provides a standalone binary of a web server implementing the [SPARQL 1.1 Protocol](https://www.w3.org/TR/sparql11-protocol/) and the [SPARQL 1.1 Graph Store Protocol](https://www.w3.org/TR/sparql11-http-rdf-update/). Its source code is in the `server` directory.
-[![Latest Version](https://img.shields.io/crates/v/oxigraph_server.svg)](https://crates.io/crates/oxigraph_server) 
-[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/oxigraph/oxigraph?sort=semver)](https://hub.docker.com/r/oxigraph/oxigraph)
+
+- [The database written as a Rust library](https://crates.io/crates/oxigraph). Its source code is in the `lib` directory.
+  [![Latest Version](https://img.shields.io/crates/v/oxigraph.svg)](https://crates.io/crates/oxigraph)
+  [![Released API docs](https://docs.rs/oxigraph/badge.svg)](https://docs.rs/oxigraph)
+- [`pyoxigraph` that exposes Oxigraph to the Python world](https://oxigraph.org/pyoxigraph/). Its source code is in the `python` directory. [![PyPI](https://img.shields.io/pypi/v/pyoxigraph)](https://pypi.org/project/pyoxigraph/)
+- [JavaScript bindings for Oxigraph](https://www.npmjs.com/package/oxigraph). WebAssembly is used to package Oxigraph into a NodeJS compatible NPM package. Its source code is in the `js` directory.
+  [![npm](https://img.shields.io/npm/v/oxigraph)](https://www.npmjs.com/package/oxigraph)
+- [Oxigraph server](https://crates.io/crates/oxigraph_server) that provides a standalone binary of a web server implementing the [SPARQL 1.1 Protocol](https://www.w3.org/TR/sparql11-protocol/) and the [SPARQL 1.1 Graph Store Protocol](https://www.w3.org/TR/sparql11-http-rdf-update/). Its source code is in the `server` directory.
+  [![Latest Version](https://img.shields.io/crates/v/oxigraph_server.svg)](https://crates.io/crates/oxigraph_server)
+  [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/oxigraph/oxigraph?sort=semver)](https://hub.docker.com/r/oxigraph/oxigraph)
 
 Oxigraph implements the following specifications:
-* [SPARQL 1.1 Query](https://www.w3.org/TR/sparql11-query/), [SPARQL 1.1 Update](https://www.w3.org/TR/sparql11-update/), and [SPARQL 1.1 Federated Query](https://www.w3.org/TR/sparql11-federated-query/).
-* [Turtle](https://www.w3.org/TR/turtle/), [TriG](https://www.w3.org/TR/trig/), [N-Triples](https://www.w3.org/TR/n-triples/), [N-Quads](https://www.w3.org/TR/n-quads/), and [RDF XML](https://www.w3.org/TR/rdf-syntax-grammar/) RDF serialization formats for both data ingestion and retrieval using the [Rio library](https://github.com/oxigraph/rio).
-* [SPARQL Query Results XML Format](http://www.w3.org/TR/rdf-sparql-XMLres/), [SPARQL 1.1 Query Results JSON Format](https://www.w3.org/TR/sparql11-results-json/) and [SPARQL 1.1 Query Results CSV and TSV Formats](https://www.w3.org/TR/sparql11-results-csv-tsv/).
+
+- [SPARQL 1.1 Query](https://www.w3.org/TR/sparql11-query/), [SPARQL 1.1 Update](https://www.w3.org/TR/sparql11-update/), and [SPARQL 1.1 Federated Query](https://www.w3.org/TR/sparql11-federated-query/).
+- [Turtle](https://www.w3.org/TR/turtle/), [TriG](https://www.w3.org/TR/trig/), [N-Triples](https://www.w3.org/TR/n-triples/), [N-Quads](https://www.w3.org/TR/n-quads/), and [RDF XML](https://www.w3.org/TR/rdf-syntax-grammar/) RDF serialization formats for both data ingestion and retrieval using the [Rio library](https://github.com/oxigraph/rio).
+- [SPARQL Query Results XML Format](http://www.w3.org/TR/rdf-sparql-XMLres/), [SPARQL 1.1 Query Results JSON Format](https://www.w3.org/TR/sparql11-results-json/) and [SPARQL 1.1 Query Results CSV and TSV Formats](https://www.w3.org/TR/sparql11-results-csv-tsv/).
 
 A preliminary benchmark [is provided](bench/README.md). There is also [a document describing Oxigraph technical architecture](https://github.com/oxigraph/oxigraph/wiki/Architecture).
 
+## Development
+
+The easiest way to set up the development environment is to use Visual Studio Code's [development containers](https://code.visualstudio.com/docs/remote/containers). Note that this requires Docker Desktop on Windows and Mac and Docker CE/EE on Linux.
+
+Open the repository with Visual Studio Code and use the Command Palette to run `Remote-Containers: Rebuild Container`. This will re-open the project inside a development container with the Rust toolchain and Python dependencies installed. For more details on how the development container is set up, see [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json) and [.devcontainer/Dockerfile](.devcontainer/Dockerfile).
+
+For further development details, see the README in each of the respective sub-projects.
 
 ## Help
 
@@ -46,18 +54,16 @@ Feel free to use [GitHub discussions](https://github.com/oxigraph/oxigraph/discu
 
 If you need advanced support or are willing to pay to get some extra features, feel free to reach out to [Tpt](https://github.com/Tpt/).
 
-
 ## License
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
-   
-at your option.
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  http://opensource.org/licenses/MIT)
 
+at your option.
 
 ### Contribution
 

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,4 +1,0 @@
-docs/_build
-docs/build
-*.so
-*.pyc

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,4 @@
+docs/_build
+docs/build
+*.so
+*.pyc

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,4 @@
-Pyoxigraph (Oxigraph for Python)
-================================
+# Pyoxigraph (Oxigraph for Python)
 
 [![PyPI](https://img.shields.io/pypi/v/pyoxigraph)](https://pypi.org/project/pyoxigraph/)
 ![PyPI - Implementation](https://img.shields.io/pypi/implementation/pyoxigraph)
@@ -9,13 +8,13 @@ Pyoxigraph (Oxigraph for Python)
 
 Pyoxigraph is a graph database library implementing the [SPARQL](https://www.w3.org/TR/sparql11-overview/) standard.
 It is a Python library written on top of [Oxigraph](https://crates.io/crates/oxigraph).
- 
+
 Pyoxigraph offers two stores with [SPARQL 1.1](https://www.w3.org/TR/sparql11-overview/) capabilities.
 One of the store is in-memory, and the other one is disk based.
 
 It also provides a set of utility functions for reading, writing and processing RDF files in
-[Turtle](https://www.w3.org/TR/turtle/), 
-[TriG](https://www.w3.org/TR/trig/), 
+[Turtle](https://www.w3.org/TR/turtle/),
+[TriG](https://www.w3.org/TR/trig/),
 [N-Triples](https://www.w3.org/TR/n-triples/),
 [N-Quads](https://www.w3.org/TR/n-quads/) and
 [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/).
@@ -32,14 +31,12 @@ Pyoxigraph documentation is [available on the Oxigraph website](https://oxigraph
 To build and install the development version of pyoxigraph you need to clone this git repository
 and to run `pip install .` in the `python` directory (the one this README is in).
 
-
 ## Help
 
 Feel free to use [GitHub discussions](https://github.com/oxigraph/oxigraph/discussions) or [the Gitter chat](https://gitter.im/oxigraph/community) to ask questions or talk about Oxigraph.
 [Bug reports](https://github.com/oxigraph/oxigraph/issues) are also very welcome.
 
 If you need advanced support or are willing to pay to get some extra features, feel free to reach out to [Tpt](https://github.com/Tpt).
-
 
 ## How to contribute
 
@@ -49,20 +46,33 @@ Pyoxigraph is built using [Maturin](https://github.com/PyO3/maturin).
 Maturin could be installed using the `pip install 'maturin>=0.9,<0.10'`.
 To install a development version of Oxigraph just run `maturin develop` in this README directory.
 
+### Tests
+
 The Python bindings tests are written in Python.
 To run them use `python -m unittest` in the `tests` directory.
+
+### Docs
+
+The Sphinx documentation can be generated and viewed in the browser using the following command:
+
+```
+sphinx-autobuild docs docs/_build/html
+```
+
+Note that you will need to have [sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/) installed. This should be installed already if you are using this repository's development container.
+
+Alternatively, you can use `sphinx-build` with Python's `http.server` to achieve the same thing.
 
 ## License
 
 This project is licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or
+- Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or
   http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](../LICENSE-MIT) or
+- MIT license ([LICENSE-MIT](../LICENSE-MIT) or
   http://opensource.org/licenses/MIT)
 
 at your option.
-
 
 ### Contribution
 

--- a/python/pyoxigraph/__init__.py
+++ b/python/pyoxigraph/__init__.py
@@ -1,0 +1,6 @@
+from .pyoxigraph import __author__, __version__
+from .models import NamedNode, BlankNode, Literal, Triple, Quad, DefaultGraph
+from .parse import parse
+from .serialize import serialize
+from .store import Store
+from .sparql import Variable, QuerySolutions, QuerySolution, QueryTriples

--- a/python/pyoxigraph/models.py
+++ b/python/pyoxigraph/models.py
@@ -1,0 +1,242 @@
+from typing import Union
+
+from .pyoxigraph import NamedNode as PyNamedNode
+from .pyoxigraph import BlankNode as PyBlankNode
+from .pyoxigraph import Literal as PyLiteral
+from .pyoxigraph import Triple as PyTriple
+from .pyoxigraph import Quad as PyQuad
+from .pyoxigraph import DefaultGraph as PyDefaultGraph
+
+
+class NamedNode(PyNamedNode):
+    """An RDF `node identified by an IRI <https://www.w3.org/TR/rdf11-concepts/#dfn-iri>`_.
+
+    :param value: the IRI as a string.
+    :raises ValueError: if the IRI is not valid according to `RFC 3987 <https://tools.ietf.org/rfc/rfc3987>`_.
+
+    The :py:func:`str` function provides a serialization compatible with N-Triples, Turtle, and SPARQL:
+
+    >>> str(NamedNode('http://example.com'))
+    '<http://example.com>'
+    """
+
+    def __init__(self, value: str) -> None:
+        ...
+
+    @property
+    def value(self) -> str:
+        """the named node IRI.
+
+        >>> NamedNode("http://example.com").value
+        'http://example.com'
+        """
+        return super().value
+
+
+class BlankNode(PyBlankNode):
+    """An RDF `blank node <https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node>`_.
+
+    :param value: the `blank node ID <https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier>`_ (if not present, a random blank node ID is automatically generated).
+    :raises ValueError: if the blank node ID is invalid according to NTriples, Turtle, and SPARQL grammars.
+
+    The :py:func:`str` function provides a serialization compatible with NTriples, Turtle, and SPARQL:
+
+    >>> str(BlankNode('ex'))
+    '_:ex'
+    """
+
+    def __init__(self, value: Union[str, None] = None) -> None:
+        ...
+
+    @property
+    def value(self) -> str:
+        """the `blank node ID <https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier>`_.
+
+        >>> BlankNode("ex").value
+        'ex'"""
+        return super().value
+
+
+class Literal(PyLiteral):
+    """An RDF `literal <https://www.w3.org/TR/rdf11-concepts/#dfn-literal>`_.
+
+    :param value: the literal value or `lexical form <https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form>`_.
+    :param datatype: the literal `datatype IRI <https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri>`_.
+    :param language: the literal `language tag <https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag>`_.
+    :raises ValueError: if the language tag is not valid according to `RFC 5646 <https://tools.ietf.org/rfc/rfc5646>`_ (`BCP 47 <https://tools.ietf.org/rfc/bcp/bcp47>`_).
+
+    The :py:func:`str` function provides a serialization compatible with NTriples, Turtle, and SPARQL:
+
+    >>> str(Literal('example'))
+    '"example"'
+    >>> str(Literal('example', language='en'))
+    '"example"@en'
+    >>> str(Literal('11', datatype=NamedNode('http://www.w3.org/2001/XMLSchema#integer')))
+    '"11"^^<http://www.w3.org/2001/XMLSchema#integer>'
+    """
+
+    def __init__(
+        self,
+        value: str,
+        datatype: Union[NamedNode, None] = None,
+        language: Union[str, None] = None,
+    ) -> None:
+        ...
+
+    @property
+    def datatype(self) -> NamedNode:
+        """the literal `datatype IRI <https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri>`_.
+
+        >>> Literal('11', datatype=NamedNode('http://www.w3.org/2001/XMLSchema#integer')).datatype
+        <NamedNode value=http://www.w3.org/2001/XMLSchema#integer>
+        >>> Literal('example').datatype
+        <NamedNode value=http://www.w3.org/2001/XMLSchema#string>
+        >>> Literal('example', language='en').datatype
+        <NamedNode value=http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>
+        """
+        return super().datatype
+
+    @property
+    def language(self) -> Union[str, None]:
+        """the literal `language tag <https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag>`_.
+
+        >>> Literal('example', language='en').language
+        'en'
+        >>> Literal('example').language
+        """
+        return super().language
+
+    @property
+    def value(self) -> str:
+        """the literal value or `lexical form <https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form>`_.
+
+        >>> Literal("example").value
+        'example'
+        """
+        return super().value
+
+
+class Triple(PyTriple):
+    """An RDF `triple <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple>`_.
+
+    :param subject: the triple subject.
+    :param predicate: the triple predicate.
+    :param object: the triple object.
+
+    The :py:func:`str` function provides a serialization compatible with NTriples, Turtle, and SPARQL:
+
+    >>> str(Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+    '<http://example.com> <http://example.com/p> "1"'
+
+    A triple could also be easily destructed into its components:
+
+    >>> (s, p, o) = Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'))
+    """
+
+    def __init__(
+        self,
+        subject: Union[NamedNode, BlankNode, "Triple"],
+        predicate: NamedNode,
+        object: Union[NamedNode, BlankNode, Literal, "Triple"],
+    ) -> None:
+        ...
+
+    @property
+    def subject(self) -> Union[NamedNode, BlankNode, "Triple"]:
+        """the triple subject.
+
+        >>> Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')).subject
+        <NamedNode value=http://example.com>
+        """
+        return super().subject
+
+    @property
+    def predicate(self) -> NamedNode:
+        """the triple predicate.
+
+        >>> Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')).predicate
+        <NamedNode value=http://example.com/p>
+        """
+        return super().predicate
+
+    @property
+    def object(self) -> Union[NamedNode, BlankNode, Literal, "Triple"]:
+        """the triple object.
+
+        >>> Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')).object
+        <Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>>
+        """
+        return super().object
+
+
+class Quad(PyQuad):
+    """
+    An RDF `triple <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple>`_.
+    in a `RDF dataset <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset>`_.
+
+    :param subject: the quad subject.
+    :param predicate: the quad predicate.
+    :param object: the quad object.
+    :param graph: the quad graph name. If not present, the default graph is assumed.
+
+    The :py:func:`str` function provides a serialization compatible with NTriples, Turtle, and SPARQL:
+
+    >>> str(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+    '<http://example.com> <http://example.com/p> "1" <http://example.com/g>'
+
+    >>> str(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), DefaultGraph()))
+    '<http://example.com> <http://example.com/p> "1"'
+
+    A quad could also be easily destructed into its components:
+
+    >>> (s, p, o, g) = Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g'))
+    """
+
+    def __init__(
+        self,
+        subject: Union[NamedNode, BlankNode, Triple],
+        predicate: NamedNode,
+        object: Union[NamedNode, BlankNode, Literal, Triple],
+        graph: Union[NamedNode, BlankNode, "DefaultGraph", None] = None,
+    ) -> None:
+        ...
+
+    @property
+    def subject(self) -> Union[NamedNode, BlankNode, Triple]:
+        """the quad subject.
+
+        >>> Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')).subject
+        <NamedNode value=http://example.com>
+        """
+        return super().subject
+
+    @property
+    def predicate(self) -> NamedNode:
+        """the quad predicate.
+
+        >>> Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')).predicate
+        <NamedNode value=http://example.com/p>
+        """
+        return super().predicate
+
+    @property
+    def object(self) -> Union[NamedNode, BlankNode, Literal, Triple]:
+        """the quad object.
+
+        >>> Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')).object
+        <Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>>
+        """
+        return super().object
+
+    @property
+    def graph_name(self) -> Union[NamedNode, BlankNode, "DefaultGraph"]:
+        """the quad graph name.
+
+        >>> Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')).graph_name
+        <NamedNode value=http://example.com/g>
+        """
+        return super().graph_name
+
+
+class DefaultGraph(PyDefaultGraph):
+    """The RDF `default graph name <https://www.w3.org/TR/rdf11-concepts/#dfn-default-graph>`_."""

--- a/python/pyoxigraph/parse.py
+++ b/python/pyoxigraph/parse.py
@@ -1,0 +1,38 @@
+import io
+from typing import Union, Iterator
+
+from pyoxigraph import Triple, Quad
+from .pyoxigraph import parse as pyparse
+
+
+def parse(
+    input: Union[io.RawIOBase, io.BufferedIOBase, str],
+    mime_type: str,
+    base_iri: Union[str, None] = None,
+) -> Iterator[Union[Triple, Quad]]:
+    """Parses RDF graph and dataset serialization formats.
+
+    It currently supports the following formats:
+
+    * `N-Triples <https://www.w3.org/TR/n-triples/>`_ (``application/n-triples``)
+    * `N-Quads <https://www.w3.org/TR/n-quads/>`_ (``application/n-quads``)
+    * `Turtle <https://www.w3.org/TR/turtle/>`_ (``text/turtle``)
+    * `TriG <https://www.w3.org/TR/trig/>`_ (``application/trig``)
+    * `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_ (``application/rdf+xml``)
+
+    It supports also some MIME type aliases.
+    For example, ``application/turtle`` could also be used for `Turtle <https://www.w3.org/TR/turtle/>`_
+    and ``application/xml`` for `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_.
+
+    :param input: The binary I/O object or file path to read from. For example, it could be a file path as a string or a file reader opened in binary mode with ``open('my_file.ttl', 'rb')``.
+    :param mime_type: the MIME type of the RDF serialization.
+    :param base_iri: the base IRI used to resolve the relative IRIs in the file or :py:const:`None` if relative IRI resolution should not be done.
+    :return: an iterator of RDF triples or quads depending on the format.
+    :raises ValueError: if the MIME type is not supported.
+    :raises SyntaxError: if the provided data is invalid.
+
+    >>> input = io.BytesIO(b'<foo> <p> "1" .')
+    >>> list(parse(input, "text/turtle", base_iri="http://example.com/"))
+    [<Triple subject=<NamedNode value=http://example.com/foo> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>>>]
+    """
+    return pyparse(input, mime_type, base_iri)

--- a/python/pyoxigraph/serialize.py
+++ b/python/pyoxigraph/serialize.py
@@ -1,0 +1,38 @@
+import io
+from typing import Iterator, Union
+
+from pyoxigraph import Triple, Quad
+from .pyoxigraph import serialize as pyserialize
+
+
+def serialize(
+    input: Iterator[Union[Triple, Quad]],
+    output: Union[io.RawIOBase, io.BufferedIOBase, str],
+    mime_type: str,
+):
+    """Serializes an RDF graph or dataset.
+
+    It currently supports the following formats:
+
+    * `N-Triples <https://www.w3.org/TR/n-triples/>`_ (``application/n-triples``)
+    * `N-Quads <https://www.w3.org/TR/n-quads/>`_ (``application/n-quads``)
+    * `Turtle <https://www.w3.org/TR/turtle/>`_ (``text/turtle``)
+    * `TriG <https://www.w3.org/TR/trig/>`_ (``application/trig``)
+    * `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_ (``application/rdf+xml``)
+
+    It supports also some MIME type aliases.
+    For example, ``application/turtle`` could also be used for `Turtle <https://www.w3.org/TR/turtle/>`_
+    and ``application/xml`` for `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_.
+
+    :param input: the RDF triples and quads to serialize.
+    :param output: The binary I/O object or file path to write to. For example, it could be a file path as a string or a file writer opened in binary mode with ``open('my_file.ttl', 'wb')``.
+    :param mime_type: the MIME type of the RDF serialization.
+    :raises ValueError: if the MIME type is not supported.
+    :raises TypeError: if a triple is given during a quad format serialization or reverse.
+
+    >>> output = io.BytesIO()
+    >>> serialize([Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'))], output, "text/turtle")
+    >>> output.getvalue()
+    b'<http://example.com> <http://example.com/p> "1" .\n'
+    """
+    return pyserialize(input, output, mime_type)

--- a/python/pyoxigraph/sparql.py
+++ b/python/pyoxigraph/sparql.py
@@ -1,0 +1,83 @@
+from typing import List
+from .pyoxigraph import Variable as PyVariable
+from .pyoxigraph import QuerySolutions as PyQuerySolutions
+from .pyoxigraph import QuerySolution as PyQuerySolution
+from .pyoxigraph import QueryTriples as PyQueryTriples
+
+
+class Variable(PyVariable):
+    """A SPARQL query variable.
+
+    :param value: the variable name as a string.
+    :raises ValueError: if the variable name is invalid according to the SPARQL grammar.
+
+    The :py:func:`str` function provides a serialization compatible with SPARQL:
+
+    >>> str(Variable('foo'))
+    '?foo'
+    """
+
+    def __init__(self, value: str) -> None:
+        ...
+
+    @property
+    def value(self) -> str:
+        """the variable name.
+
+        >>> Variable("foo").value
+        'foo'
+        """
+        return super().value
+
+
+class QuerySolutions(PyQuerySolutions):
+    """An iterator of :py:class:`QuerySolution` returned by a SPARQL ``SELECT`` query
+
+    >>> store = Store()
+    >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+    >>> list(store.query('SELECT ?s WHERE { ?s ?p ?o }'))
+    [<QuerySolution s=<NamedNode value=http://example.com>>]
+    """
+
+    @property
+    def variables(self) -> List[Variable]:
+        """the ordered list of all variables that could appear in the query results
+
+        >>> store = Store()
+        >>> store.query('SELECT ?s WHERE { ?s ?p ?o }').variables
+        [<Variable value=s>]
+        """
+        return super().variables
+
+
+class QuerySolution(PyQuerySolution):
+    """Tuple associating variables and terms that are the result of a SPARQL ``SELECT`` query.
+
+    It is the equivalent of a row in SQL.
+
+    It could be indexes by variable name (:py:class:`Variable` or :py:class:`str`) or position in the tuple (:py:class:`int`).
+    Unpacking also works.
+
+    >>> store = Store()
+    >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+    >>> solution = next(store.query('SELECT ?s ?p ?o WHERE { ?s ?p ?o }'))
+    >>> solution[Variable('s')]
+    <NamedNode value=http://example.com>
+    >>> solution['s']
+    <NamedNode value=http://example.com>
+    >>> solution[0]
+    <NamedNode value=http://example.com>
+    >>> s, p, o = solution
+    >>> s
+    <NamedNode value=http://example.com>
+    """
+
+
+class QueryTriples(PyQueryTriples):
+    """An iterator of :py:class:`Triple` returned by a SPARQL ``CONSTRUCT`` or ``DESCRIBE`` query
+
+    >>> store = Store()
+    >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+    >>> list(store.query('CONSTRUCT WHERE { ?s ?p ?o }'))
+    [<Triple subject=<NamedNode value=http://example.com> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>>>]
+    """

--- a/python/pyoxigraph/store.py
+++ b/python/pyoxigraph/store.py
@@ -44,7 +44,6 @@ class Store(PyStore):
         """Adds a quad to the store.
 
         :param quad: the quad to add.
-        :type quad: Quad
         :raises IOError: if an I/O error happens during the quad insertion.
 
         >>> store = Store()
@@ -283,7 +282,6 @@ class Store(PyStore):
         :param object: the quad object or :py:const:`None` to match everything.
         :param graph: the quad graph name. To match only the default graph, use :py:class:`DefaultGraph`. To match everything use :py:const:`None`.
         :return: an iterator of the quads matching the pattern.
-        :rtype: iter(Quad)
         :raises IOError: if an I/O error happens during the quads lookup.
 
         >>> store = Store()

--- a/python/pyoxigraph/store.py
+++ b/python/pyoxigraph/store.py
@@ -34,7 +34,7 @@ class Store(PyStore):
     >>> store = Store()
     >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
     >>> str(store)
-    '<http://example.com> <http://example.com/p> "1" <http://example.com/g> .\n'
+    '<http://example.com> <http://example.com/p> "1" <http://example.com/g> .\\n'
     """
 
     def __init__(self, path: Union[str, None] = None) -> None:
@@ -193,7 +193,7 @@ class Store(PyStore):
         >>> output = io.BytesIO()
         >>> store.dump(output, "text/turtle", from_graph=NamedNode("http://example.com/g"))
         >>> output.getvalue()
-        b'<http://example.com> <http://example.com/p> "1" .\n'
+        b'<http://example.com> <http://example.com/p> "1" .\\n'
         """
         super().dump(output, mime_type, from_graph=from_graph)
 

--- a/python/pyoxigraph/store.py
+++ b/python/pyoxigraph/store.py
@@ -1,0 +1,420 @@
+import io
+import mimetypes
+from typing import Iterator, List, Union
+
+from pyoxigraph import (
+    Quad,
+    BlankNode,
+    DefaultGraph,
+    Literal,
+)
+
+from pyoxigraph.sparql import QuerySolutions, QueryTriples
+
+from .pyoxigraph import NamedNode, Store as PyStore
+
+
+class Store(PyStore):
+    """RDF store.
+
+    It encodes a `RDF dataset <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset>`_ and allows to query it using SPARQL.
+    It is based on the `RocksDB <https://rocksdb.org/>`_ key-value database.
+
+    This store ensures the "repeatable read" isolation level: the store only exposes changes that have
+    been "committed" (i.e. no partial writes) and the exposed state does not change for the complete duration
+    of a read operation (e.g. a SPARQL query) or a read/write operation (e.g. a SPARQL update).
+
+    :param path: the path of the directory in which the store should read and write its data. If the directory does not exist, it is created.
+                 If no directory is provided a temporary one is created and removed when the Python garbage collector removes the store.
+                 In this case, the store data are kept in memory and never written on disk.
+    :raises IOError: if the target directory contains invalid data or could not be accessed.
+
+    The :py:func:`str` function provides a serialization of the store in NQuads:
+
+    >>> store = Store()
+    >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+    >>> str(store)
+    '<http://example.com> <http://example.com/p> "1" <http://example.com/g> .\n'
+    """
+
+    def __init__(self, path: Union[str, None] = None) -> None:
+        ...
+
+    def add(self, quad: Quad) -> None:
+        """Adds a quad to the store.
+
+        :param quad: the quad to add.
+        :type quad: Quad
+        :raises IOError: if an I/O error happens during the quad insertion.
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> list(store)
+        [<Quad subject=<NamedNode value=http://example.com> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>> graph_name=<NamedNode value=http://example.com/g>>]
+        """
+        super().add(quad)
+
+    def add_graph(self, graph_name: Union[NamedNode, BlankNode]) -> None:
+        """Adds a named graph to the store.
+
+        :param graph_name: the name of the name graph to add.
+        :raises IOError: if an I/O error happens during the named graph insertion.
+
+        >>> store = Store()
+        >>> store.add_graph(NamedNode('http://example.com/g'))
+        >>> list(store.named_graphs())
+        [<NamedNode value=http://example.com/g>]
+        """
+        super().add_graph(graph_name)
+
+    def backup(self, target_directory: str) -> None:
+        """Creates database backup into the `target_directory`.
+
+        After its creation, the backup is usable using :py:class:`Store` constructor.
+        like a regular pyxigraph database and operates independently from the original database.
+
+        Warning: Backups are only possible for on-disk databases created by providing a path to :py:class:`Store` constructor.
+        Temporary in-memory databases created without path are not compatible with the backup system.
+
+        Warning: An error is raised if the ``target_directory`` already exists.
+
+        If the target directory is in the same file system as the current database,
+        the database content will not be fully copied
+        but hard links will be used to point to the original database immutable snapshots.
+        This allows cheap regular backups.
+
+        If you want to move your data to another RDF storage system, you should have a look at the :py:func:`dump_dataset` function instead.
+
+        :param target_directory: the directory name to save the database to.
+        :raises IOError: if an I/O error happens during the backup.
+        """
+        super().backup(target_directory)
+
+    def bulk_load(
+        self,
+        input: Union[io.RawIOBase, io.BufferedIOBase, str],
+        mime_type: str,
+        base_iri: Union[str, None] = None,
+        to_graph: Union[NamedNode, BlankNode, DefaultGraph, None] = None,
+    ) -> None:
+        """Loads an RDF serialization into the store.
+
+        This function is designed to be as fast as possible on big files **without** transactional guarantees.
+        If the file is invalid only a piece of it might be written to the store.
+
+        The :py:func:`load` method is also available for loads with transactional guarantees.
+
+        It currently supports the following formats:
+
+        * `N-Triples <https://www.w3.org/TR/n-triples/>`_ (``application/n-triples``)
+        * `N-Quads <https://www.w3.org/TR/n-quads/>`_ (``application/n-quads``)
+        * `Turtle <https://www.w3.org/TR/turtle/>`_ (``text/turtle``)
+        * `TriG <https://www.w3.org/TR/trig/>`_ (``application/trig``)
+        * `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_ (``application/rdf+xml``)
+
+        It supports also some MIME type aliases.
+        For example, ``application/turtle`` could also be used for `Turtle <https://www.w3.org/TR/turtle/>`_
+        and ``application/xml`` for `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_.
+
+        :param input: the binary I/O object or file path to read from. For example, it could be a file path as a string or a file reader opened in binary mode with ``open('my_file.ttl', 'rb')``.
+        :param mime_type: the MIME type of the RDF serialization.
+        :param base_iri: the base IRI used to resolve the relative IRIs in the file or :py:const:`None` if relative IRI resolution should not be done.
+        :param to_graph: if it is a file composed of triples, the graph in which the triples should be stored. By default, the default graph is used.
+        :raises ValueError: if the MIME type is not supported or the `to_graph` parameter is given with a quad file.
+        :raises SyntaxError: if the provided data is invalid.
+        :raises IOError: if an I/O error happens during a quad insertion.
+
+        >>> store = Store()
+        >>> store.bulk_load(io.BytesIO(b'<foo> <p> "1" .'), "text/turtle", base_iri="http://example.com/", to_graph=NamedNode("http://example.com/g"))
+        >>> list(store)
+        [<Quad subject=<NamedNode value=http://example.com/foo> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>> graph_name=<NamedNode value=http://example.com/g>>]
+        """
+        super().bulk_load(input, mimetypes, base_iri, to_graph)
+
+    def clear(self) -> None:
+        """Clears the store by removing all its contents.
+
+        :raises IOError: if an I/O error happens during the operation.
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> store.clear()
+        >>> list(store)
+        []
+        >>> list(store.named_graphs())
+        []
+        """
+        super().clear()
+
+    def clear_graph(self, graph_name: NamedNode) -> None:
+        """Clears a graph from the store without removing it.
+
+        :param graph_name: the name of the name graph to clear.
+        :raises IOError: if an I/O error happens during the operation.
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> store.clear_graph(NamedNode('http://example.com/g'))
+        >>> list(store)
+        []
+        >>> list(store.named_graphs())
+        [<NamedNode value=http://example.com/g>]
+        """
+        super().clear_graph(graph_name)
+
+    def dump(
+        self,
+        output: Union[io.RawIOBase, io.BufferedIOBase, str],
+        mime_type: str,
+        from_graph: Union[NamedNode, BlankNode, DefaultGraph, None] = None,
+    ) -> None:
+        """Dumps the store quads or triples into a file.
+
+        It currently supports the following formats:
+
+        * `N-Triples <https://www.w3.org/TR/n-triples/>`_ (``application/n-triples``)
+        * `N-Quads <https://www.w3.org/TR/n-quads/>`_ (``application/n-quads``)
+        * `Turtle <https://www.w3.org/TR/turtle/>`_ (``text/turtle``)
+        * `TriG <https://www.w3.org/TR/trig/>`_ (``application/trig``)
+        * `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_ (``application/rdf+xml``)
+
+        It supports also some MIME type aliases.
+        For example, ``application/turtle`` could also be used for `Turtle <https://www.w3.org/TR/turtle/>`_
+        and ``application/xml`` for `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_.
+
+        :param output: The binary I/O object or file path to write to. For example, it could be a file path as a string or a file writer opened in binary mode with ``open('my_file.ttl', 'wb')``.
+        :param mime_type: the MIME type of the RDF serialization.
+        :param from_graph: if a triple based format is requested, the store graph from which dump the triples. By default, the default graph is used.
+        :raises ValueError: if the MIME type is not supported or the `from_graph` parameter is given with a quad syntax.
+        :raises IOError: if an I/O error happens during a quad lookup
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> output = io.BytesIO()
+        >>> store.dump(output, "text/turtle", from_graph=NamedNode("http://example.com/g"))
+        >>> output.getvalue()
+        b'<http://example.com> <http://example.com/p> "1" .\n'
+        """
+        super().dump(output, mime_type, from_graph=from_graph)
+
+    def flush(self) -> None:
+        """Flushes all buffers and ensures that all writes are saved on disk.
+
+        Flushes are automatically done using background threads but might lag a little bit.
+
+        :raises IOError: if an I/O error happens during the flush.
+        """
+        super().flush()
+
+    def load(
+        self,
+        input: Union[io.RawIOBase, io.BufferedIOBase, str],
+        mime_type: str,
+        base_iri: Union[str, None] = None,
+        to_graph: Union[NamedNode, BlankNode, DefaultGraph, None] = None,
+    ) -> None:
+        """Loads an RDF serialization into the store.
+
+        Loads are applied in a transactional manner: either the full operation succeeds or nothing is written to the database.
+        The :py:func:`bulk_load` method is also available for much faster loading of big files but without transactional guarantees.
+
+        Beware, the full file is loaded into memory.
+
+        It currently supports the following formats:
+
+        * `N-Triples <https://www.w3.org/TR/n-triples/>`_ (``application/n-triples``)
+        * `N-Quads <https://www.w3.org/TR/n-quads/>`_ (``application/n-quads``)
+        * `Turtle <https://www.w3.org/TR/turtle/>`_ (``text/turtle``)
+        * `TriG <https://www.w3.org/TR/trig/>`_ (``application/trig``)
+        * `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_ (``application/rdf+xml``)
+
+        It supports also some MIME type aliases.
+        For example, ``application/turtle`` could also be used for `Turtle <https://www.w3.org/TR/turtle/>`_
+        and ``application/xml`` for `RDF/XML <https://www.w3.org/TR/rdf-syntax-grammar/>`_.
+
+        :param input: The binary I/O object or file path to read from. For example, it could be a file path as a string or a file reader opened in binary mode with ``open('my_file.ttl', 'rb')``.
+        :param mime_type: the MIME type of the RDF serialization.
+        :param base_iri: the base IRI used to resolve the relative IRIs in the file or :py:const:`None` if relative IRI resolution should not be done.
+        :param to_graph: if it is a file composed of triples, the graph in which the triples should be stored. By default, the default graph is used.
+        :raises ValueError: if the MIME type is not supported or the `to_graph` parameter is given with a quad file.
+        :raises SyntaxError: if the provided data is invalid.
+        :raises IOError: if an I/O error happens during a quad insertion.
+
+        >>> store = Store()
+        >>> store.load(io.BytesIO(b'<foo> <p> "1" .'), "text/turtle", base_iri="http://example.com/", to_graph=NamedNode("http://example.com/g"))
+        >>> list(store)
+        [<Quad subject=<NamedNode value=http://example.com/foo> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>> graph_name=<NamedNode value=http://example.com/g>>]
+        """
+        super().load(input, mime_type, base_iri=base_iri, to_graph=to_graph)
+
+    def named_graphs(self) -> Iterator[Union[NamedNode, BlankNode]]:
+        """Returns an iterator over all the store named graphs.
+
+        :return: an iterator of the store graph names.
+        :raises IOError: if an I/O error happens during the named graphs lookup.
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> list(store.named_graphs())
+        [<NamedNode value=http://example.com/g>]
+        """
+        return super().named_graphs()
+
+    def optimize(self) -> None:
+        """Optimizes the database for future workload.
+
+        Useful to call after a batch upload or another similar operation.
+
+        :raises IOError: if an I/O error happens during the optimization.
+        """
+        super().optimize()
+
+    def quads_for_pattern(
+        self,
+        subject: Union[NamedNode, BlankNode, None] = None,
+        predicate: Union[NamedNode, None] = None,
+        object: Union[NamedNode, BlankNode, Literal, None] = None,
+        graph: Union[NamedNode, BlankNode, DefaultGraph, None] = None,
+    ) -> Iterator[Quad]:
+        """Looks for the quads matching a given pattern.
+
+        :param subject: the quad subject or :py:const:`None` to match everything.
+        :param predicate: the quad predicate or :py:const:`None` to match everything.
+        :param object: the quad object or :py:const:`None` to match everything.
+        :param graph: the quad graph name. To match only the default graph, use :py:class:`DefaultGraph`. To match everything use :py:const:`None`.
+        :return: an iterator of the quads matching the pattern.
+        :rtype: iter(Quad)
+        :raises IOError: if an I/O error happens during the quads lookup.
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> list(store.quads_for_pattern(NamedNode('http://example.com'), None, None, None))
+        [<Quad subject=<NamedNode value=http://example.com> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>> graph_name=<NamedNode value=http://example.com/g>>]
+        """
+        return super().quads_for_pattern(subject, predicate, object, graph)
+
+    def query(
+        self,
+        query: str,
+        base_iri: Union[str, None] = None,
+        use_default_graph_as_union: bool = False,
+        default_graph: Union[
+            NamedNode,
+            BlankNode,
+            DefaultGraph,
+            List[Union[NamedNode, BlankNode, DefaultGraph]],
+            None,
+        ] = None,
+        named_graphs: Union[List[Union[NamedNode, BlankNode]], None] = None,
+    ) -> Union[QuerySolutions, QueryTriples, bool]:
+        """Executes a `SPARQL 1.1 query <https://www.w3.org/TR/sparql11-query/>`_.
+
+        :param query: the query to execute.
+        :param base_iri: the base IRI used to resolve the relative IRIs in the SPARQL query or :py:const:`None` if relative IRI resolution should not be done.
+        :param use_default_graph_as_union: if the SPARQL query should look for triples in all the dataset graphs by default (i.e. without `GRAPH` operations). Disabled by default.
+        :param default_graph: list of the graphs that should be used as the query default graph. By default, the store default graph is used.
+        :param named_graphs: list of the named graphs that could be used in SPARQL `GRAPH` clause. By default, all the store named graphs are available.
+        :return: a :py:class:`bool` for ``ASK`` queries, an iterator of :py:class:`Triple` for ``CONSTRUCT`` and ``DESCRIBE`` queries and an iterator of :py:class:`QuerySolution` for ``SELECT`` queries.
+        :raises SyntaxError: if the provided query is invalid.
+        :raises IOError: if an I/O error happens while reading the store.
+
+        ``SELECT`` query:
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+        >>> list(solution['s'] for solution in store.query('SELECT ?s WHERE { ?s ?p ?o }'))
+        [<NamedNode value=http://example.com>]
+
+        ``CONSTRUCT`` query:
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+        >>> list(store.query('CONSTRUCT WHERE { ?s ?p ?o }'))
+        [<Triple subject=<NamedNode value=http://example.com> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>>>]
+
+        ``ASK`` query:
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+        >>> store.query('ASK { ?s ?p ?o }')
+        True
+        """
+        return super().query(
+            query,
+            base_iri=base_iri,
+            use_default_graph_as_union=use_default_graph_as_union,
+            default_graph=default_graph,
+            named_graphs=named_graphs,
+        )
+
+    def remove(self, quad: Quad) -> None:
+        """Removes a quad from the store.
+
+        :param quad: the quad to remove.
+        :raises IOError: if an I/O error happens during the quad removal.
+
+        >>> store = Store()
+        >>> quad = Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g'))
+        >>> store.add(quad)
+        >>> store.remove(quad)
+        >>> list(store)
+        []
+        """
+        super().remove(quad)
+
+    def remove_graph(
+        self, graph_name: Union[NamedNode, BlankNode, DefaultGraph]
+    ) -> None:
+        """Removes a graph from the store.
+
+        The default graph will not be removed but just cleared.
+
+        :param graph_name: the name of the name graph to remove.
+        :raises IOError: if an I/O error happens during the named graph removal.
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
+        >>> store.remove_graph(NamedNode('http://example.com/g'))
+        >>> list(store.named_graphs())
+        []
+        """
+        super().remove_graph(graph_name)
+
+    def update(
+        self,
+        update: str,
+        base_iri: Union[str, None] = None,
+    ) -> None:
+        """Executes a `SPARQL 1.1 update <https://www.w3.org/TR/sparql11-update/>`_.
+
+        Updates are applied in a transactional manner: either the full operation succeeds or nothing is written to the database.
+
+        :param update: the update to execute.
+        :param base_iri: the base IRI used to resolve the relative IRIs in the SPARQL update or :py:const:`None` if relative IRI resolution should not be done.
+        :raises SyntaxError: if the provided update is invalid.
+        :raises IOError: if an I/O error happens while reading the store.
+
+        ``INSERT DATA`` update:
+
+        >>> store = Store()
+        >>> store.update('INSERT DATA { <http://example.com> <http://example.com/p> "1" }')
+        >>> list(store)
+        [<Quad subject=<NamedNode value=http://example.com> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>> graph_name=<DefaultGraph>>]
+
+        ``DELETE DATA`` update:
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+        >>> store.update('DELETE DATA { <http://example.com> <http://example.com/p> "1" }')
+        >>> list(store)
+        []
+
+        ``DELETE`` update:
+
+        >>> store = Store()
+        >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
+        >>> store.update('DELETE WHERE { <http://example.com> ?p ?o }')
+        >>> list(store)
+        []
+        """
+        super().update(update, base_iri=base_iri)

--- a/python/src/model.rs
+++ b/python/src/model.rs
@@ -19,7 +19,7 @@ use std::vec::IntoIter;
 ///
 /// >>> str(NamedNode('http://example.com'))
 /// '<http://example.com>'
-#[pyclass(name = "NamedNode", module = "oxigraph")]
+#[pyclass(name = "NamedNode", module = "oxigraph", subclass)]
 #[pyo3(text_signature = "(value)")]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash)]
 pub struct PyNamedNode {
@@ -121,7 +121,7 @@ impl PyNamedNode {
 ///
 /// >>> str(BlankNode('ex'))
 /// '_:ex'
-#[pyclass(name = "BlankNode", module = "oxigraph")]
+#[pyclass(name = "BlankNode", module = "oxigraph", subclass)]
 #[pyo3(text_signature = "(value)")]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct PyBlankNode {
@@ -234,7 +234,7 @@ impl PyBlankNode {
 /// '"example"@en'
 /// >>> str(Literal('11', datatype=NamedNode('http://www.w3.org/2001/XMLSchema#integer')))
 /// '"11"^^<http://www.w3.org/2001/XMLSchema#integer>'
-#[pyclass(name = "Literal", module = "oxigraph")]
+#[pyclass(name = "Literal", module = "oxigraph", subclass)]
 #[pyo3(text_signature = "(value, *, datatype = None, language = None)")]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct PyLiteral {
@@ -353,7 +353,7 @@ impl PyLiteral {
 }
 
 /// The RDF `default graph name <https://www.w3.org/TR/rdf11-concepts/#dfn-default-graph>`_.
-#[pyclass(name = "DefaultGraph", module = "oxigraph")]
+#[pyclass(name = "DefaultGraph", module = "oxigraph", subclass)]
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
 pub struct PyDefaultGraph {}
 
@@ -531,7 +531,7 @@ impl IntoPy<PyObject> for PyTerm {
 /// A triple could also be easily destructed into its components:
 ///
 /// >>> (s, p, o) = Triple(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'))
-#[pyclass(name = "Triple", module = "oxigraph")]
+#[pyclass(name = "Triple", module = "oxigraph", subclass)]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 #[pyo3(text_signature = "(subject, predicate, object)")]
 pub struct PyTriple {
@@ -708,7 +708,7 @@ impl IntoPy<PyObject> for PyGraphName {
 /// A quad could also be easily destructed into its components:
 ///
 /// >>> (s, p, o, g) = Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g'))
-#[pyclass(name = "Quad", module = "oxigraph")]
+#[pyclass(name = "Quad", module = "oxigraph", subclass)]
 #[pyo3(text_signature = "(subject, predicate, object, graph_name = None)")]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct PyQuad {
@@ -870,7 +870,7 @@ impl PyQuad {
 ///
 /// >>> str(Variable('foo'))
 /// '?foo'
-#[pyclass(name = "Variable", module = "oxigraph")]
+#[pyclass(name = "Variable", module = "oxigraph", subclass)]
 #[pyo3(text_signature = "(value)")]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct PyVariable {

--- a/python/src/sparql.rs
+++ b/python/src/sparql.rs
@@ -85,7 +85,7 @@ pub fn query_results_to_python(py: Python<'_>, results: QueryResults) -> PyResul
 /// >>> s, p, o = solution
 /// >>> s
 /// <NamedNode value=http://example.com>
-#[pyclass(unsendable, name = "QuerySolution", module = "oxigraph")]
+#[pyclass(unsendable, name = "QuerySolution", module = "oxigraph", subclass)]
 pub struct PyQuerySolution {
     inner: QuerySolution,
 }
@@ -158,7 +158,7 @@ impl SolutionValueIter {
 /// >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
 /// >>> list(store.query('SELECT ?s WHERE { ?s ?p ?o }'))
 /// [<QuerySolution s=<NamedNode value=http://example.com>>]
-#[pyclass(unsendable, name = "QuerySolutions", module = "oxigraph")]
+#[pyclass(unsendable, name = "QuerySolutions", module = "oxigraph", subclass)]
 pub struct PyQuerySolutions {
     inner: QuerySolutionIter,
 }
@@ -198,7 +198,7 @@ impl PyQuerySolutions {
 /// >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1')))
 /// >>> list(store.query('CONSTRUCT WHERE { ?s ?p ?o }'))
 /// [<Triple subject=<NamedNode value=http://example.com> predicate=<NamedNode value=http://example.com/p> object=<Literal value=1 datatype=<NamedNode value=http://www.w3.org/2001/XMLSchema#string>>>]
-#[pyclass(unsendable, name = "QueryTriples", module = "oxigraph")]
+#[pyclass(unsendable, name = "QueryTriples", module = "oxigraph", subclass)]
 pub struct PyQueryTriples {
     inner: QueryTripleIter,
 }

--- a/python/src/store.rs
+++ b/python/src/store.rs
@@ -32,7 +32,7 @@ use pyo3::{Py, PyRef};
 /// >>> store.add(Quad(NamedNode('http://example.com'), NamedNode('http://example.com/p'), Literal('1'), NamedNode('http://example.com/g')))
 /// >>> str(store)
 /// '<http://example.com> <http://example.com/p> "1" <http://example.com/g> .\n'
-#[pyclass(name = "Store", module = "oxigraph")]
+#[pyclass(name = "Store", module = "oxigraph", subclass)]
 #[pyo3(text_signature = "(path = None)")]
 #[derive(Clone)]
 pub struct PyStore {

--- a/python/tests/test_parse.py
+++ b/python/tests/test_parse.py
@@ -1,0 +1,20 @@
+import unittest
+import io
+
+from pyoxigraph import *
+
+
+class TestParse(unittest.TestCase):
+    def test_parse(self):
+        input = io.BytesIO(b'<foo> <p> "1" .')
+        result = list(parse(input, "text/turtle", base_iri="http://example.com/"))
+
+        assert result == [
+            Triple(
+                NamedNode("http://example.com/foo"),
+                NamedNode("http://example.com/p"),
+                Literal(
+                    "1", datatype=NamedNode("http://www.w3.org/2001/XMLSchema#string")
+                ),
+            )
+        ]

--- a/python/tests/test_serialize.py
+++ b/python/tests/test_serialize.py
@@ -1,0 +1,24 @@
+import unittest
+import io
+
+from pyoxigraph import *
+
+
+class TestSerialize(unittest.TestCase):
+    def test_serialize(self):
+        output = io.BytesIO()
+        serialize(
+            [
+                Triple(
+                    NamedNode("http://example.com"),
+                    NamedNode("http://example.com/p"),
+                    Literal("1"),
+                )
+            ],
+            output,
+            "text/turtle",
+        )
+
+        assert (
+            output.getvalue() == b'<http://example.com> <http://example.com/p> "1" .\n'
+        )

--- a/python/tests/test_store.py
+++ b/python/tests/test_store.py
@@ -3,6 +3,7 @@ import unittest
 from io import BytesIO, RawIOBase
 
 from pyoxigraph import *
+from pyoxigraph.pyoxigraph import QuerySolutions, QuerySolution, QueryTriples
 from tempfile import NamedTemporaryFile
 
 foo = NamedNode("http://foo")


### PR DESCRIPTION
This PR is branched off of https://github.com/oxigraph/oxigraph/pull/221. Once https://github.com/oxigraph/oxigraph/pull/221 is merged, this PR will be easier to review.

This PR adds python type annotations by subclassing pyoxigraph pyo3 classes as python classes and wraps pyoxigraph pyo3 functions with python functions.

Additionally, this PR also adds a basic test for the parse and serialize functions.

All tests are passing.