### PR TITLE
Variable should stay not bound in subqueries even if they are bound in the parent query

### DIFF
--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -27,6 +27,7 @@
     :nested_expression
     :order_terms
     :nested_anonymous
+    :unbound_variable_in_subquery
     ) .
 
 :small_unicode_escape_with_multibytes_char rdf:type mf:NegativeSyntaxTest ;
@@ -122,3 +123,9 @@
          [ qt:query  <nested_anonymous.rq> ;
            qt:data   <nested_anonymous.ttl> ] ;
     mf:result  <nested_anonymous.srx> .
+
+:unbound_variable_in_subquery rdf:type mf:QueryEvaluationTest ;
+    mf:name "Variable should stay not bound in subqueries even if they are bound in the parent query" ;
+    mf:action
+         [ qt:query  <unbound_variable_in_subquery.rq> ] ;
+    mf:result  <unbound_variable_in_subquery.srx> .

--- a/testsuite/oxigraph-tests/sparql/unbound_variable_in_subquery.rq
+++ b/testsuite/oxigraph-tests/sparql/unbound_variable_in_subquery.rq
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+
+SELECT ?a ?b WHERE {
+    BIND(ex:a as ?a)
+    {SELECT ?b WHERE { BIND(ex:b as ?b) FILTER(!BOUND(?a))}}
+}

--- a/testsuite/oxigraph-tests/sparql/unbound_variable_in_subquery.srx
+++ b/testsuite/oxigraph-tests/sparql/unbound_variable_in_subquery.srx
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head>
+        <variable name="a"/>
+        <variable name="b"/>
+    </head>
+    <results>
+        <result>
+            <binding name="a">
+                <uri>http://example.com/a</uri>
+            </binding>
+            <binding name="b">
+                <uri>http://example.com/b</uri>
+            </binding>
+        </result>
+    </results>
+</sparql>


### PR DESCRIPTION
This is a bit naive and keeps out some interesting optimization.

We should be smarter and still propagate "always bound variables"

Closes #261