### PR TITLE
Set version constraints for Python build dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+  - package-ecosystem: "pip"
+    directory: "/python/"
+    schedule:
+      interval: weekly

--- a/python/README.md
+++ b/python/README.md
@@ -59,7 +59,7 @@ The Sphinx documentation can be generated and viewed in the browser using the fo
 sphinx-autobuild docs docs/_build/html
 ```
 
-Note that you will need to have [sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/) installed. This should be installed already if you are using this repository's development container.
+Note that you will need to have [sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/) installed.
 
 Alternatively, you can use `sphinx-build` with Python's `http.server` to achieve the same thing.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin~=0.13.0"]
+requires = ["maturin~=0.14.0"]
 build-backend = "maturin"
 
 [project]

--- a/python/requirements.dev.txt
+++ b/python/requirements.dev.txt
@@ -1,6 +1,5 @@
-black
+black~=22.10
 furo
-maturin
-mypy
-sphinx
-sphinx-autobuild
+maturin~=0.14.0
+mypy~=0.991.0
+sphinx~=5.3


### PR DESCRIPTION
Allows to avoid some unintended breakage if a build package introduces a breaking change