### PR TITLE
Python: Makes abi3 optional

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - run: sed 's/%arch%/x86_64/g' .github/workflows/manylinux_build.sh > .github/workflows/manylinux_build_script.sh
+      - run: sed 's/%arch%/x86_64/g' .github/workflows/manylinux_build.sh | sed 's/%for_each_version%//g' > .github/workflows/manylinux_build_script.sh
       - run: docker run -v "$(pwd)":/workdir --platform linux/x86_64 quay.io/pypa/manylinux2014_x86_64 /bin/bash /workdir/.github/workflows/manylinux_build_script.sh
       - uses: actions/upload-artifact@v3
         with:
@@ -89,7 +89,7 @@ jobs:
       - run: rm -r target/wheels
       - run: python generate_stubs.py pyoxigraph pyoxigraph.pyi --black
         working-directory: ./python
-      - run: maturin build --release -m python/Cargo.toml --universal2
+      - run: maturin build --release -m python/Cargo.toml --universal2 --features abi3
       - uses: actions/upload-artifact@v3
         with:
           name: pyoxigraph_wheel_universal2_mac
@@ -112,7 +112,7 @@ jobs:
       - run: rm -r target/wheels
       - run: python generate_stubs.py pyoxigraph pyoxigraph.pyi --black
         working-directory: ./python
-      - run: maturin build --release -m python/Cargo.toml
+      - run: maturin build --release -m python/Cargo.toml --features abi3
       - uses: actions/upload-artifact@v3
         with:
           name: pyoxigraph_wheel_x86_64_windows

--- a/.github/workflows/manylinux_build.sh
+++ b/.github/workflows/manylinux_build.sh
@@ -13,4 +13,9 @@ source venv/bin/activate
 pip install -r requirements.dev.txt
 maturin develop --release -m Cargo.toml
 python generate_stubs.py pyoxigraph pyoxigraph.pyi --black
-maturin build --release -m Cargo.toml
+maturin build --release -m Cargo.toml --features abi3
+if [ %for_each_version% ]; then
+  for VERSION in 7 8 9 10 11; do
+    maturin build --release -m Cargo.toml --interpreter "python3.$VERSION"
+  done
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           platforms: linux/${{ matrix.architecture }}
         if: matrix.architecture != 'x86_64'
-      - run: sed 's/%arch%/${{ matrix.architecture }}/g' .github/workflows/manylinux_build.sh > .github/workflows/manylinux_build_script.sh
+      - run: sed 's/%arch%/${{ matrix.architecture }}/g' .github/workflows/manylinux_build.sh | sed 's/%for_each_version%/true/g' > .github/workflows/manylinux_build_script.sh
       - run: docker run -v "$(pwd)":/workdir --platform linux/${{ matrix.architecture }} quay.io/pypa/manylinux2014_${{ matrix.architecture }} /bin/bash /workdir/.github/workflows/manylinux_build_script.sh
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -111,8 +111,8 @@ jobs:
       - run: rm -r target/wheels
       - run: python generate_stubs.py pyoxigraph pyoxigraph.pyi --black
         working-directory: ./python
-      - run: maturin publish --no-sdist -m python/Cargo.toml -u __token__ -p ${{ secrets.PYPI_PASSWORD }}
-      - run: maturin publish --no-sdist --target aarch64-apple-darwin -m python/Cargo.toml -u __token__ -p ${{ secrets.PYPI_PASSWORD }}
+      - run: maturin publish --no-sdist -m python/Cargo.toml --features abi3 -u __token__ -p ${{ secrets.PYPI_PASSWORD }}
+      - run: maturin publish --no-sdist --target aarch64-apple-darwin -m python/Cargo.toml --features abi3 -u __token__ -p ${{ secrets.PYPI_PASSWORD }}
       - uses: softprops/action-gh-release@v1
         with:
           files: target/wheels/*.whl
@@ -134,7 +134,7 @@ jobs:
       - run: rm -r target/wheels
       - run: python generate_stubs.py pyoxigraph pyoxigraph.pyi --black
         working-directory: ./python
-      - run: maturin publish --no-sdist -m python/Cargo.toml -u __token__ -p ${{ secrets.PYPI_PASSWORD }}
+      - run: maturin publish --no-sdist -m python/Cargo.toml --features abi3 -u __token__ -p ${{ secrets.PYPI_PASSWORD }}
       - uses: softprops/action-gh-release@v1
         with:
           files: target/wheels/*.whl

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,6 +15,9 @@ crate-type = ["cdylib"]
 name = "pyoxigraph"
 doctest = false
 
+[features]
+abi3 = ["pyo3/abi3-py37"]
+
 [dependencies]
 oxigraph = { version = "0.3.10", path="../lib", features = ["http_client"] }
-pyo3 = { version = "0.17", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.17", features = ["extension-module"] }


### PR DESCRIPTION
Prebuilt wheels are still using abi3 except for Linux where target-specific builds are also available