### PR TITLE
Implements SEP-0002 ADJUST function

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,7 +39,7 @@ lazy_static = "1"
 sysinfo = "0.27"
 oxrdf = { version = "0.1.1", path="oxrdf", features = ["rdf-star", "oxsdatatypes"] }
 oxsdatatypes = { version = "0.1.0", path="oxsdatatypes" }
-spargebra = { version = "0.2.3", path="spargebra", features = ["rdf-star", "sep-0006"] }
+spargebra = { version = "0.2.3", path="spargebra", features = ["rdf-star", "sep-0002", "sep-0006"] }
 sparesults = { version = "0.1.3", path="sparesults", features = ["rdf-star"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/lib/spargebra/Cargo.toml
+++ b/lib/spargebra/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.60"
 [features]
 default = []
 rdf-star = ["oxrdf/rdf-star"]
+sep-0002 = []
 sep-0006 = []
 
 [dependencies]

--- a/lib/spargebra/src/algebra.rs
+++ b/lib/spargebra/src/algebra.rs
@@ -376,6 +376,8 @@ pub enum Function {
     Object,
     #[cfg(feature = "rdf-star")]
     IsTriple,
+    #[cfg(feature = "sep-0002")]
+    Adjust,
     Custom(NamedNode),
 }
 
@@ -439,6 +441,8 @@ impl Function {
             Self::Object => write!(f, "object"),
             #[cfg(feature = "rdf-star")]
             Self::IsTriple => write!(f, "istriple"),
+            #[cfg(feature = "sep-0002")]
+            Self::Adjust => write!(f, "adjust"),
             Self::Custom(iri) => write!(f, "{iri}"),
         }
     }
@@ -503,6 +507,8 @@ impl fmt::Display for Function {
             Self::Object => write!(f, "OBJECT"),
             #[cfg(feature = "rdf-star")]
             Self::IsTriple => write!(f, "isTRIPLE"),
+            #[cfg(feature = "sep-0002")]
+            Self::Adjust => write!(f, "ADJUST"),
             Self::Custom(iri) => iri.fmt(f),
         }
     }

--- a/lib/spargebra/src/parser.rs
+++ b/lib/spargebra/src/parser.rs
@@ -2109,6 +2109,10 @@ parser! {
             i("isTriple") "(" _ e:Expression() _ ")" {?
                 #[cfg(feature = "rdf-star")]{Ok(Expression::FunctionCall(Function::IsTriple, vec![e]))}
                 #[cfg(not(feature = "rdf-star"))]{Err("The isTriple function is only available in SPARQL-star")}
+            } /
+            i("ADJUST") "("  _ a:Expression() _ "," _ b:Expression() _ ")" {?
+                #[cfg(feature = "sep-0002")]{Ok(Expression::FunctionCall(Function::Adjust, vec![a, b]))}
+                #[cfg(not(feature = "sep-0002"))]{Err("The ADJUST function is only available in SPARQL 1.2 SEP 0002")}
             }
 
         //[122]

--- a/lib/src/sparql/eval.rs
+++ b/lib/src/sparql/eval.rs
@@ -1557,6 +1557,38 @@ impl SimpleEvaluator {
                     })
                 })
             }
+
+            PlanExpression::Adjust(dt, tz) => {
+                let dt = self.expression_evaluator(dt);
+                let tz = self.expression_evaluator(tz);
+                Rc::new(move |tuple| {
+                    let timezone_offset = Some(
+                        match tz(tuple)? {
+                            EncodedTerm::DayTimeDurationLiteral(tz) => TimezoneOffset::try_from(tz),
+                            EncodedTerm::DurationLiteral(tz) => TimezoneOffset::try_from(tz),
+                            _ => return None,
+                        }
+                        .ok()?,
+                    );
+                    Some(match dt(tuple)? {
+                        EncodedTerm::DateTimeLiteral(date_time) => {
+                            date_time.adjust(timezone_offset)?.into()
+                        }
+                        EncodedTerm::TimeLiteral(time) => time.adjust(timezone_offset)?.into(),
+                        EncodedTerm::DateLiteral(date) => date.adjust(timezone_offset)?.into(),
+                        EncodedTerm::GYearMonthLiteral(year_month) => {
+                            year_month.adjust(timezone_offset)?.into()
+                        }
+                        EncodedTerm::GYearLiteral(year) => year.adjust(timezone_offset)?.into(),
+                        EncodedTerm::GMonthDayLiteral(month_day) => {
+                            month_day.adjust(timezone_offset)?.into()
+                        }
+                        EncodedTerm::GDayLiteral(day) => day.adjust(timezone_offset)?.into(),
+                        EncodedTerm::GMonthLiteral(month) => month.adjust(timezone_offset)?.into(),
+                        _ => return None,
+                    })
+                })
+            }
             PlanExpression::Now => {
                 let now = self.now;
                 Rc::new(move |_| Some(now.into()))

--- a/lib/src/sparql/plan.rs
+++ b/lib/src/sparql/plan.rs
@@ -460,6 +460,7 @@ pub enum PlanExpression {
     Predicate(Box<Self>),
     Object(Box<Self>),
     IsTriple(Box<Self>),
+    Adjust(Box<Self>, Box<Self>),
     BooleanCast(Box<Self>),
     DoubleCast(Box<Self>),
     FloatCast(Box<Self>),
@@ -557,7 +558,8 @@ impl PlanExpression {
             | Self::StrDt(a, b)
             | Self::SameTerm(a, b)
             | Self::SubStr(a, b, None)
-            | Self::Regex(a, b, None) => {
+            | Self::Regex(a, b, None)
+            | Self::Adjust(a, b) => {
                 a.lookup_used_variables(callback);
                 b.lookup_used_variables(callback);
             }

--- a/lib/src/sparql/plan_builder.rs
+++ b/lib/src/sparql/plan_builder.rs
@@ -651,6 +651,10 @@ impl<'a> PlanBuilder<'a> {
                 Function::IsTriple => PlanExpression::IsTriple(Box::new(
                     self.build_for_expression(&parameters[0], variables, graph_name)?,
                 )),
+                Function::Adjust => PlanExpression::Adjust(
+                    Box::new(self.build_for_expression(&parameters[0], variables, graph_name)?),
+                    Box::new(self.build_for_expression(&parameters[1], variables, graph_name)?),
+                ),
                 Function::Custom(name) => {
                     if self.custom_functions.contains_key(name) {
                         PlanExpression::CustomFunction(


### PR DESCRIPTION
ADJUST is now only implemented when a new timezone is given. I am not sure "" for no timezone is the best way to go.

It is behind a sep-0002 feature in spargebra and sparql-smith and enabled by default in Oxigraph.