### PR TITLE
Add back oxrocksdb-sys to the main workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ members = [
     "lib/spargebra",
     "lib/sparesults",
     "lib/sparql-smith",
+    "oxrocksdb-sys",
     "python",
     "server",
     "testsuite"
 ]
-exclude = ["oxrocksdb-sys"]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Having it separated was failing fuzz tests for some unknown reason

This reverts commit d97eb9eb31e512d40a39ba81df1ff1e60ae7fdb7.
This reverts commit 4927b3148e3d26b1ab26bdbdf3d4080d6bbb5e56.