### PR TITLE
Uses "ParseDecimalError" naming just like "ParseFloatError"

### DIFF
--- a/lib/oxsdatatypes/src/boolean.rs
+++ b/lib/oxsdatatypes/src/boolean.rs
@@ -88,17 +88,11 @@ mod tests {
 
     #[test]
     fn from_str() -> Result<(), ParseBoolError> {
-        assert_eq!(Boolean::from(true), Boolean::from_str("true")?);
-        assert_eq!(Boolean::from(true), Boolean::from_str("1")?);
-        assert_eq!(Boolean::from(false), Boolean::from_str("false")?);
-        assert_eq!(Boolean::from(false), Boolean::from_str("0")?);
+        assert_eq!(Boolean::from_str("true")?.to_string(), "true");
+        assert_eq!(Boolean::from_str("1")?.to_string(), "true");
+        assert_eq!(Boolean::from_str("false")?.to_string(), "false");
+        assert_eq!(Boolean::from_str("0")?.to_string(), "false");
         Ok(())
-    }
-
-    #[test]
-    fn to_string() {
-        assert_eq!("true", Boolean::from(true).to_string());
-        assert_eq!("false", Boolean::from(false).to_string());
     }
 
     #[test]

--- a/lib/oxsdatatypes/src/date_time.rs
+++ b/lib/oxsdatatypes/src/date_time.rs
@@ -1814,878 +1814,623 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_str() {
+    fn from_str() -> Result<(), XsdParseError> {
+        assert_eq!(Time::from_str("00:00:00Z")?.to_string(), "00:00:00Z");
+        assert_eq!(Time::from_str("00:00:00+00:00")?.to_string(), "00:00:00Z");
+        assert_eq!(Time::from_str("00:00:00-00:00")?.to_string(), "00:00:00Z");
+        assert_eq!(Time::from_str("00:00:00")?.to_string(), "00:00:00");
         assert_eq!(
-            Time::from_str("00:00:00Z").unwrap().to_string(),
-            "00:00:00Z"
-        );
-        assert_eq!(Time::from_str("00:00:00").unwrap().to_string(), "00:00:00");
-        assert_eq!(
-            Time::from_str("00:00:00+02:00").unwrap().to_string(),
+            Time::from_str("00:00:00+02:00")?.to_string(),
             "00:00:00+02:00"
         );
         assert_eq!(
-            Time::from_str("00:00:00+14:00").unwrap().to_string(),
+            Time::from_str("00:00:00+14:00")?.to_string(),
             "00:00:00+14:00"
         );
-        assert_eq!(Time::from_str("24:00:00").unwrap().to_string(), "00:00:00");
+        assert_eq!(Time::from_str("24:00:00")?.to_string(), "00:00:00");
+        assert_eq!(Time::from_str("24:00:00.00")?.to_string(), "00:00:00");
         assert_eq!(
-            Time::from_str("24:00:00.00").unwrap().to_string(),
-            "00:00:00"
-        );
-        assert_eq!(
-            Time::from_str("23:59:59.9999999999").unwrap().to_string(),
+            Time::from_str("23:59:59.9999999999")?.to_string(),
             "23:59:59.9999999999"
         );
 
+        assert_eq!(Date::from_str("0001-01-01Z")?.to_string(), "0001-01-01Z");
+        assert_eq!(Date::from_str("0001-01-01")?.to_string(), "0001-01-01");
         assert_eq!(
-            Date::from_str("0001-01-01Z").unwrap().to_string(),
-            "0001-01-01Z"
-        );
-        assert_eq!(
-            Date::from_str("0001-01-01").unwrap().to_string(),
-            "0001-01-01"
-        );
-        assert_eq!(
-            DateTime::from_str("0001-01-01T00:00:00Z")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("0001-01-01T00:00:00Z")?.to_string(),
             "0001-01-01T00:00:00Z"
         );
         assert_eq!(
-            DateTime::from_str("0001-01-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("0001-01-01T00:00:00")?.to_string(),
             "0001-01-01T00:00:00"
         );
         assert_eq!(
-            DateTime::from_str("1000000000-01-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1000000000-01-01T00:00:00")?.to_string(),
             "1000000000-01-01T00:00:00"
         );
         assert_eq!(
-            DateTime::from_str("2001-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2001-12-31T23:59:59")?.to_string(),
             "2001-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("2004-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2004-12-31T23:59:59")?.to_string(),
             "2004-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("1900-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1900-12-31T23:59:59")?.to_string(),
             "1900-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("2000-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2000-12-31T23:59:59")?.to_string(),
             "2000-12-31T23:59:59",
         );
         assert_eq!(
-            DateTime::from_str("1899-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1899-12-31T23:59:59")?.to_string(),
             "1899-12-31T23:59:59"
         );
 
         assert_eq!(
-            DateTime::from_str("2001-02-28T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2001-02-28T23:59:59")?.to_string(),
             "2001-02-28T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("2004-02-29T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2004-02-29T23:59:59")?.to_string(),
             "2004-02-29T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("1900-02-28T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1900-02-28T23:59:59")?.to_string(),
             "1900-02-28T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("2000-02-29T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2000-02-29T23:59:59")?.to_string(),
             "2000-02-29T23:59:59",
         );
         assert_eq!(
-            DateTime::from_str("1899-02-28T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1899-02-28T23:59:59")?.to_string(),
             "1899-02-28T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("2001-03-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2001-03-01T00:00:00")?.to_string(),
             "2001-03-01T00:00:00"
         );
         assert_eq!(
-            DateTime::from_str("2004-03-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2004-03-01T00:00:00")?.to_string(),
             "2004-03-01T00:00:00"
         );
         assert_eq!(
-            DateTime::from_str("1900-03-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1900-03-01T00:00:00")?.to_string(),
             "1900-03-01T00:00:00"
         );
         assert_eq!(
-            DateTime::from_str("2000-03-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("2000-03-01T00:00:00")?.to_string(),
             "2000-03-01T00:00:00",
         );
         assert_eq!(
-            DateTime::from_str("1899-03-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("1899-03-01T00:00:00")?.to_string(),
             "1899-03-01T00:00:00"
         );
 
         assert_eq!(
-            DateTime::from_str("-1000000000-01-01T00:00:00")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("-1000000000-01-01T00:00:00")?.to_string(),
             "-1000000000-01-01T00:00:00"
         );
         assert_eq!(
-            DateTime::from_str("-2001-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("-2001-12-31T23:59:59")?.to_string(),
             "-2001-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("-2004-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("-2004-12-31T23:59:59")?.to_string(),
             "-2004-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("-1900-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("-1900-12-31T23:59:59")?.to_string(),
             "-1900-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("-2000-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("-2000-12-31T23:59:59")?.to_string(),
             "-2000-12-31T23:59:59"
         );
         assert_eq!(
-            DateTime::from_str("-1899-12-31T23:59:59")
-                .unwrap()
-                .to_string(),
+            DateTime::from_str("-1899-12-31T23:59:59")?.to_string(),
             "-1899-12-31T23:59:59"
         );
 
         assert_eq!(
-            GYearMonth::from_str("-1899-12+01:00").unwrap().to_string(),
+            GYearMonth::from_str("-1899-12+01:00")?.to_string(),
             "-1899-12+01:00"
         );
+        assert_eq!(GYearMonth::from_str("-1899-12")?.to_string(), "-1899-12");
+        assert_eq!(GYear::from_str("-1899+01:00")?.to_string(), "-1899+01:00");
+        assert_eq!(GYear::from_str("-1899")?.to_string(), "-1899");
         assert_eq!(
-            GYear::from_str("-1899+01:00").unwrap().to_string(),
-            "-1899+01:00"
-        );
-        assert_eq!(
-            GMonthDay::from_str("--01-01+01:00").unwrap().to_string(),
+            GMonthDay::from_str("--01-01+01:00")?.to_string(),
             "--01-01+01:00"
         );
-        assert_eq!(
-            GDay::from_str("---01+01:00").unwrap().to_string(),
-            "---01+01:00"
-        );
-        assert_eq!(
-            GMonth::from_str("--01+01:00").unwrap().to_string(),
-            "--01+01:00"
-        );
+        assert_eq!(GMonthDay::from_str("--01-01")?.to_string(), "--01-01");
+        assert_eq!(GDay::from_str("---01+01:00")?.to_string(), "---01+01:00");
+        assert_eq!(GDay::from_str("---01")?.to_string(), "---01");
+        assert_eq!(GMonth::from_str("--01+01:00")?.to_string(), "--01+01:00");
+        assert_eq!(GMonth::from_str("--01")?.to_string(), "--01");
+        Ok(())
     }
 
     #[test]
-    fn equals() {
+    fn equals() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("2002-04-02T12:00:00-01:00").unwrap(),
-            DateTime::from_str("2002-04-02T17:00:00+04:00").unwrap()
+            DateTime::from_str("2002-04-02T12:00:00-01:00")?,
+            DateTime::from_str("2002-04-02T17:00:00+04:00")?
         );
         assert_eq!(
-            DateTime::from_str("2002-04-02T12:00:00-05:00").unwrap(),
-            DateTime::from_str("2002-04-02T23:00:00+06:00").unwrap()
+            DateTime::from_str("2002-04-02T12:00:00-05:00")?,
+            DateTime::from_str("2002-04-02T23:00:00+06:00")?
         );
         assert_ne!(
-            DateTime::from_str("2002-04-02T12:00:00-05:00").unwrap(),
-            DateTime::from_str("2002-04-02T17:00:00-05:00").unwrap()
+            DateTime::from_str("2002-04-02T12:00:00-05:00")?,
+            DateTime::from_str("2002-04-02T17:00:00-05:00")?
         );
         assert_eq!(
-            DateTime::from_str("2002-04-02T12:00:00-05:00").unwrap(),
-            DateTime::from_str("2002-04-02T12:00:00-05:00").unwrap()
+            DateTime::from_str("2002-04-02T12:00:00-05:00")?,
+            DateTime::from_str("2002-04-02T12:00:00-05:00")?
         );
         assert_eq!(
-            DateTime::from_str("2002-04-02T23:00:00-04:00").unwrap(),
-            DateTime::from_str("2002-04-03T02:00:00-01:00").unwrap()
+            DateTime::from_str("2002-04-02T23:00:00-04:00")?,
+            DateTime::from_str("2002-04-03T02:00:00-01:00")?
         );
         assert_eq!(
-            DateTime::from_str("1999-12-31T24:00:00-05:00").unwrap(),
-            DateTime::from_str("2000-01-01T00:00:00-05:00").unwrap()
+            DateTime::from_str("1999-12-31T24:00:00-05:00")?,
+            DateTime::from_str("2000-01-01T00:00:00-05:00")?
         );
         assert_ne!(
-            DateTime::from_str("2005-04-04T24:00:00-05:00").unwrap(),
-            DateTime::from_str("2005-04-04T00:00:00-05:00").unwrap()
+            DateTime::from_str("2005-04-04T24:00:00-05:00")?,
+            DateTime::from_str("2005-04-04T00:00:00-05:00")?
         );
 
         assert_ne!(
-            Date::from_str("2004-12-25Z").unwrap(),
-            Date::from_str("2004-12-25+07:00").unwrap()
+            Date::from_str("2004-12-25Z")?,
+            Date::from_str("2004-12-25+07:00")?
         );
         assert_eq!(
-            Date::from_str("2004-12-25-12:00").unwrap(),
-            Date::from_str("2004-12-26+12:00").unwrap()
+            Date::from_str("2004-12-25-12:00")?,
+            Date::from_str("2004-12-26+12:00")?
         );
 
         assert_ne!(
-            Time::from_str("08:00:00+09:00").unwrap(),
-            Time::from_str("17:00:00-06:00").unwrap()
+            Time::from_str("08:00:00+09:00")?,
+            Time::from_str("17:00:00-06:00")?
         );
         assert_eq!(
-            Time::from_str("21:30:00+10:30").unwrap(),
-            Time::from_str("06:00:00-05:00").unwrap()
+            Time::from_str("21:30:00+10:30")?,
+            Time::from_str("06:00:00-05:00")?
         );
         assert_eq!(
-            Time::from_str("24:00:00+01:00").unwrap(),
-            Time::from_str("00:00:00+01:00").unwrap()
-        );
-
-        assert_eq!(
-            Time::from_str("05:00:00-03:00").unwrap(),
-            Time::from_str("10:00:00+02:00").unwrap()
-        );
-        assert_ne!(
-            Time::from_str("23:00:00-03:00").unwrap(),
-            Time::from_str("02:00:00Z").unwrap()
-        );
-
-        assert_ne!(
-            GYearMonth::from_str("1986-02").unwrap(),
-            GYearMonth::from_str("1986-03").unwrap()
-        );
-        assert_ne!(
-            GYearMonth::from_str("1978-03").unwrap(),
-            GYearMonth::from_str("1978-03Z").unwrap()
-        );
-
-        assert_ne!(
-            GYear::from_str("2005-12:00").unwrap(),
-            GYear::from_str("2005+12:00").unwrap()
-        );
-        assert_ne!(
-            GYear::from_str("1976-05:00").unwrap(),
-            GYear::from_str("1976").unwrap()
+            Time::from_str("24:00:00+01:00")?,
+            Time::from_str("00:00:00+01:00")?
         );
 
         assert_eq!(
-            GMonthDay::from_str("--12-25-14:00").unwrap(),
-            GMonthDay::from_str("--12-26+10:00").unwrap()
+            Time::from_str("05:00:00-03:00")?,
+            Time::from_str("10:00:00+02:00")?
         );
         assert_ne!(
-            GMonthDay::from_str("--12-25").unwrap(),
-            GMonthDay::from_str("--12-26Z").unwrap()
+            Time::from_str("23:00:00-03:00")?,
+            Time::from_str("02:00:00Z")?
         );
 
         assert_ne!(
-            GMonth::from_str("--12-14:00").unwrap(),
-            GMonth::from_str("--12+10:00").unwrap()
+            GYearMonth::from_str("1986-02")?,
+            GYearMonth::from_str("1986-03")?
         );
         assert_ne!(
-            GMonth::from_str("--12").unwrap(),
-            GMonth::from_str("--12Z").unwrap()
+            GYearMonth::from_str("1978-03")?,
+            GYearMonth::from_str("1978-03Z")?
         );
 
         assert_ne!(
-            GDay::from_str("---25-14:00").unwrap(),
-            GDay::from_str("---25+10:00").unwrap()
+            GYear::from_str("2005-12:00")?,
+            GYear::from_str("2005+12:00")?
+        );
+        assert_ne!(GYear::from_str("1976-05:00")?, GYear::from_str("1976")?);
+
+        assert_eq!(
+            GMonthDay::from_str("--12-25-14:00")?,
+            GMonthDay::from_str("--12-26+10:00")?
         );
         assert_ne!(
-            GDay::from_str("---12").unwrap(),
-            GDay::from_str("---12Z").unwrap()
+            GMonthDay::from_str("--12-25")?,
+            GMonthDay::from_str("--12-26Z")?
         );
+
+        assert_ne!(
+            GMonth::from_str("--12-14:00")?,
+            GMonth::from_str("--12+10:00")?
+        );
+        assert_ne!(GMonth::from_str("--12")?, GMonth::from_str("--12Z")?);
+
+        assert_ne!(
+            GDay::from_str("---25-14:00")?,
+            GDay::from_str("---25+10:00")?
+        );
+        assert_ne!(GDay::from_str("---12")?, GDay::from_str("---12Z")?);
+        Ok(())
     }
 
     #[test]
     #[allow(clippy::neg_cmp_op_on_partial_ord)]
-    fn cmp() {
-        assert!(
-            Date::from_str("2004-12-25Z").unwrap() < Date::from_str("2004-12-25-05:00").unwrap()
-        );
-        assert!(
-            !(Date::from_str("2004-12-25-12:00").unwrap()
-                < Date::from_str("2004-12-26+12:00").unwrap())
-        );
+    fn cmp() -> Result<(), XsdParseError> {
+        assert!(Date::from_str("2004-12-25Z")? < Date::from_str("2004-12-25-05:00")?);
+        assert!(!(Date::from_str("2004-12-25-12:00")? < Date::from_str("2004-12-26+12:00")?));
 
-        assert!(
-            Date::from_str("2004-12-25Z").unwrap() > Date::from_str("2004-12-25+07:00").unwrap()
-        );
-        assert!(
-            !(Date::from_str("2004-12-25-12:00").unwrap()
-                > Date::from_str("2004-12-26+12:00").unwrap())
-        );
+        assert!(Date::from_str("2004-12-25Z")? > Date::from_str("2004-12-25+07:00")?);
+        assert!(!(Date::from_str("2004-12-25-12:00")? > Date::from_str("2004-12-26+12:00")?));
 
-        assert!(!(Time::from_str("12:00:00").unwrap() < Time::from_str("23:00:00+06:00").unwrap()));
-        assert!(Time::from_str("11:00:00-05:00").unwrap() < Time::from_str("17:00:00Z").unwrap());
-        assert!(!(Time::from_str("23:59:59").unwrap() < Time::from_str("24:00:00").unwrap()));
+        assert!(!(Time::from_str("12:00:00")? < Time::from_str("23:00:00+06:00")?));
+        assert!(Time::from_str("11:00:00-05:00")? < Time::from_str("17:00:00Z")?);
+        assert!(!(Time::from_str("23:59:59")? < Time::from_str("24:00:00")?));
 
-        assert!(
-            !(Time::from_str("08:00:00+09:00").unwrap()
-                > Time::from_str("17:00:00-06:00").unwrap())
-        );
+        assert!(!(Time::from_str("08:00:00+09:00")? > Time::from_str("17:00:00-06:00")?));
 
-        assert!(
-            GMonthDay::from_str("--12-12+13:00").unwrap()
-                < GMonthDay::from_str("--12-12+11:00").unwrap()
-        );
-        assert!(GDay::from_str("---15").unwrap() < GDay::from_str("---16").unwrap());
-        assert!(GDay::from_str("---15-13:00").unwrap() > GDay::from_str("---16+13:00").unwrap());
+        assert!(GMonthDay::from_str("--12-12+13:00")? < GMonthDay::from_str("--12-12+11:00")?);
+        assert!(GDay::from_str("---15")? < GDay::from_str("---16")?);
+        assert!(GDay::from_str("---15-13:00")? > GDay::from_str("---16+13:00")?);
         assert_eq!(
-            GDay::from_str("---15-11:00").unwrap(),
-            GDay::from_str("---16+13:00").unwrap()
+            GDay::from_str("---15-11:00")?,
+            GDay::from_str("---16+13:00")?
         );
-        assert!(GDay::from_str("---15-13:00")
-            .unwrap()
-            .partial_cmp(&GDay::from_str("---16").unwrap())
+        assert!(GDay::from_str("---15-13:00")?
+            .partial_cmp(&GDay::from_str("---16")?)
             .is_none());
+        Ok(())
     }
 
     #[test]
-    fn year() {
+    fn year() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("1999-05-31T13:20:00-05:00")
-                .unwrap()
-                .year(),
+            DateTime::from_str("1999-05-31T13:20:00-05:00")?.year(),
             1999
         );
         assert_eq!(
-            DateTime::from_str("1999-05-31T21:30:00-05:00")
-                .unwrap()
-                .year(),
+            DateTime::from_str("1999-05-31T21:30:00-05:00")?.year(),
             1999
         );
-        assert_eq!(
-            DateTime::from_str("1999-12-31T19:20:00").unwrap().year(),
-            1999
-        );
-        assert_eq!(
-            DateTime::from_str("1999-12-31T24:00:00").unwrap().year(),
-            2000
-        );
-        assert_eq!(
-            DateTime::from_str("-0002-06-06T00:00:00").unwrap().year(),
-            -2
-        );
+        assert_eq!(DateTime::from_str("1999-12-31T19:20:00")?.year(), 1999);
+        assert_eq!(DateTime::from_str("1999-12-31T24:00:00")?.year(), 2000);
+        assert_eq!(DateTime::from_str("-0002-06-06T00:00:00")?.year(), -2);
 
-        assert_eq!(Date::from_str("1999-05-31").unwrap().year(), 1999);
-        assert_eq!(Date::from_str("2000-01-01+05:00").unwrap().year(), 2000);
-        assert_eq!(Date::from_str("-0002-06-01").unwrap().year(), -2);
+        assert_eq!(Date::from_str("1999-05-31")?.year(), 1999);
+        assert_eq!(Date::from_str("2000-01-01+05:00")?.year(), 2000);
+        assert_eq!(Date::from_str("-0002-06-01")?.year(), -2);
+
+        assert_eq!(GYear::from_str("-0002")?.year(), -2);
+        assert_eq!(GYearMonth::from_str("-0002-02")?.year(), -2);
+        Ok(())
     }
 
     #[test]
-    fn month() {
-        assert_eq!(
-            DateTime::from_str("1999-05-31T13:20:00-05:00")
-                .unwrap()
-                .month(),
-            5
-        );
-        assert_eq!(
-            DateTime::from_str("1999-12-31T19:20:00-05:00")
-                .unwrap()
-                .month(),
-            12
-        );
+    fn month() -> Result<(), XsdParseError> {
+        assert_eq!(DateTime::from_str("1999-05-31T13:20:00-05:00")?.month(), 5);
+        assert_eq!(DateTime::from_str("1999-12-31T19:20:00-05:00")?.month(), 12);
 
-        assert_eq!(Date::from_str("1999-05-31-05:00").unwrap().month(), 5);
-        assert_eq!(Date::from_str("2000-01-01+05:00").unwrap().month(), 1);
+        assert_eq!(Date::from_str("1999-05-31-05:00")?.month(), 5);
+        assert_eq!(Date::from_str("2000-01-01+05:00")?.month(), 1);
+
+        assert_eq!(GMonth::from_str("--02")?.month(), 2);
+        assert_eq!(GYearMonth::from_str("-0002-02")?.month(), 2);
+        assert_eq!(GMonthDay::from_str("--02-03")?.month(), 2);
+        Ok(())
     }
 
     #[test]
-    fn day() {
-        assert_eq!(
-            DateTime::from_str("1999-05-31T13:20:00-05:00")
-                .unwrap()
-                .day(),
-            31
-        );
-        assert_eq!(
-            DateTime::from_str("1999-12-31T20:00:00-05:00")
-                .unwrap()
-                .day(),
-            31
-        );
+    fn day() -> Result<(), XsdParseError> {
+        assert_eq!(DateTime::from_str("1999-05-31T13:20:00-05:00")?.day(), 31);
+        assert_eq!(DateTime::from_str("1999-12-31T20:00:00-05:00")?.day(), 31);
 
-        assert_eq!(Date::from_str("1999-05-31-05:00").unwrap().day(), 31);
-        assert_eq!(Date::from_str("2000-01-01+05:00").unwrap().day(), 1);
+        assert_eq!(Date::from_str("1999-05-31-05:00")?.day(), 31);
+        assert_eq!(Date::from_str("2000-01-01+05:00")?.day(), 1);
+
+        assert_eq!(GDay::from_str("---03")?.day(), 3);
+        assert_eq!(GMonthDay::from_str("--02-03")?.day(), 3);
+        Ok(())
     }
 
     #[test]
-    fn hour() {
-        assert_eq!(
-            DateTime::from_str("1999-05-31T08:20:00-05:00")
-                .unwrap()
-                .hour(),
-            8
-        );
-        assert_eq!(
-            DateTime::from_str("1999-12-31T21:20:00-05:00")
-                .unwrap()
-                .hour(),
-            21
-        );
-        assert_eq!(
-            DateTime::from_str("1999-12-31T12:00:00").unwrap().hour(),
-            12
-        );
-        assert_eq!(DateTime::from_str("1999-12-31T24:00:00").unwrap().hour(), 0);
+    fn hour() -> Result<(), XsdParseError> {
+        assert_eq!(DateTime::from_str("1999-05-31T08:20:00-05:00")?.hour(), 8);
+        assert_eq!(DateTime::from_str("1999-12-31T21:20:00-05:00")?.hour(), 21);
+        assert_eq!(DateTime::from_str("1999-12-31T12:00:00")?.hour(), 12);
+        assert_eq!(DateTime::from_str("1999-12-31T24:00:00")?.hour(), 0);
 
-        assert_eq!(Time::from_str("11:23:00-05:00").unwrap().hour(), 11);
-        assert_eq!(Time::from_str("21:23:00-05:00").unwrap().hour(), 21);
-        assert_eq!(Time::from_str("01:23:00+05:00").unwrap().hour(), 1);
-        assert_eq!(Time::from_str("24:00:00").unwrap().hour(), 0);
+        assert_eq!(Time::from_str("11:23:00-05:00")?.hour(), 11);
+        assert_eq!(Time::from_str("21:23:00-05:00")?.hour(), 21);
+        assert_eq!(Time::from_str("01:23:00+05:00")?.hour(), 1);
+        assert_eq!(Time::from_str("24:00:00")?.hour(), 0);
+        Ok(())
     }
 
     #[test]
-    fn minute() {
+    fn minute() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("1999-05-31T13:20:00-05:00")
-                .unwrap()
-                .minute(),
+            DateTime::from_str("1999-05-31T13:20:00-05:00")?.minute(),
             20
         );
         assert_eq!(
-            DateTime::from_str("1999-05-31T13:30:00+05:30")
-                .unwrap()
-                .minute(),
+            DateTime::from_str("1999-05-31T13:30:00+05:30")?.minute(),
             30
         );
 
-        assert_eq!(Time::from_str("13:00:00Z").unwrap().minute(), 0);
+        assert_eq!(Time::from_str("13:00:00Z")?.minute(), 0);
+        Ok(())
     }
 
     #[test]
-    fn second() {
+    fn second() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("1999-05-31T13:20:00-05:00")
-                .unwrap()
-                .second(),
+            DateTime::from_str("1999-05-31T13:20:00-05:00")?.second(),
             Decimal::from(0)
         );
 
         assert_eq!(
-            Time::from_str("13:20:10.5").unwrap().second(),
-            Decimal::from_str("10.5").unwrap()
+            Time::from_str("13:20:10.5")?.second(),
+            Decimal::from_str("10.5")?
         );
+        Ok(())
     }
 
     #[test]
-    fn timezone() {
+    fn timezone() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("1999-05-31T13:20:00-05:00")
-                .unwrap()
-                .timezone(),
-            Some(DayTimeDuration::from_str("-PT5H").unwrap())
+            DateTime::from_str("1999-05-31T13:20:00-05:00")?.timezone(),
+            Some(DayTimeDuration::from_str("-PT5H")?)
         );
         assert_eq!(
-            DateTime::from_str("2000-06-12T13:20:00Z")
-                .unwrap()
-                .timezone(),
-            Some(DayTimeDuration::from_str("PT0S").unwrap())
+            DateTime::from_str("2000-06-12T13:20:00Z")?.timezone(),
+            Some(DayTimeDuration::from_str("PT0S")?)
+        );
+        assert_eq!(DateTime::from_str("2004-08-27T00:00:00")?.timezone(), None);
+
+        assert_eq!(
+            Date::from_str("1999-05-31-05:00")?.timezone(),
+            Some(DayTimeDuration::from_str("-PT5H")?)
         );
         assert_eq!(
-            DateTime::from_str("2004-08-27T00:00:00")
-                .unwrap()
-                .timezone(),
-            None
+            Date::from_str("2000-06-12Z")?.timezone(),
+            Some(DayTimeDuration::from_str("PT0S")?)
         );
 
         assert_eq!(
-            Date::from_str("1999-05-31-05:00").unwrap().timezone(),
-            Some(DayTimeDuration::from_str("-PT5H").unwrap())
+            Time::from_str("13:20:00-05:00")?.timezone(),
+            Some(DayTimeDuration::from_str("-PT5H")?)
         );
-        assert_eq!(
-            Date::from_str("2000-06-12Z").unwrap().timezone(),
-            Some(DayTimeDuration::from_str("PT0S").unwrap())
-        );
-
-        assert_eq!(
-            Time::from_str("13:20:00-05:00").unwrap().timezone(),
-            Some(DayTimeDuration::from_str("-PT5H").unwrap())
-        );
-        assert_eq!(Time::from_str("13:20:00").unwrap().timezone(), None);
+        assert_eq!(Time::from_str("13:20:00")?.timezone(), None);
+        Ok(())
     }
 
     #[test]
-    fn sub() {
+    fn sub() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("2000-10-30T06:12:00-05:00")
-                .unwrap()
-                .checked_sub(DateTime::from_str("1999-11-28T09:00:00Z").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("P337DT2H12M").unwrap()
+            DateTime::from_str("2000-10-30T06:12:00-05:00")?
+                .checked_sub(DateTime::from_str("1999-11-28T09:00:00Z")?),
+            Some(DayTimeDuration::from_str("P337DT2H12M")?)
         );
 
         assert_eq!(
-            Date::from_str("2000-10-30")
-                .unwrap()
-                .checked_sub(Date::from_str("1999-11-28").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("P337D").unwrap()
+            Date::from_str("2000-10-30")?.checked_sub(Date::from_str("1999-11-28")?),
+            Some(DayTimeDuration::from_str("P337D")?)
         );
         assert_eq!(
-            Date::from_str("2000-10-30+05:00")
-                .unwrap()
-                .checked_sub(Date::from_str("1999-11-28Z").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("P336DT19H").unwrap()
+            Date::from_str("2000-10-30+05:00")?.checked_sub(Date::from_str("1999-11-28Z")?),
+            Some(DayTimeDuration::from_str("P336DT19H")?)
         );
         assert_eq!(
-            Date::from_str("2000-10-15-05:00")
-                .unwrap()
-                .checked_sub(Date::from_str("2000-10-10+02:00").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("P5DT7H").unwrap()
+            Date::from_str("2000-10-15-05:00")?.checked_sub(Date::from_str("2000-10-10+02:00")?),
+            Some(DayTimeDuration::from_str("P5DT7H")?)
         );
 
         assert_eq!(
-            Time::from_str("11:12:00Z")
-                .unwrap()
-                .checked_sub(Time::from_str("04:00:00-05:00").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("PT2H12M").unwrap()
+            Time::from_str("11:12:00Z")?.checked_sub(Time::from_str("04:00:00-05:00")?),
+            Some(DayTimeDuration::from_str("PT2H12M")?)
         );
         assert_eq!(
-            Time::from_str("11:00:00-05:00")
-                .unwrap()
-                .checked_sub(Time::from_str("21:30:00+05:30").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("PT0S").unwrap()
+            Time::from_str("11:00:00-05:00")?.checked_sub(Time::from_str("21:30:00+05:30")?),
+            Some(DayTimeDuration::from_str("PT0S")?)
         );
         assert_eq!(
-            Time::from_str("17:00:00-06:00")
-                .unwrap()
-                .checked_sub(Time::from_str("08:00:00+09:00").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("P1D").unwrap()
+            Time::from_str("17:00:00-06:00")?.checked_sub(Time::from_str("08:00:00+09:00")?),
+            Some(DayTimeDuration::from_str("P1D")?)
         );
         assert_eq!(
-            Time::from_str("24:00:00")
-                .unwrap()
-                .checked_sub(Time::from_str("23:59:59").unwrap())
-                .unwrap(),
-            DayTimeDuration::from_str("-PT23H59M59S").unwrap()
+            Time::from_str("24:00:00")?.checked_sub(Time::from_str("23:59:59")?),
+            Some(DayTimeDuration::from_str("-PT23H59M59S")?)
         );
+        Ok(())
     }
 
     #[test]
-    fn add_duration() {
+    fn add_duration() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("2000-01-12T12:13:14Z")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1Y3M5DT7H10M3.3S").unwrap())
-                .unwrap(),
-            DateTime::from_str("2001-04-17T19:23:17.3Z").unwrap()
+            DateTime::from_str("2000-01-12T12:13:14Z")?
+                .checked_add_duration(Duration::from_str("P1Y3M5DT7H10M3.3S")?),
+            Some(DateTime::from_str("2001-04-17T19:23:17.3Z")?)
         );
         assert_eq!(
-            Date::from_str("2000-01-01")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("-P3M").unwrap())
-                .unwrap()
-                .to_string(),
-            "1999-10-01"
+            Date::from_str("2000-01-01")?.checked_add_duration(Duration::from_str("-P3M")?),
+            Some(Date::from_str("1999-10-01")?)
         );
         assert_eq!(
-            Date::from_str("2000-01-12")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("PT33H").unwrap())
-                .unwrap(),
-            Date::from_str("2000-01-13").unwrap()
+            Date::from_str("2000-01-12")?.checked_add_duration(Duration::from_str("PT33H")?),
+            Some(Date::from_str("2000-01-13")?)
         );
         assert_eq!(
-            Date::from_str("2000-03-30")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1D").unwrap())
-                .unwrap(),
-            Date::from_str("2000-03-31").unwrap()
+            Date::from_str("2000-03-30")?.checked_add_duration(Duration::from_str("P1D")?),
+            Some(Date::from_str("2000-03-31")?)
         );
         assert_eq!(
-            Date::from_str("2000-03-31")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1M").unwrap())
-                .unwrap(),
-            Date::from_str("2000-04-30").unwrap()
+            Date::from_str("2000-03-31")?.checked_add_duration(Duration::from_str("P1M")?),
+            Some(Date::from_str("2000-04-30")?)
         );
         assert_eq!(
-            Date::from_str("2000-03-30")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1M").unwrap())
-                .unwrap(),
-            Date::from_str("2000-04-30").unwrap()
+            Date::from_str("2000-03-30")?.checked_add_duration(Duration::from_str("P1M")?),
+            Some(Date::from_str("2000-04-30")?)
         );
         assert_eq!(
-            Date::from_str("2000-04-30")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1D").unwrap())
-                .unwrap(),
-            Date::from_str("2000-05-01").unwrap()
+            Date::from_str("2000-04-30")?.checked_add_duration(Duration::from_str("P1D")?),
+            Some(Date::from_str("2000-05-01")?)
         );
 
         assert_eq!(
-            DateTime::from_str("2000-10-30T11:12:00")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1Y2M").unwrap())
-                .unwrap(),
-            DateTime::from_str("2001-12-30T11:12:00").unwrap()
+            DateTime::from_str("2000-10-30T11:12:00")?
+                .checked_add_duration(Duration::from_str("P1Y2M")?),
+            Some(DateTime::from_str("2001-12-30T11:12:00")?)
         );
         assert_eq!(
-            DateTime::from_str("2000-10-30T11:12:00")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P3DT1H15M").unwrap())
-                .unwrap(),
-            DateTime::from_str("2000-11-02T12:27:00").unwrap()
+            DateTime::from_str("2000-10-30T11:12:00")?
+                .checked_add_duration(Duration::from_str("P3DT1H15M")?),
+            Some(DateTime::from_str("2000-11-02T12:27:00")?)
         );
 
         assert_eq!(
-            Date::from_str("2000-10-30")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1Y2M").unwrap())
-                .unwrap(),
-            Date::from_str("2001-12-30").unwrap()
+            Date::from_str("2000-10-30")?.checked_add_duration(Duration::from_str("P1Y2M")?),
+            Some(Date::from_str("2001-12-30")?)
         );
         assert_eq!(
-            Date::from_str("2004-10-30Z")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P2DT2H30M0S").unwrap())
-                .unwrap(),
-            Date::from_str("2004-11-01Z").unwrap()
+            Date::from_str("2004-10-30Z")?.checked_add_duration(Duration::from_str("P2DT2H30M0S")?),
+            Some(Date::from_str("2004-11-01Z")?)
         );
 
         assert_eq!(
-            Time::from_str("11:12:00")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P3DT1H15M").unwrap())
-                .unwrap(),
-            Time::from_str("12:27:00").unwrap()
+            Time::from_str("11:12:00")?.checked_add_duration(Duration::from_str("P3DT1H15M")?),
+            Some(Time::from_str("12:27:00")?)
         );
         assert_eq!(
-            Time::from_str("23:12:00+03:00")
-                .unwrap()
-                .checked_add_duration(Duration::from_str("P1DT3H15M").unwrap())
-                .unwrap(),
-            Time::from_str("02:27:00+03:00").unwrap()
+            Time::from_str("23:12:00+03:00")?
+                .checked_add_duration(Duration::from_str("P1DT3H15M")?),
+            Some(Time::from_str("02:27:00+03:00")?)
         );
+        Ok(())
     }
 
     #[test]
-    fn sub_duration() {
+    fn sub_duration() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("2000-10-30T11:12:00")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P1Y2M").unwrap())
-                .unwrap(),
-            DateTime::from_str("1999-08-30T11:12:00").unwrap()
+            DateTime::from_str("2000-10-30T11:12:00")?
+                .checked_sub_duration(Duration::from_str("P1Y2M")?),
+            Some(DateTime::from_str("1999-08-30T11:12:00")?)
         );
         assert_eq!(
-            DateTime::from_str("2000-10-30T11:12:00")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P3DT1H15M").unwrap())
-                .unwrap(),
-            DateTime::from_str("2000-10-27T09:57:00").unwrap()
+            DateTime::from_str("2000-10-30T11:12:00")?
+                .checked_sub_duration(Duration::from_str("P3DT1H15M")?),
+            Some(DateTime::from_str("2000-10-27T09:57:00")?)
         );
 
         assert_eq!(
-            Date::from_str("2000-10-30")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P1Y2M").unwrap())
-                .unwrap(),
-            Date::from_str("1999-08-30").unwrap()
+            Date::from_str("2000-10-30")?.checked_sub_duration(Duration::from_str("P1Y2M")?),
+            Some(Date::from_str("1999-08-30")?)
         );
         assert_eq!(
-            Date::from_str("2000-02-29Z")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P1Y").unwrap())
-                .unwrap(),
-            Date::from_str("1999-02-28Z").unwrap()
+            Date::from_str("2000-02-29Z")?.checked_sub_duration(Duration::from_str("P1Y")?),
+            Some(Date::from_str("1999-02-28Z")?)
         );
         assert_eq!(
-            Date::from_str("2000-10-31-05:00")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P1Y1M").unwrap())
-                .unwrap(),
-            Date::from_str("1999-09-30-05:00").unwrap()
+            Date::from_str("2000-10-31-05:00")?.checked_sub_duration(Duration::from_str("P1Y1M")?),
+            Some(Date::from_str("1999-09-30-05:00")?)
         );
         assert_eq!(
-            Date::from_str("2000-10-30")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P3DT1H15M").unwrap())
-                .unwrap(),
-            Date::from_str("2000-10-26").unwrap()
+            Date::from_str("2000-10-30")?.checked_sub_duration(Duration::from_str("P3DT1H15M")?),
+            Some(Date::from_str("2000-10-26")?)
         );
 
         assert_eq!(
-            Time::from_str("11:12:00")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P3DT1H15M").unwrap())
-                .unwrap(),
-            Time::from_str("09:57:00").unwrap()
+            Time::from_str("11:12:00")?.checked_sub_duration(Duration::from_str("P3DT1H15M")?),
+            Some(Time::from_str("09:57:00")?)
         );
         assert_eq!(
-            Time::from_str("08:20:00-05:00")
-                .unwrap()
-                .checked_sub_duration(Duration::from_str("P23DT10H10M").unwrap())
-                .unwrap(),
-            Time::from_str("22:10:00-05:00").unwrap()
+            Time::from_str("08:20:00-05:00")?
+                .checked_sub_duration(Duration::from_str("P23DT10H10M")?),
+            Some(Time::from_str("22:10:00-05:00")?)
         );
+        Ok(())
     }
 
     #[test]
-    fn adjust() {
+    fn adjust() -> Result<(), XsdParseError> {
         assert_eq!(
-            DateTime::from_str("2002-03-07T10:00:00-07:00")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("PT10H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            DateTime::from_str("2002-03-08T03:00:00+10:00").unwrap()
+            DateTime::from_str("2002-03-07T10:00:00-07:00")?.adjust(Some(
+                DayTimeDuration::from_str("PT10H")?.try_into().unwrap()
+            )),
+            Some(DateTime::from_str("2002-03-08T03:00:00+10:00")?)
         );
         assert_eq!(
-            DateTime::from_str("2002-03-07T00:00:00+01:00")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("-PT8H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            DateTime::from_str("2002-03-06T15:00:00-08:00").unwrap()
+            DateTime::from_str("2002-03-07T00:00:00+01:00")?.adjust(Some(
+                DayTimeDuration::from_str("-PT8H")?.try_into().unwrap()
+            )),
+            Some(DateTime::from_str("2002-03-06T15:00:00-08:00")?)
         );
         assert_eq!(
-            DateTime::from_str("2002-03-07T10:00:00")
-                .unwrap()
-                .adjust(None)
-                .unwrap(),
-            DateTime::from_str("2002-03-07T10:00:00").unwrap()
+            DateTime::from_str("2002-03-07T10:00:00")?.adjust(None),
+            Some(DateTime::from_str("2002-03-07T10:00:00")?)
         );
         assert_eq!(
-            DateTime::from_str("2002-03-07T10:00:00-07:00")
-                .unwrap()
-                .adjust(None)
-                .unwrap(),
-            DateTime::from_str("2002-03-07T10:00:00").unwrap()
+            DateTime::from_str("2002-03-07T10:00:00-07:00")?.adjust(None),
+            Some(DateTime::from_str("2002-03-07T10:00:00")?)
         );
 
         assert_eq!(
-            Date::from_str("2002-03-07")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("-PT10H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            Date::from_str("2002-03-07-10:00").unwrap()
+            Date::from_str("2002-03-07")?.adjust(Some(
+                DayTimeDuration::from_str("-PT10H")?.try_into().unwrap()
+            )),
+            Some(Date::from_str("2002-03-07-10:00")?)
         );
         assert_eq!(
-            Date::from_str("2002-03-07-07:00")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("-PT10H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            Date::from_str("2002-03-06-10:00").unwrap()
+            Date::from_str("2002-03-07-07:00")?.adjust(Some(
+                DayTimeDuration::from_str("-PT10H")
+                    .unwrap()
+                    .try_into()
+                    .unwrap()
+            )),
+            Some(Date::from_str("2002-03-06-10:00")?)
         );
         assert_eq!(
-            Date::from_str("2002-03-07").unwrap().adjust(None).unwrap(),
-            Date::from_str("2002-03-07").unwrap()
+            Date::from_str("2002-03-07")?.adjust(None),
+            Some(Date::from_str("2002-03-07")?)
         );
         assert_eq!(
-            Date::from_str("2002-03-07-07:00")
-                .unwrap()
-                .adjust(None)
-                .unwrap(),
-            Date::from_str("2002-03-07").unwrap()
+            Date::from_str("2002-03-07-07:00")?.adjust(None),
+            Some(Date::from_str("2002-03-07")?)
         );
 
         assert_eq!(
-            Time::from_str("10:00:00")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("-PT10H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            Time::from_str("10:00:00-10:00").unwrap()
+            Time::from_str("10:00:00")?.adjust(Some(
+                DayTimeDuration::from_str("-PT10H")?.try_into().unwrap()
+            )),
+            Some(Time::from_str("10:00:00-10:00")?)
         );
         assert_eq!(
-            Time::from_str("10:00:00-07:00")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("-PT10H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            Time::from_str("07:00:00-10:00").unwrap()
+            Time::from_str("10:00:00-07:00")?.adjust(Some(
+                DayTimeDuration::from_str("-PT10H")?.try_into().unwrap()
+            )),
+            Some(Time::from_str("07:00:00-10:00")?)
         );
         assert_eq!(
-            Time::from_str("10:00:00").unwrap().adjust(None).unwrap(),
-            Time::from_str("10:00:00").unwrap()
+            Time::from_str("10:00:00")?.adjust(None),
+            Some(Time::from_str("10:00:00")?)
         );
         assert_eq!(
-            Time::from_str("10:00:00-07:00")
-                .unwrap()
-                .adjust(None)
-                .unwrap(),
-            Time::from_str("10:00:00").unwrap()
+            Time::from_str("10:00:00-07:00")?.adjust(None),
+            Some(Time::from_str("10:00:00")?)
         );
         assert_eq!(
-            Time::from_str("10:00:00-07:00")
-                .unwrap()
-                .adjust(Some(
-                    DayTimeDuration::from_str("PT10H")
-                        .unwrap()
-                        .try_into()
-                        .unwrap()
-                ))
-                .unwrap(),
-            Time::from_str("03:00:00+10:00").unwrap()
+            Time::from_str("10:00:00-07:00")?.adjust(Some(
+                DayTimeDuration::from_str("PT10H")?.try_into().unwrap()
+            )),
+            Some(Time::from_str("03:00:00+10:00")?)
         );
+        Ok(())
     }
 
     #[test]
-    fn now() {
+    fn now() -> Result<(), XsdParseError> {
         let now = DateTime::now().unwrap();
-        assert!(DateTime::from_str("2022-01-01T00:00:00Z").unwrap() < now);
-        assert!(now < DateTime::from_str("2100-01-01T00:00:00Z").unwrap());
+        assert!(DateTime::from_str("2022-01-01T00:00:00Z")? < now);
+        assert!(now < DateTime::from_str("2100-01-01T00:00:00Z")?);
+        Ok(())
     }
 }

--- a/lib/oxsdatatypes/src/double.rs
+++ b/lib/oxsdatatypes/src/double.rs
@@ -278,19 +278,28 @@ mod tests {
 
     #[test]
     fn from_str() -> Result<(), ParseFloatError> {
-        assert!(Double::from(f64::NAN).is_identical_with(&Double::from_str("NaN")?));
-        assert_eq!(Double::from(f64::INFINITY), Double::from_str("INF")?);
-        assert_eq!(Double::from(f64::INFINITY), Double::from_str("+INF")?);
-        assert_eq!(Double::from(f64::NEG_INFINITY), Double::from_str("-INF")?);
-        assert_eq!(Double::from(0.), Double::from_str("0.0E0")?);
-        assert_eq!(Double::from(-0.), Double::from_str("-0.0E0")?);
+        assert_eq!(Double::from_str("NaN")?.to_string(), "NaN");
+        assert_eq!(Double::from_str("INF")?.to_string(), "INF");
+        assert_eq!(Double::from_str("+INF")?.to_string(), "INF");
+        assert_eq!(Double::from_str("-INF")?.to_string(), "-INF");
+        assert_eq!(Double::from_str("0.0E0")?.to_string(), "0");
+        assert_eq!(Double::from_str("-0.0E0")?.to_string(), "-0");
+        assert_eq!(Double::from_str("0.1e1")?.to_string(), "1");
+        assert_eq!(Double::from_str("-0.1e1")?.to_string(), "-1");
+        assert_eq!(Double::from_str("1.e1")?.to_string(), "10");
+        assert_eq!(Double::from_str("-1.e1")?.to_string(), "-10");
+        assert_eq!(Double::from_str("1")?.to_string(), "1");
+        assert_eq!(Double::from_str("-1")?.to_string(), "-1");
+        assert_eq!(Double::from_str("1.")?.to_string(), "1");
+        assert_eq!(Double::from_str("-1.")?.to_string(), "-1");
+        assert_eq!(
+            Double::from_str(&f64::MIN.to_string()).unwrap(),
+            Double::from(f64::MIN)
+        );
+        assert_eq!(
+            Double::from_str(&f64::MAX.to_string()).unwrap(),
+            Double::from(f64::MAX)
+        );
         Ok(())
-    }
-
-    #[test]
-    fn to_string() {
-        assert_eq!("NaN", Double::from(f64::NAN).to_string());
-        assert_eq!("INF", Double::from(f64::INFINITY).to_string());
-        assert_eq!("-INF", Double::from(f64::NEG_INFINITY).to_string());
     }
 }

--- a/lib/oxsdatatypes/src/duration.rs
+++ b/lib/oxsdatatypes/src/duration.rs
@@ -596,75 +596,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_str() {
+    fn from_str() -> Result<(), XsdParseError> {
         let min = Duration::new(
             i64::MIN + 1,
             Decimal::MIN.checked_add(Decimal::step()).unwrap(),
         );
         let max = Duration::new(i64::MAX, Decimal::MAX);
 
-        assert_eq!(
-            YearMonthDuration::from_str("P1Y").unwrap().to_string(),
-            "P1Y"
-        );
-        assert_eq!(Duration::from_str("P1Y").unwrap().to_string(), "P1Y");
-        assert_eq!(
-            YearMonthDuration::from_str("P1M").unwrap().to_string(),
-            "P1M"
-        );
-        assert_eq!(Duration::from_str("P1M").unwrap().to_string(), "P1M");
-        assert_eq!(DayTimeDuration::from_str("P1D").unwrap().to_string(), "P1D");
-        assert_eq!(Duration::from_str("P1D").unwrap().to_string(), "P1D");
-        assert_eq!(
-            DayTimeDuration::from_str("PT1H").unwrap().to_string(),
-            "PT1H"
-        );
-        assert_eq!(Duration::from_str("PT1H").unwrap().to_string(), "PT1H");
-        assert_eq!(
-            DayTimeDuration::from_str("PT1M").unwrap().to_string(),
-            "PT1M"
-        );
-        assert_eq!(Duration::from_str("PT1M").unwrap().to_string(), "PT1M");
-        assert_eq!(
-            DayTimeDuration::from_str("PT1.1S").unwrap().to_string(),
-            "PT1.1S"
-        );
-        assert_eq!(Duration::from_str("PT1.1S").unwrap().to_string(), "PT1.1S");
-        assert_eq!(
-            YearMonthDuration::from_str("-P1Y").unwrap().to_string(),
-            "-P1Y"
-        );
-        assert_eq!(Duration::from_str("-P1Y").unwrap().to_string(), "-P1Y");
-        assert_eq!(
-            YearMonthDuration::from_str("-P1M").unwrap().to_string(),
-            "-P1M"
-        );
-        assert_eq!(Duration::from_str("-P1M").unwrap().to_string(), "-P1M");
-        assert_eq!(
-            DayTimeDuration::from_str("-P1D").unwrap().to_string(),
-            "-P1D"
-        );
-        assert_eq!(Duration::from_str("-P1D").unwrap().to_string(), "-P1D");
-        assert_eq!(
-            DayTimeDuration::from_str("-PT1H").unwrap().to_string(),
-            "-PT1H"
-        );
-        assert_eq!(Duration::from_str("-PT1H").unwrap().to_string(), "-PT1H");
-        assert_eq!(
-            DayTimeDuration::from_str("-PT1M").unwrap().to_string(),
-            "-PT1M"
-        );
-        assert_eq!(Duration::from_str("-PT1M").unwrap().to_string(), "-PT1M");
-        assert_eq!(
-            DayTimeDuration::from_str("-PT1.1S").unwrap().to_string(),
-            "-PT1.1S"
-        );
-        assert_eq!(
-            Duration::from_str("-PT1.1S").unwrap().to_string(),
-            "-PT1.1S"
-        );
-        assert_eq!(Duration::from_str(&max.to_string()).unwrap(), max);
-        assert_eq!(Duration::from_str(&min.to_string()).unwrap(), min);
+        assert_eq!(YearMonthDuration::from_str("P1Y")?.to_string(), "P1Y");
+        assert_eq!(Duration::from_str("P1Y")?.to_string(), "P1Y");
+        assert_eq!(YearMonthDuration::from_str("P1M")?.to_string(), "P1M");
+        assert_eq!(Duration::from_str("P1M")?.to_string(), "P1M");
+        assert_eq!(DayTimeDuration::from_str("P1D")?.to_string(), "P1D");
+        assert_eq!(Duration::from_str("P1D")?.to_string(), "P1D");
+        assert_eq!(DayTimeDuration::from_str("PT1H")?.to_string(), "PT1H");
+        assert_eq!(Duration::from_str("PT1H")?.to_string(), "PT1H");
+        assert_eq!(DayTimeDuration::from_str("PT1M")?.to_string(), "PT1M");
+        assert_eq!(Duration::from_str("PT1M")?.to_string(), "PT1M");
+        assert_eq!(DayTimeDuration::from_str("PT1.1S")?.to_string(), "PT1.1S");
+        assert_eq!(Duration::from_str("PT1.1S")?.to_string(), "PT1.1S");
+        assert_eq!(YearMonthDuration::from_str("-P1Y")?.to_string(), "-P1Y");
+        assert_eq!(Duration::from_str("-P1Y")?.to_string(), "-P1Y");
+        assert_eq!(YearMonthDuration::from_str("-P1M")?.to_string(), "-P1M");
+        assert_eq!(Duration::from_str("-P1M")?.to_string(), "-P1M");
+        assert_eq!(DayTimeDuration::from_str("-P1D")?.to_string(), "-P1D");
+        assert_eq!(Duration::from_str("-P1D")?.to_string(), "-P1D");
+        assert_eq!(DayTimeDuration::from_str("-PT1H")?.to_string(), "-PT1H");
+        assert_eq!(Duration::from_str("-PT1H")?.to_string(), "-PT1H");
+        assert_eq!(DayTimeDuration::from_str("-PT1M")?.to_string(), "-PT1M");
+        assert_eq!(Duration::from_str("-PT1M")?.to_string(), "-PT1M");
+        assert_eq!(DayTimeDuration::from_str("-PT1S")?.to_string(), "-PT1S");
+        assert_eq!(Duration::from_str("-PT1S")?.to_string(), "-PT1S");
+        assert_eq!(DayTimeDuration::from_str("-PT1.1S")?.to_string(), "-PT1.1S");
+        assert_eq!(Duration::from_str("-PT1.1S")?.to_string(), "-PT1.1S");
+        assert_eq!(Duration::from_str(&max.to_string())?, max);
+        assert_eq!(Duration::from_str(&min.to_string())?, min);
+        assert_eq!(Duration::from_str("PT0H")?.to_string(), "PT0S");
+        assert_eq!(Duration::from_str("-PT0H")?.to_string(), "PT0S");
+        assert_eq!(YearMonthDuration::from_str("P0Y")?.to_string(), "P0M");
+        assert_eq!(DayTimeDuration::from_str("PT0H")?.to_string(), "PT0S");
+        Ok(())
     }
 
     #[test]
@@ -678,149 +649,126 @@ mod tests {
     }
 
     #[test]
-    fn equals() {
+    fn equals() -> Result<(), XsdParseError> {
         assert_eq!(
-            YearMonthDuration::from_str("P1Y").unwrap(),
-            YearMonthDuration::from_str("P12M").unwrap()
-        );
-        assert_eq!(
-            YearMonthDuration::from_str("P1Y").unwrap(),
-            Duration::from_str("P12M").unwrap()
+            YearMonthDuration::from_str("P1Y")?,
+            YearMonthDuration::from_str("P12M")?
         );
         assert_eq!(
-            Duration::from_str("P1Y").unwrap(),
-            YearMonthDuration::from_str("P12M").unwrap()
+            YearMonthDuration::from_str("P1Y")?,
+            Duration::from_str("P12M")?
         );
         assert_eq!(
-            Duration::from_str("P1Y").unwrap(),
-            Duration::from_str("P12M").unwrap()
+            Duration::from_str("P1Y")?,
+            YearMonthDuration::from_str("P12M")?
+        );
+        assert_eq!(Duration::from_str("P1Y")?, Duration::from_str("P12M")?);
+        assert_eq!(
+            DayTimeDuration::from_str("PT24H")?,
+            DayTimeDuration::from_str("P1D")?
         );
         assert_eq!(
-            DayTimeDuration::from_str("PT24H").unwrap(),
-            DayTimeDuration::from_str("P1D").unwrap()
+            DayTimeDuration::from_str("PT24H")?,
+            Duration::from_str("P1D")?
         );
         assert_eq!(
-            DayTimeDuration::from_str("PT24H").unwrap(),
-            Duration::from_str("P1D").unwrap()
+            Duration::from_str("PT24H")?,
+            DayTimeDuration::from_str("P1D")?
+        );
+        assert_eq!(Duration::from_str("PT24H")?, Duration::from_str("P1D")?);
+        assert_ne!(Duration::from_str("P1Y")?, Duration::from_str("P365D")?);
+        assert_eq!(Duration::from_str("P0Y")?, Duration::from_str("P0D")?);
+        assert_ne!(Duration::from_str("P1Y")?, Duration::from_str("P365D")?);
+        assert_eq!(Duration::from_str("P2Y")?, Duration::from_str("P24M")?);
+        assert_eq!(Duration::from_str("P10D")?, Duration::from_str("PT240H")?);
+        assert_eq!(
+            Duration::from_str("P2Y0M0DT0H0M0S")?,
+            Duration::from_str("P24M")?
         );
         assert_eq!(
-            Duration::from_str("PT24H").unwrap(),
-            DayTimeDuration::from_str("P1D").unwrap()
+            Duration::from_str("P0Y0M10D")?,
+            Duration::from_str("PT240H")?
         );
-        assert_eq!(
-            Duration::from_str("PT24H").unwrap(),
-            Duration::from_str("P1D").unwrap()
-        );
-        assert_ne!(
-            Duration::from_str("P1Y").unwrap(),
-            Duration::from_str("P365D").unwrap()
-        );
-        assert_eq!(
-            Duration::from_str("P0Y").unwrap(),
-            Duration::from_str("P0D").unwrap()
-        );
-        assert_ne!(
-            Duration::from_str("P1Y").unwrap(),
-            Duration::from_str("P365D").unwrap()
-        );
-        assert_eq!(
-            Duration::from_str("P2Y").unwrap(),
-            Duration::from_str("P24M").unwrap()
-        );
-        assert_eq!(
-            Duration::from_str("P10D").unwrap(),
-            Duration::from_str("PT240H").unwrap()
-        );
-        assert_eq!(
-            Duration::from_str("P2Y0M0DT0H0M0S").unwrap(),
-            Duration::from_str("P24M").unwrap()
-        );
-        assert_eq!(
-            Duration::from_str("P0Y0M10D").unwrap(),
-            Duration::from_str("PT240H").unwrap()
-        );
-        assert_ne!(
-            Duration::from_str("P1M").unwrap(),
-            Duration::from_str("P30D").unwrap()
-        );
+        assert_ne!(Duration::from_str("P1M")?, Duration::from_str("P30D")?);
+        Ok(())
     }
 
     #[test]
-    fn years() {
-        assert_eq!(Duration::from_str("P20Y15M").unwrap().years(), 21);
-        assert_eq!(Duration::from_str("-P15M").unwrap().years(), -1);
-        assert_eq!(Duration::from_str("-P2DT15H").unwrap().years(), 0);
+    fn years() -> Result<(), XsdParseError> {
+        assert_eq!(Duration::from_str("P20Y15M")?.years(), 21);
+        assert_eq!(Duration::from_str("-P15M")?.years(), -1);
+        assert_eq!(Duration::from_str("-P2DT15H")?.years(), 0);
+        Ok(())
     }
 
     #[test]
-    fn months() {
-        assert_eq!(Duration::from_str("P20Y15M").unwrap().months(), 3);
-        assert_eq!(Duration::from_str("-P20Y18M").unwrap().months(), -6);
-        assert_eq!(Duration::from_str("-P2DT15H0M0S").unwrap().months(), 0);
+    fn months() -> Result<(), XsdParseError> {
+        assert_eq!(Duration::from_str("P20Y15M")?.months(), 3);
+        assert_eq!(Duration::from_str("-P20Y18M")?.months(), -6);
+        assert_eq!(Duration::from_str("-P2DT15H0M0S")?.months(), 0);
+        Ok(())
     }
 
     #[test]
-    fn days() {
-        assert_eq!(Duration::from_str("P3DT10H").unwrap().days(), 3);
-        assert_eq!(Duration::from_str("P3DT55H").unwrap().days(), 5);
-        assert_eq!(Duration::from_str("P3Y5M").unwrap().days(), 0);
+    fn days() -> Result<(), XsdParseError> {
+        assert_eq!(Duration::from_str("P3DT10H")?.days(), 3);
+        assert_eq!(Duration::from_str("P3DT55H")?.days(), 5);
+        assert_eq!(Duration::from_str("P3Y5M")?.days(), 0);
+        Ok(())
     }
 
     #[test]
-    fn hours() {
-        assert_eq!(Duration::from_str("P3DT10H").unwrap().hours(), 10);
-        assert_eq!(Duration::from_str("P3DT12H32M12S").unwrap().hours(), 12);
-        assert_eq!(Duration::from_str("PT123H").unwrap().hours(), 3);
-        assert_eq!(Duration::from_str("-P3DT10H").unwrap().hours(), -10);
+    fn hours() -> Result<(), XsdParseError> {
+        assert_eq!(Duration::from_str("P3DT10H")?.hours(), 10);
+        assert_eq!(Duration::from_str("P3DT12H32M12S")?.hours(), 12);
+        assert_eq!(Duration::from_str("PT123H")?.hours(), 3);
+        assert_eq!(Duration::from_str("-P3DT10H")?.hours(), -10);
+        Ok(())
     }
 
     #[test]
-    fn minutes() {
-        assert_eq!(Duration::from_str("P3DT10H").unwrap().minutes(), 0);
-        assert_eq!(Duration::from_str("-P5DT12H30M").unwrap().minutes(), -30);
+    fn minutes() -> Result<(), XsdParseError> {
+        assert_eq!(Duration::from_str("P3DT10H")?.minutes(), 0);
+        assert_eq!(Duration::from_str("-P5DT12H30M")?.minutes(), -30);
+        Ok(())
     }
 
     #[test]
-    fn seconds() {
+    fn seconds() -> Result<(), XsdParseError> {
         assert_eq!(
-            Duration::from_str("P3DT10H12.5S").unwrap().seconds(),
-            Decimal::from_str("12.5").unwrap()
+            Duration::from_str("P3DT10H12.5S")?.seconds(),
+            Decimal::from_str("12.5")?
         );
         assert_eq!(
-            Duration::from_str("-PT256S").unwrap().seconds(),
-            Decimal::from_str("-16.0").unwrap()
+            Duration::from_str("-PT256S")?.seconds(),
+            Decimal::from_str("-16.0")?
         );
+        Ok(())
     }
 
     #[test]
-    fn add() {
+    fn add() -> Result<(), XsdParseError> {
         assert_eq!(
-            Duration::from_str("P2Y11M")
-                .unwrap()
-                .checked_add(Duration::from_str("P3Y3M").unwrap()),
-            Some(Duration::from_str("P6Y2M").unwrap())
+            Duration::from_str("P2Y11M")?.checked_add(Duration::from_str("P3Y3M")?),
+            Some(Duration::from_str("P6Y2M")?)
         );
         assert_eq!(
-            Duration::from_str("P2DT12H5M")
-                .unwrap()
-                .checked_add(Duration::from_str("P5DT12H").unwrap()),
-            Some(Duration::from_str("P8DT5M").unwrap())
+            Duration::from_str("P2DT12H5M")?.checked_add(Duration::from_str("P5DT12H")?),
+            Some(Duration::from_str("P8DT5M")?)
         );
+        Ok(())
     }
 
     #[test]
-    fn sub() {
+    fn sub() -> Result<(), XsdParseError> {
         assert_eq!(
-            Duration::from_str("P2Y11M")
-                .unwrap()
-                .checked_sub(Duration::from_str("P3Y3M").unwrap()),
-            Some(Duration::from_str("-P4M").unwrap())
+            Duration::from_str("P2Y11M")?.checked_sub(Duration::from_str("P3Y3M")?),
+            Some(Duration::from_str("-P4M")?)
         );
         assert_eq!(
-            Duration::from_str("P2DT12H")
-                .unwrap()
-                .checked_sub(Duration::from_str("P1DT10H30M").unwrap()),
-            Some(Duration::from_str("P1DT1H30M").unwrap())
+            Duration::from_str("P2DT12H")?.checked_sub(Duration::from_str("P1DT10H30M")?),
+            Some(Duration::from_str("P1DT1H30M")?)
         );
+        Ok(())
     }
 }

--- a/lib/oxsdatatypes/src/float.rs
+++ b/lib/oxsdatatypes/src/float.rs
@@ -267,19 +267,28 @@ mod tests {
 
     #[test]
     fn from_str() -> Result<(), ParseFloatError> {
-        assert!(Float::from(f32::NAN).is_identical_with(&Float::from_str("NaN")?));
-        assert_eq!(Float::from(f32::INFINITY), Float::from_str("INF")?);
-        assert_eq!(Float::from(f32::INFINITY), Float::from_str("+INF")?);
-        assert_eq!(Float::from(f32::NEG_INFINITY), Float::from_str("-INF")?);
-        assert_eq!(Float::from(0.), Float::from_str("0.0E0")?);
-        assert_eq!(Float::from(-0.), Float::from_str("-0.0E0")?);
+        assert_eq!(Float::from_str("NaN")?.to_string(), "NaN");
+        assert_eq!(Float::from_str("INF")?.to_string(), "INF");
+        assert_eq!(Float::from_str("+INF")?.to_string(), "INF");
+        assert_eq!(Float::from_str("-INF")?.to_string(), "-INF");
+        assert_eq!(Float::from_str("0.0E0")?.to_string(), "0");
+        assert_eq!(Float::from_str("-0.0E0")?.to_string(), "-0");
+        assert_eq!(Float::from_str("0.1e1")?.to_string(), "1");
+        assert_eq!(Float::from_str("-0.1e1")?.to_string(), "-1");
+        assert_eq!(Float::from_str("1.e1")?.to_string(), "10");
+        assert_eq!(Float::from_str("-1.e1")?.to_string(), "-10");
+        assert_eq!(Float::from_str("1")?.to_string(), "1");
+        assert_eq!(Float::from_str("-1")?.to_string(), "-1");
+        assert_eq!(Float::from_str("1.")?.to_string(), "1");
+        assert_eq!(Float::from_str("-1.")?.to_string(), "-1");
+        assert_eq!(
+            Float::from_str(&f32::MIN.to_string())?,
+            Float::from(f32::MIN)
+        );
+        assert_eq!(
+            Float::from_str(&f32::MAX.to_string())?,
+            Float::from(f32::MAX)
+        );
         Ok(())
-    }
-
-    #[test]
-    fn to_string() {
-        assert_eq!("NaN", Float::from(f32::NAN).to_string());
-        assert_eq!("INF", Float::from(f32::INFINITY).to_string());
-        assert_eq!("-INF", Float::from(f32::NEG_INFINITY).to_string());
     }
 }

--- a/lib/oxsdatatypes/src/integer.rs
+++ b/lib/oxsdatatypes/src/integer.rs
@@ -229,18 +229,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_float() {
+    fn from_str() -> Result<(), ParseIntError> {
+        assert_eq!(Integer::from_str("0")?.to_string(), "0");
+        assert_eq!(Integer::from_str("-0")?.to_string(), "0");
+        assert_eq!(Integer::from_str("123")?.to_string(), "123");
+        assert_eq!(Integer::from_str("-123")?.to_string(), "-123");
+        assert!(Integer::from_str("123456789123456789123456789123456789123456789").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn from_float() -> Result<(), ParseIntError> {
         assert_eq!(
-            Integer::try_from(Float::from(0.)).unwrap(),
-            Integer::from_str("0").unwrap()
+            Integer::try_from(Float::from(0.)).ok(),
+            Some(Integer::from_str("0")?)
         );
         assert_eq!(
-            Integer::try_from(Float::from(-0.)).unwrap(),
-            Integer::from_str("0").unwrap()
+            Integer::try_from(Float::from(-0.)).ok(),
+            Some(Integer::from_str("0")?)
         );
         assert_eq!(
-            Integer::try_from(Float::from(-123.1)).unwrap(),
-            Integer::from_str("-123").unwrap()
+            Integer::try_from(Float::from(-123.1)).ok(),
+            Some(Integer::from_str("-123")?)
         );
         assert!(Integer::try_from(Float::from(f32::NAN)).is_err());
         assert!(Integer::try_from(Float::from(f32::INFINITY)).is_err());
@@ -250,26 +260,27 @@ mod tests {
         assert!(
             Integer::try_from(Float::from(1672507302466.))
                 .unwrap()
-                .checked_sub(Integer::from_str("1672507302466").unwrap())
+                .checked_sub(Integer::from_str("1672507302466")?)
                 .unwrap()
                 .abs()
                 < Integer::from(1_000_000)
         );
+        Ok(())
     }
 
     #[test]
-    fn from_double() {
+    fn from_double() -> Result<(), ParseIntError> {
         assert_eq!(
-            Integer::try_from(Double::from(0.0)).unwrap(),
-            Integer::from_str("0").unwrap()
+            Integer::try_from(Double::from(0.0)).ok(),
+            Some(Integer::from_str("0")?)
         );
         assert_eq!(
-            Integer::try_from(Double::from(-0.0)).unwrap(),
-            Integer::from_str("0").unwrap()
+            Integer::try_from(Double::from(-0.0)).ok(),
+            Some(Integer::from_str("0")?)
         );
         assert_eq!(
-            Integer::try_from(Double::from(-123.1)).unwrap(),
-            Integer::from_str("-123").unwrap()
+            Integer::try_from(Double::from(-123.1)).ok(),
+            Some(Integer::from_str("-123")?)
         );
         assert!(
             Integer::try_from(Double::from(1672507302466.))
@@ -284,19 +295,21 @@ mod tests {
         assert!(Integer::try_from(Double::from(f64::NEG_INFINITY)).is_err());
         assert!(Integer::try_from(Double::from(f64::MIN)).is_err());
         assert!(Integer::try_from(Double::from(f64::MAX)).is_err());
+        Ok(())
     }
 
     #[test]
-    fn from_decimal() {
+    fn from_decimal() -> Result<(), ParseIntError> {
         assert_eq!(
-            Integer::try_from(Decimal::from(0)).unwrap(),
-            Integer::from_str("0").unwrap()
+            Integer::try_from(Decimal::from(0)).ok(),
+            Some(Integer::from_str("0")?)
         );
         assert_eq!(
-            Integer::try_from(Decimal::from_str("-123.1").unwrap()).unwrap(),
-            Integer::from_str("-123").unwrap()
+            Integer::try_from(Decimal::from_str("-123.1").unwrap()).ok(),
+            Some(Integer::from_str("-123")?)
         );
         assert!(Integer::try_from(Decimal::MIN).is_err());
         assert!(Integer::try_from(Decimal::MAX).is_err());
+        Ok(())
     }
 }

--- a/lib/oxsdatatypes/src/lib.rs
+++ b/lib/oxsdatatypes/src/lib.rs
@@ -17,7 +17,7 @@ pub use self::boolean::Boolean;
 pub use self::date_time::{
     Date, DateTime, DateTimeError, GDay, GMonth, GMonthDay, GYear, GYearMonth, Time, TimezoneOffset,
 };
-pub use self::decimal::{Decimal, DecimalOverflowError, DecimalParseError};
+pub use self::decimal::{Decimal, DecimalOverflowError, ParseDecimalError};
 pub use self::double::Double;
 pub use self::duration::{DayTimeDuration, Duration, YearMonthDuration};
 pub use self::float::Float;

--- a/lib/oxsdatatypes/src/parser.rs
+++ b/lib/oxsdatatypes/src/parser.rs
@@ -1,5 +1,5 @@
 use super::date_time::{DateTimeError, GDay, GMonth, GMonthDay, GYear, GYearMonth, TimezoneOffset};
-use super::decimal::DecimalParseError;
+use super::decimal::ParseDecimalError;
 use super::duration::{DayTimeDuration, YearMonthDuration};
 use super::*;
 use nom::branch::alt;
@@ -29,7 +29,7 @@ enum XsdParseErrorKind {
     TooMuchData { count: usize },
     Overflow,
     ParseInt(ParseIntError),
-    ParseDecimal(DecimalParseError),
+    ParseDecimal(ParseDecimalError),
     OutOfIntegerRange { value: u8, min: u8, max: u8 },
     DateTime(DateTimeError),
 }
@@ -108,8 +108,8 @@ impl From<ParseIntError> for XsdParseError {
     }
 }
 
-impl From<DecimalParseError> for XsdParseError {
-    fn from(error: DecimalParseError) -> Self {
+impl From<ParseDecimalError> for XsdParseError {
+    fn from(error: ParseDecimalError) -> Self {
         Self {
             kind: XsdParseErrorKind::ParseDecimal(error),
         }


### PR DESCRIPTION
Improves and simplifies tests