### PR TITLE
Installs cargo deny directly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - run: rustup update
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-deny || true
+      - run: cargo deny check
 
   test_linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Swatinem/rust-cache seems better than EmbarkStudios/cargo-deny-action to cache binaries