### PR TITLE
JS: Optimizes release builds for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ members = [
 [profile.release]
 lto = true
 codegen-units = 1
+
+[profile.release.package.oxigraph_js]
+opt-level = "z"


### PR DESCRIPTION
Makes the WASM file go from 2.6MB to 2.3MB