### PR TITLE
Adds a simple explanation with profiling for SPARQL queries evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,8 @@ dependencies = [
  "digest",
  "getrandom",
  "hex",
+ "js-sys",
+ "json-event-parser",
  "lazy_static",
  "libc",
  "md-5",

--- a/bench/explanation_to_flamegraph.py
+++ b/bench/explanation_to_flamegraph.py
@@ -1,0 +1,56 @@
+"""
+Converts a SPARQL query JSON explanation file to a flamegraph.
+Usage: python explanation_to_flamegraph.py explanation.json flamegraph.svg
+"""
+import json
+import subprocess
+from argparse import ArgumentParser
+from pathlib import Path
+from shutil import which
+from tempfile import NamedTemporaryFile
+
+if which('flamegraph.pl') is None:
+    raise Exception(
+        'This script requires the flamegraph.pl script from https://github.com/brendangregg/FlameGraph to be installed and be in $PATH.')
+
+parser = ArgumentParser(
+    prog='OxigraphFlamegraph',
+    description='Builds a flamegraph from the Oxigraph query explanation JSON format',
+    epilog='Text at the bottom of help')
+parser.add_argument('json_explanation', type=Path)
+parser.add_argument('flamegraph_svg', type=Path)
+args = parser.parse_args()
+
+
+def trace_line(label: str, value: float):
+    return f"{label} {int(value * 1_000_000)}"
+
+
+with args.json_explanation.open('rt') as fp:
+    explanation = json.load(fp)
+trace = []
+if "parsing duration in seconds" in explanation:
+    trace.append(trace_line("parsing", explanation['parsing duration in seconds']))
+if "planning duration in seconds" in explanation:
+    trace.append(trace_line("planning", explanation['planning duration in seconds']))
+already_used_names = {}
+
+
+def add_to_trace(node, path):
+    path = f"{path};{node['name'].replace(' ', '`')}"
+    if path in already_used_names:
+        already_used_names[path] += 1
+        path = f"{path}`{already_used_names[path]}"
+    else:
+        already_used_names[path] = 0
+    samples = node['duration in seconds'] - sum(child['duration in seconds'] for child in node.get("children", ()))
+    trace.append(trace_line(path, samples))
+    for i, child in enumerate(node.get("children", ())):
+        add_to_trace(child, path)
+
+
+add_to_trace(explanation["plan"], 'eval')
+with NamedTemporaryFile('w+t') as fp:
+    fp.write('\n'.join(trace))
+    fp.flush()
+    args.flamegraph_svg.write_bytes(subprocess.run(['flamegraph.pl', fp.name], stdout=subprocess.PIPE).stdout)

--- a/bench/explanation_to_trace.py
+++ b/bench/explanation_to_trace.py
@@ -1,0 +1,52 @@
+"""
+Converts a SPARQL query JSON explanation file to a tracing event file compatible with Chrome.
+Usage: python explanation_to_trace.py explanation.json trace.json
+"""
+import json
+from argparse import ArgumentParser
+from pathlib import Path
+
+parser = ArgumentParser(
+    prog='OxigraphTracing',
+    description='Builds a Trace Event Format file from the Oxigraph query explanation JSON format')
+parser.add_argument('json_explanation', type=Path)
+parser.add_argument('json_trace_event', type=Path)
+args = parser.parse_args()
+
+with args.json_explanation.open('rt') as fp:
+    explanation = json.load(fp)
+trace = []
+
+
+def trace_element(name: str, cat: str, start_s: float, duration_s: float):
+    return {
+        "name": name,
+        "cat": cat,
+        "ph": "X",
+        "ts": int(start_s * 1_000_000),
+        "dur": int(duration_s * 1_000_000),
+        "pid": 1
+    }
+
+
+def add_to_trace(node, path, start_time: float):
+    path = f"{path};{node['name'].replace(' ', '`')}"
+    trace.append(trace_element(node["name"], node["name"].split("(")[0], start_time, node["duration in seconds"]))
+    for child in node.get("children", ()):
+        add_to_trace(child, path, start_time)
+        start_time += child["duration in seconds"]
+
+
+current_time = 0
+if "parsing duration in seconds" in explanation:
+    d = explanation["parsing duration in seconds"]
+    trace.append(trace_element(f"parsing", "parsing", current_time, d))
+    current_time += d
+if "planning duration in seconds" in explanation:
+    d = explanation["planning duration in seconds"]
+    trace.append(trace_element(f"planning", "planning", current_time, d))
+    current_time += d
+add_to_trace(explanation["plan"], 'eval', current_time)
+
+with args.json_trace_event.open("wt") as fp:
+    json.dump(trace, fp)

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,6 +36,7 @@ rio_xml = "0.8"
 hex = "0.4"
 siphasher = "0.3"
 lazy_static = "1"
+json-event-parser = "0.1"
 oxrdf = { version = "0.1.5", path="oxrdf", features = ["rdf-star", "oxsdatatypes"] }
 oxsdatatypes = { version = "0.1.1", path="oxsdatatypes" }
 spargebra = { version = "0.2.7", path="spargebra", features = ["rdf-star", "sep-0002", "sep-0006"] }
@@ -48,6 +49,7 @@ oxhttp = { version = "0.1", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = "0.4"

--- a/lib/src/sparql/mod.rs
+++ b/lib/src/sparql/mod.rs
@@ -56,7 +56,7 @@ pub(crate) fn evaluate_query(
                 options.service_handler(),
                 Rc::new(options.custom_functions),
             )
-            .evaluate_select_plan(&plan, Rc::new(variables)))
+            .evaluate_select_plan(Rc::new(plan), Rc::new(variables)))
         }
         spargebra::Query::Ask {
             pattern, base_iri, ..
@@ -74,7 +74,7 @@ pub(crate) fn evaluate_query(
                 options.service_handler(),
                 Rc::new(options.custom_functions),
             )
-            .evaluate_ask_plan(&plan)
+            .evaluate_ask_plan(Rc::new(plan))
         }
         spargebra::Query::Construct {
             template,
@@ -102,7 +102,7 @@ pub(crate) fn evaluate_query(
                 options.service_handler(),
                 Rc::new(options.custom_functions),
             )
-            .evaluate_construct_plan(&plan, construct))
+            .evaluate_construct_plan(Rc::new(plan), construct))
         }
         spargebra::Query::Describe {
             pattern, base_iri, ..
@@ -120,7 +120,7 @@ pub(crate) fn evaluate_query(
                 options.service_handler(),
                 Rc::new(options.custom_functions),
             )
-            .evaluate_describe_plan(&plan))
+            .evaluate_describe_plan(Rc::new(plan)))
         }
     }
 }

--- a/lib/src/sparql/plan.rs
+++ b/lib/src/sparql/plan.rs
@@ -9,7 +9,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum PlanNode {
     StaticBindings {
         encoded_tuples: Vec<EncodedTuple>,
@@ -19,7 +19,7 @@ pub enum PlanNode {
     Service {
         service_name: PatternValue,
         variables: Rc<Vec<Variable>>,
-        child: Box<Self>,
+        child: Rc<Self>,
         graph_pattern: Rc<GraphPattern>,
         silent: bool,
     },
@@ -37,69 +37,69 @@ pub enum PlanNode {
     },
     /// Streams left and materializes right join
     HashJoin {
-        left: Box<Self>,
-        right: Box<Self>,
+        left: Rc<Self>,
+        right: Rc<Self>,
     },
     /// Right nested in left loop
     ForLoopJoin {
-        left: Box<Self>,
-        right: Box<Self>,
+        left: Rc<Self>,
+        right: Rc<Self>,
     },
     /// Streams left and materializes right anti join
     AntiJoin {
-        left: Box<Self>,
-        right: Box<Self>,
+        left: Rc<Self>,
+        right: Rc<Self>,
     },
     Filter {
-        child: Box<Self>,
+        child: Rc<Self>,
         expression: Box<PlanExpression>,
     },
     Union {
-        children: Vec<Self>,
+        children: Vec<Rc<Self>>,
     },
     /// hash left join
     HashLeftJoin {
-        left: Box<Self>,
-        right: Box<Self>,
+        left: Rc<Self>,
+        right: Rc<Self>,
         expression: Box<PlanExpression>,
     },
     /// right nested in left loop
     ForLoopLeftJoin {
-        left: Box<Self>,
-        right: Box<Self>,
+        left: Rc<Self>,
+        right: Rc<Self>,
         possible_problem_vars: Rc<Vec<usize>>, //Variables that should not be part of the entry of the left join
     },
     Extend {
-        child: Box<Self>,
+        child: Rc<Self>,
         variable: PlanVariable,
         expression: Box<PlanExpression>,
     },
     Sort {
-        child: Box<Self>,
+        child: Rc<Self>,
         by: Vec<Comparator>,
     },
     HashDeduplicate {
-        child: Box<Self>,
+        child: Rc<Self>,
     },
     /// Removes duplicated consecutive elements
     Reduced {
-        child: Box<Self>,
+        child: Rc<Self>,
     },
     Skip {
-        child: Box<Self>,
+        child: Rc<Self>,
         count: usize,
     },
     Limit {
-        child: Box<Self>,
+        child: Rc<Self>,
         count: usize,
     },
     Project {
-        child: Box<Self>,
+        child: Rc<Self>,
         mapping: Rc<Vec<(PlanVariable, PlanVariable)>>, // pairs of (variable key in child, variable key in output)
     },
     Aggregate {
         // By definition the group by key are the range 0..key_mapping.len()
-        child: Box<Self>,
+        child: Rc<Self>,
         key_variables: Rc<Vec<PlanVariable>>,
         aggregates: Rc<Vec<(PlanAggregation, PlanVariable)>>,
     },

--- a/lib/src/sparql/plan.rs
+++ b/lib/src/sparql/plan.rs
@@ -4,10 +4,12 @@ use crate::storage::numeric_encoder::EncodedTerm;
 use regex::Regex;
 use spargebra::algebra::GraphPattern;
 use spargebra::term::GroundTerm;
+use std::cell::Cell;
 use std::cmp::max;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
+use std::time::Duration;
 
 #[derive(Debug)]
 pub enum PlanNode {
@@ -751,4 +753,11 @@ impl IntoIterator for EncodedTuple {
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
     }
+}
+
+pub struct PlanNodeWithStats {
+    pub node: Rc<PlanNode>,
+    pub children: Vec<Rc<PlanNodeWithStats>>,
+    pub exec_count: Cell<usize>,
+    pub exec_duration: Cell<Duration>,
 }

--- a/lib/src/sparql/update.rs
+++ b/lib/src/sparql/update.rs
@@ -132,8 +132,9 @@ impl<'a, 'b: 'a> SimpleUpdateEvaluator<'a, 'b> {
             Rc::new(self.options.query_options.custom_functions.clone()),
         );
         let mut bnodes = HashMap::new();
-        let tuples = evaluator.plan_evaluator(&plan)(EncodedTuple::with_capacity(variables.len()))
-            .collect::<Result<Vec<_>, _>>()?; //TODO: would be much better to stream
+        let tuples =
+            evaluator.plan_evaluator(Rc::new(plan))(EncodedTuple::with_capacity(variables.len()))
+                .collect::<Result<Vec<_>, _>>()?; //TODO: would be much better to stream
         for tuple in tuples {
             for quad in delete {
                 if let Some(quad) =

--- a/lib/src/sparql/update.rs
+++ b/lib/src/sparql/update.rs
@@ -130,11 +130,12 @@ impl<'a, 'b: 'a> SimpleUpdateEvaluator<'a, 'b> {
             self.base_iri.clone(),
             self.options.query_options.service_handler(),
             Rc::new(self.options.query_options.custom_functions.clone()),
+            false,
         );
         let mut bnodes = HashMap::new();
+        let (eval, _) = evaluator.plan_evaluator(Rc::new(plan));
         let tuples =
-            evaluator.plan_evaluator(Rc::new(plan))(EncodedTuple::with_capacity(variables.len()))
-                .collect::<Result<Vec<_>, _>>()?; //TODO: would be much better to stream
+            eval(EncodedTuple::with_capacity(variables.len())).collect::<Result<Vec<_>, _>>()?; //TODO: would be much better to stream
         for tuple in tuples {
             for quad in delete {
                 if let Some(quad) =

--- a/lib/tests/store.rs
+++ b/lib/tests/store.rs
@@ -12,11 +12,11 @@ use std::fs::{create_dir, remove_dir_all, File};
 use std::io::Cursor;
 #[cfg(not(target_family = "wasm"))]
 use std::io::Write;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(target_os = "linux")]
 use std::iter::once;
 #[cfg(not(target_family = "wasm"))]
 use std::path::{Path, PathBuf};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(target_os = "linux")]
 use std::process::Command;
 const DATA: &str = r#"
 @prefix schema: <http://schema.org/> .
@@ -501,7 +501,7 @@ fn test_open_read_only_bad_dir() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(target_os = "linux")]
 fn reset_dir(dir: &str) -> Result<(), Box<dyn Error>> {
     assert!(Command::new("git")
         .args(["clean", "-fX", dir])


### PR DESCRIPTION
Only exposed in the CLI `query` command for now.

Example to get a flamegraph:
```bash
oxigraph_server query --location MY_DATA --query-file MY_QUERY --results-format csv --explain-file EXPLANATION.json --stats
python3 bench/explanation_to_flamegraph.py EXPLANATION.json FLAMEGRAPH.svg
```
![example flamegraph](https://user-images.githubusercontent.com/458123/231473642-1261e11b-d6f3-4d77-95d5-7818b5460510.svg)

