### PR TITLE
Fix missing GSPO index compaction

### DIFF
--- a/lib/src/storage/mod.rs
+++ b/lib/src/storage/mod.rs
@@ -288,7 +288,7 @@ impl Storage {
     #[cfg(not(target_family = "wasm"))]
     pub fn flush(&self) -> Result<(), StorageError> {
         self.db.flush(&self.default_cf)?;
-        self.db.flush(&self.gpos_cf)?;
+        self.db.flush(&self.gspo_cf)?;
         self.db.flush(&self.gpos_cf)?;
         self.db.flush(&self.gosp_cf)?;
         self.db.flush(&self.spog_cf)?;
@@ -303,7 +303,7 @@ impl Storage {
     #[cfg(not(target_family = "wasm"))]
     pub fn compact(&self) -> Result<(), StorageError> {
         self.db.compact(&self.default_cf)?;
-        self.db.compact(&self.gpos_cf)?;
+        self.db.compact(&self.gspo_cf)?;
         self.db.compact(&self.gpos_cf)?;
         self.db.compact(&self.gosp_cf)?;
         self.db.compact(&self.spog_cf)?;


### PR DESCRIPTION
This fixes a missing compaction of the GSPO index.

With dataset sizes and number of graphs growing, we've recently been seeing degrading query performance for some of our query workloads (made apparent via the new explain feature!). As we have a lot of point-like lookups (via GraphPatterns with all positions known) in our query plans, and this is the index chosen for those, we are probably disproportionally impacted by this.

With this fix a lot of our query times have decreased by ~50%.