### PR TITLE
Python: drops compatibility with Musl 1.1

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -149,7 +149,7 @@ jobs:
           platforms: linux/${{ matrix.architecture }}
         if: github.event_name == 'release' && matrix.architecture != 'x86_64'
       - run: sed 's/%arch%/${{ matrix.architecture }}/g' .github/workflows/musllinux_build.sh | sed 's/%for_each_version%/${{ github.event_name == 'release' || '' }}/g' > .github/workflows/musllinux_build_script.sh
-      - run: docker run -v "$(pwd)":/workdir --platform linux/${{ matrix.architecture }} quay.io/pypa/musllinux_1_1_${{ matrix.architecture }} /bin/bash /workdir/.github/workflows/musllinux_build_script.sh
+      - run: docker run -v "$(pwd)":/workdir --platform linux/${{ matrix.architecture }} quay.io/pypa/musllinux_1_2_${{ matrix.architecture }} /bin/bash /workdir/.github/workflows/musllinux_build_script.sh
         if: github.event_name == 'release' || matrix.architecture == 'x86_64'
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/musllinux_build.sh
+++ b/.github/workflows/musllinux_build.sh
@@ -11,9 +11,9 @@ source venv/bin/activate
 pip install -r requirements.dev.txt
 maturin develop --release -m Cargo.toml
 python generate_stubs.py pyoxigraph pyoxigraph.pyi --black
-maturin build --release -m Cargo.toml --features abi3 --compatibility musllinux_1_1
+maturin build --release -m Cargo.toml --features abi3 --compatibility musllinux_1_2
 if [ %for_each_version% ]; then
   for VERSION in 7 8 9 10 11; do
-    maturin build --release -m Cargo.toml --interpreter "python3.$VERSION" --compatibility musllinux_1_1
+    maturin build --release -m Cargo.toml --interpreter "python3.$VERSION" --compatibility musllinux_1_2
   done
 fi


### PR DESCRIPTION
Rust is moving to 1.2+: https://blog.rust-lang.org/2023/05/09/Updating-musl-targets.html