### PR TITLE
Python: fixes parsing from text I/O with not-ASCII char

### DIFF
--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -5,7 +5,9 @@ from tempfile import NamedTemporaryFile, TemporaryFile
 from pyoxigraph import Literal, NamedNode, Quad, Triple, parse, serialize
 
 EXAMPLE_TRIPLE = Triple(
-    NamedNode("http://example.com/foo"), NamedNode("http://example.com/p"), Literal("1")
+    NamedNode("http://example.com/foo"),
+    NamedNode("http://example.com/p"),
+    Literal("éù"),
 )
 EXAMPLE_QUAD = Quad(
     NamedNode("http://example.com/foo"),
@@ -18,7 +20,7 @@ EXAMPLE_QUAD = Quad(
 class TestParse(unittest.TestCase):
     def test_parse_file(self) -> None:
         with NamedTemporaryFile() as fp:
-            fp.write(b'<foo> <p> "1" .')
+            fp.write('<foo> <p> "éù" .'.encode())
             fp.flush()
             self.assertEqual(
                 list(parse(fp.name, "text/turtle", base_iri="http://example.com/")),
@@ -33,7 +35,7 @@ class TestParse(unittest.TestCase):
         self.assertEqual(
             list(
                 parse(
-                    StringIO('<foo> <p> "1" .'),
+                    StringIO('<foo> <p> "éù" .'),
                     "text/turtle",
                     base_iri="http://example.com/",
                 )
@@ -41,11 +43,23 @@ class TestParse(unittest.TestCase):
             [EXAMPLE_TRIPLE],
         )
 
+    def test_parse_long_str_io(self) -> None:
+        self.assertEqual(
+            list(
+                parse(
+                    StringIO('<foo> <p> "éù" .\n' * 1024),
+                    "text/turtle",
+                    base_iri="http://example.com/",
+                )
+            ),
+            [EXAMPLE_TRIPLE] * 1024,
+        )
+
     def test_parse_bytes_io(self) -> None:
         self.assertEqual(
             list(
                 parse(
-                    BytesIO(b'<foo> <p> "1" .'),
+                    BytesIO('<foo> <p> "éù" .'.encode()),
                     "text/turtle",
                     base_iri="http://example.com/",
                 )
@@ -75,15 +89,16 @@ class TestSerialize(unittest.TestCase):
         output = BytesIO()
         serialize([EXAMPLE_TRIPLE], output, "text/turtle")
         self.assertEqual(
-            output.getvalue(),
-            b'<http://example.com/foo> <http://example.com/p> "1" .\n',
+            output.getvalue().decode(),
+            '<http://example.com/foo> <http://example.com/p> "éù" .\n',
         )
 
     def test_serialize_to_file(self) -> None:
         with NamedTemporaryFile() as fp:
             serialize([EXAMPLE_TRIPLE], fp.name, "text/turtle")
             self.assertEqual(
-                fp.read(), b'<http://example.com/foo> <http://example.com/p> "1" .\n'
+                fp.read().decode(),
+                '<http://example.com/foo> <http://example.com/p> "éù" .\n',
             )
 
     def test_serialize_io_error(self) -> None:


### PR DESCRIPTION
Python text IO is counting by number of character
and not by number of bytes.
However, we were asking to read a number of bytes
and not a number of character,
leading to strange I/O exceptions being raised.