### PR TITLE
Makes xsd:dateTime year parsing stricter

### DIFF
--- a/lib/oxsdatatypes/src/date_time.rs
+++ b/lib/oxsdatatypes/src/date_time.rs
@@ -2024,6 +2024,10 @@ mod tests {
         assert_eq!(GDay::from_str("---01")?.to_string(), "---01");
         assert_eq!(GMonth::from_str("--01+01:00")?.to_string(), "--01+01:00");
         assert_eq!(GMonth::from_str("--01")?.to_string(), "--01");
+
+        assert!(GYear::from_str("02020").is_err());
+        assert!(GYear::from_str("+2020").is_err());
+        assert!(GYear::from_str("33").is_err());
         Ok(())
     }
 

--- a/lib/oxsdatatypes/src/parser.rs
+++ b/lib/oxsdatatypes/src/parser.rs
@@ -432,12 +432,15 @@ fn year_frag(input: &str) -> Result<(i64, &str), XsdParseError> {
         (1, input)
     };
     let (number_str, input) = integer_prefix(input);
-    let number = i64::from_str(number_str)?;
-    if number < 1000 && number_str.len() != 4 {
+    if number_str.len() < 4 {
+        return Err(XsdParseError::msg("The year should be encoded on 4 digits"));
+    }
+    if number_str.len() > 4 && number_str.starts_with('0') {
         return Err(XsdParseError::msg(
-            "The years below 1000 must be encoded on exactly 4 digits",
+            "The years value must not start with 0 if it can be encoded in at least 4 digits",
         ));
     }
+    let number = i64::from_str(number_str)?;
     Ok((sign * number, input))
 }
 


### PR DESCRIPTION
Do not allow syntaxes not allowed by the grammar