### PR TITLE
Python: Removes DefaultGraph.value

### DIFF
--- a/python/src/model.rs
+++ b/python/src/model.rs
@@ -441,13 +441,6 @@ impl PyDefaultGraph {
         Self {}
     }
 
-    /// :return: the empty string.
-    /// :rtype: str
-    #[getter]
-    fn value(&self) -> &str {
-        ""
-    }
-
     fn __str__(&self) -> &str {
         "DEFAULT"
     }


### PR DESCRIPTION
Not useful, always returns the empty string

Issue #257