### PR TITLE
Always print xsd:float and xsd:double with exponential notation

### DIFF
--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -272,7 +272,7 @@ impl From<f32> for Literal {
             } else if value == f32::NEG_INFINITY {
                 "-INF".to_owned()
             } else {
-                value.to_string()
+                format!("{value:E}")
             },
             datatype: xsd::FLOAT.into(),
         })
@@ -288,7 +288,7 @@ impl From<f64> for Literal {
             } else if value == f64::NEG_INFINITY {
                 "-INF".to_owned()
             } else {
-                value.to_string()
+                format!("{value:E}")
             },
             datatype: xsd::DOUBLE.into(),
         })
@@ -667,10 +667,12 @@ mod tests {
         assert_eq!("-INF", Literal::from(f64::NEG_INFINITY).value());
         assert_eq!("NaN", Literal::from(f32::NAN).value());
         assert_eq!("NaN", Literal::from(f64::NAN).value());
+        assert_eq!("11E-1", Literal::from(1.1_f32).value());
+        assert_eq!("11E-1", Literal::from(1.1_f64).value());
     }
 
     #[test]
-    fn test_canoincal_escaping() {
+    fn test_canonical_escaping() {
         assert_eq!(
             Literal::from_str(r#""\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000a\u000b\u000c\u000d\u000e\u000f""#).unwrap().to_string(),
             r###""\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F""###

--- a/lib/oxsdatatypes/src/double.rs
+++ b/lib/oxsdatatypes/src/double.rs
@@ -202,7 +202,7 @@ impl fmt::Display for Double {
         } else if self.value == f64::NEG_INFINITY {
             f.write_str("-INF")
         } else {
-            self.value.fmt(f)
+            write!(f, "{:E}", self.value)
         }
     }
 }
@@ -305,16 +305,18 @@ mod tests {
         assert_eq!(Double::from_str("INF")?.to_string(), "INF");
         assert_eq!(Double::from_str("+INF")?.to_string(), "INF");
         assert_eq!(Double::from_str("-INF")?.to_string(), "-INF");
-        assert_eq!(Double::from_str("0.0E0")?.to_string(), "0");
-        assert_eq!(Double::from_str("-0.0E0")?.to_string(), "-0");
-        assert_eq!(Double::from_str("0.1e1")?.to_string(), "1");
-        assert_eq!(Double::from_str("-0.1e1")?.to_string(), "-1");
-        assert_eq!(Double::from_str("1.e1")?.to_string(), "10");
-        assert_eq!(Double::from_str("-1.e1")?.to_string(), "-10");
-        assert_eq!(Double::from_str("1")?.to_string(), "1");
-        assert_eq!(Double::from_str("-1")?.to_string(), "-1");
-        assert_eq!(Double::from_str("1.")?.to_string(), "1");
-        assert_eq!(Double::from_str("-1.")?.to_string(), "-1");
+        assert_eq!(Double::from_str("0")?.to_string(), "0E0");
+        assert_eq!(Double::from_str("0.0E0")?.to_string(), "0E0");
+        assert_eq!(Double::from_str("-0.0E0")?.to_string(), "-0E0");
+        assert_eq!(Double::from_str("-0")?.to_string(), "-0E0");
+        assert_eq!(Double::from_str("0.1e1")?.to_string(), "1E0");
+        assert_eq!(Double::from_str("-0.1e1")?.to_string(), "-1E0");
+        assert_eq!(Double::from_str("1.e1")?.to_string(), "1E1");
+        assert_eq!(Double::from_str("-1.e1")?.to_string(), "-1E1");
+        assert_eq!(Double::from_str("1")?.to_string(), "1E0");
+        assert_eq!(Double::from_str("-1")?.to_string(), "-1E0");
+        assert_eq!(Double::from_str("1.")?.to_string(), "1E0");
+        assert_eq!(Double::from_str("-1.")?.to_string(), "-1E0");
         assert_eq!(
             Double::from_str(&f64::MIN.to_string()).unwrap(),
             Double::MIN

--- a/lib/oxsdatatypes/src/float.rs
+++ b/lib/oxsdatatypes/src/float.rs
@@ -192,7 +192,7 @@ impl fmt::Display for Float {
         } else if self.value == f32::NEG_INFINITY {
             f.write_str("-INF")
         } else {
-            self.value.fmt(f)
+            write!(f, "{:E}", self.value)
         }
     }
 }
@@ -295,16 +295,16 @@ mod tests {
         assert_eq!(Float::from_str("INF")?.to_string(), "INF");
         assert_eq!(Float::from_str("+INF")?.to_string(), "INF");
         assert_eq!(Float::from_str("-INF")?.to_string(), "-INF");
-        assert_eq!(Float::from_str("0.0E0")?.to_string(), "0");
-        assert_eq!(Float::from_str("-0.0E0")?.to_string(), "-0");
-        assert_eq!(Float::from_str("0.1e1")?.to_string(), "1");
-        assert_eq!(Float::from_str("-0.1e1")?.to_string(), "-1");
-        assert_eq!(Float::from_str("1.e1")?.to_string(), "10");
-        assert_eq!(Float::from_str("-1.e1")?.to_string(), "-10");
-        assert_eq!(Float::from_str("1")?.to_string(), "1");
-        assert_eq!(Float::from_str("-1")?.to_string(), "-1");
-        assert_eq!(Float::from_str("1.")?.to_string(), "1");
-        assert_eq!(Float::from_str("-1.")?.to_string(), "-1");
+        assert_eq!(Float::from_str("0.0E0")?.to_string(), "0E0");
+        assert_eq!(Float::from_str("-0.0E0")?.to_string(), "-0E0");
+        assert_eq!(Float::from_str("0.1e1")?.to_string(), "1E0");
+        assert_eq!(Float::from_str("-0.1e1")?.to_string(), "-1E0");
+        assert_eq!(Float::from_str("1.e1")?.to_string(), "1E1");
+        assert_eq!(Float::from_str("-1.e1")?.to_string(), "-1E1");
+        assert_eq!(Float::from_str("1")?.to_string(), "1E0");
+        assert_eq!(Float::from_str("-1")?.to_string(), "-1E0");
+        assert_eq!(Float::from_str("1.")?.to_string(), "1E0");
+        assert_eq!(Float::from_str("-1.")?.to_string(), "-1E0");
         assert_eq!(Float::from_str(&f32::MIN.to_string())?, Float::MIN);
         assert_eq!(Float::from_str(&f32::MAX.to_string())?, Float::MAX);
         Ok(())


### PR DESCRIPTION
Follows a bit more the XML schema canonical mapping