### PR TITLE
Stop assuming JS platform when compiling to wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,17 @@ jobs:
       - run: cargo clippy --lib --tests --target wasm32-wasi
         working-directory: ./lib
 
+  clippy_wasm_unknown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - run: rustup update && rustup target add wasm32-unknown-unknown && rustup component add clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --lib --tests --target wasm32-unknown-unknown --features getrandom/custom --features oxsdatatypes/custom-now
+        working-directory: ./lib
+
   clippy_msv:
     runs-on: ubuntu-latest
     steps:
@@ -158,7 +169,7 @@ jobs:
           submodules: true
       - run: rustup update
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features
+      - run: cargo test
         env:
           RUST_BACKTRACE: 1
 
@@ -185,7 +196,7 @@ jobs:
       - run: rustup update
       - uses: Swatinem/rust-cache@v2
       - run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-      - run: cargo test --all-features
+      - run: cargo test
         env:
           RUST_BACKTRACE: 1
 

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 name = "oxigraph"
 
 [dependencies]
-oxigraph = { version = "0.4.0-alpha.1-dev", path="../lib" }
+oxigraph = { version = "0.4.0-alpha.1-dev", path="../lib", features = ["js"] }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 console_error_panic_hook = "0.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.65"
 
 [features]
 default = []
+js = ["getrandom/js", "oxsdatatypes/js", "js-sys"]
 http_client = ["oxhttp", "oxhttp/rustls"]
 rocksdb_debug = []
 
@@ -46,8 +47,8 @@ oxrocksdb-sys = { version = "0.4.0-alpha.1-dev", path="../oxrocksdb-sys" }
 oxhttp = { version = "0.1", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-js-sys = "0.3"
+getrandom = "0.2"
+js-sys = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = "0.5"

--- a/lib/oxsdatatypes/Cargo.toml
+++ b/lib/oxsdatatypes/Cargo.toml
@@ -13,8 +13,12 @@ An implementation of some XSD datatypes for SPARQL implementations
 edition = "2021"
 rust-version = "1.65"
 
+[features]
+js = ["js-sys"]
+custom-now = []
+
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-js-sys = "0.3"
+js-sys = { version = "0.3", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/lib/oxsdatatypes/README.md
+++ b/lib/oxsdatatypes/README.md
@@ -32,6 +32,22 @@ Each datatype provides:
 * `from_be_bytes` and `to_be_bytes` methods for serialization.
 
 
+### `DateTime::now` behavior
+
+The `DateTime::now()` function needs special OS support.
+Currently:
+- If the `custom-now` feature is enabled, a function computing `now` must be set:
+  ```rust
+  use oxsdatatypes::{DateTimeError, Duration};
+  
+  #[no_mangle]
+  fn custom_ox_now() -> Result<Duration, DateTimeError> {
+    unimplemented!("now implementation")
+  }
+  ```
+- For `wasm32-unknown-unknown` if the `js` feature is enabled the `Date.now()` ECMAScript API is used.
+- For all other targets `SystemTime::now()` is used.
+
 ## License
 
 This project is licensed under either of

--- a/lib/oxsdatatypes/src/duration.rs
+++ b/lib/oxsdatatypes/src/duration.rs
@@ -85,7 +85,7 @@ impl Duration {
     #[inline]
     #[must_use]
     pub(super) const fn all_seconds(self) -> Decimal {
-        self.day_time.all_seconds()
+        self.day_time.as_seconds()
     }
 
     #[inline]
@@ -443,8 +443,9 @@ impl DayTimeDuration {
         self.seconds.checked_rem(60).unwrap()
     }
 
+    /// The duration in seconds.
     #[inline]
-    pub(super) const fn all_seconds(self) -> Decimal {
+    pub const fn as_seconds(self) -> Decimal {
         self.seconds
     }
 

--- a/lib/src/sparql/algebra.rs
+++ b/lib/src/sparql/algebra.rs
@@ -6,10 +6,10 @@
 
 use crate::model::*;
 use crate::sparql::eval::Timer;
+use oxsdatatypes::DayTimeDuration;
 use spargebra::GraphUpdateOperation;
 use std::fmt;
 use std::str::FromStr;
-use std::time::Duration;
 
 /// A parsed [SPARQL query](https://www.w3.org/TR/sparql11-query/).
 ///
@@ -32,7 +32,7 @@ use std::time::Duration;
 pub struct Query {
     pub(super) inner: spargebra::Query,
     pub(super) dataset: QueryDataset,
-    pub(super) parsing_duration: Option<Duration>,
+    pub(super) parsing_duration: Option<DayTimeDuration>,
 }
 
 impl Query {
@@ -43,7 +43,7 @@ impl Query {
         Ok(Self {
             dataset: query.dataset,
             inner: query.inner,
-            parsing_duration: Some(start.elapsed()),
+            parsing_duration: start.elapsed(),
         })
     }
 


### PR DESCRIPTION
- Adds the "js" feature to enable JS support
- Adds the "custom-now" feature to oxsdatatypes to inject a custom "now" implementation It is already possible for random with the getrandom "custom" feature

Issue #471