### PR TITLE
Makes parse_ and serialize_ method take owned Parser and Serializer

### DIFF
--- a/lib/oxrdfio/src/parser.rs
+++ b/lib/oxrdfio/src/parser.rs
@@ -214,9 +214,12 @@ impl RdfParser {
     ///
     /// let file = "_:a <http://example.com/p> <http://example.com/o> .";
     ///
-    /// let parser = RdfParser::from_format(RdfFormat::NQuads).rename_blank_nodes();
-    /// let result1 = parser.parse_read(file.as_bytes()).collect::<Result<Vec<_>,_>>()?;
-    /// let result2 = parser.parse_read(file.as_bytes()).collect::<Result<Vec<_>,_>>()?;
+    /// let result1 = RdfParser::from_format(RdfFormat::NQuads)
+    ///     .rename_blank_nodes()
+    ///     .parse_read(file.as_bytes()).collect::<Result<Vec<_>,_>>()?;
+    /// let result2 = RdfParser::from_format(RdfFormat::NQuads)
+    ///     .rename_blank_nodes()
+    ///     .parse_read(file.as_bytes()).collect::<Result<Vec<_>,_>>()?;
     /// assert_ne!(result1, result2);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
@@ -247,9 +250,9 @@ impl RdfParser {
     /// assert_eq!(quads[0].subject.to_string(), "<http://example.com/s>");
     /// # std::io::Result::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, reader: R) -> FromReadQuadReader<R> {
+    pub fn parse_read<R: Read>(self, reader: R) -> FromReadQuadReader<R> {
         FromReadQuadReader {
-            parser: match &self.inner {
+            parser: match self.inner {
                 RdfParserKind::N3(p) => FromReadQuadReaderKind::N3(p.parse_read(reader)),
                 RdfParserKind::NQuads(p) => FromReadQuadReaderKind::NQuads(p.parse_read(reader)),
                 RdfParserKind::NTriples(p) => {
@@ -288,11 +291,11 @@ impl RdfParser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         reader: R,
     ) -> FromTokioAsyncReadQuadReader<R> {
         FromTokioAsyncReadQuadReader {
-            parser: match &self.inner {
+            parser: match self.inner {
                 RdfParserKind::N3(p) => {
                     FromTokioAsyncReadQuadReaderKind::N3(p.parse_tokio_async_read(reader))
                 }

--- a/lib/oxrdfio/src/serializer.rs
+++ b/lib/oxrdfio/src/serializer.rs
@@ -82,7 +82,7 @@ impl RdfSerializer {
     /// assert_eq!(buffer.as_slice(), "<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/g> .\n".as_bytes());
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn serialize_to_write<W: Write>(&self, write: W) -> ToWriteQuadWriter<W> {
+    pub fn serialize_to_write<W: Write>(self, write: W) -> ToWriteQuadWriter<W> {
         ToWriteQuadWriter {
             formatter: match self.format {
                 RdfFormat::NQuads => {
@@ -133,7 +133,7 @@ impl RdfSerializer {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn serialize_to_tokio_async_write<W: AsyncWrite + Unpin>(
-        &self,
+        self,
         write: W,
     ) -> ToTokioAsyncWriteQuadWriter<W> {
         ToTokioAsyncWriteQuadWriter {

--- a/lib/oxrdfxml/src/parser.rs
+++ b/lib/oxrdfxml/src/parser.rs
@@ -94,7 +94,7 @@ impl RdfXmlParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, read: R) -> FromReadRdfXmlReader<R> {
+    pub fn parse_read<R: Read>(self, read: R) -> FromReadRdfXmlReader<R> {
         FromReadRdfXmlReader {
             results: Vec::new(),
             reader: self.parse(BufReader::new(read)),
@@ -135,7 +135,7 @@ impl RdfXmlParser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         read: R,
     ) -> FromTokioAsyncReadRdfXmlReader<R> {
         FromTokioAsyncReadRdfXmlReader {

--- a/lib/oxrdfxml/src/serializer.rs
+++ b/lib/oxrdfxml/src/serializer.rs
@@ -57,7 +57,7 @@ impl RdfXmlSerializer {
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
     #[allow(clippy::unused_self)]
-    pub fn serialize_to_write<W: Write>(&self, write: W) -> ToWriteRdfXmlWriter<W> {
+    pub fn serialize_to_write<W: Write>(self, write: W) -> ToWriteRdfXmlWriter<W> {
         ToWriteRdfXmlWriter {
             writer: Writer::new_with_indent(write, b'\t', 1),
             inner: InnerRdfXmlWriter {
@@ -93,7 +93,7 @@ impl RdfXmlSerializer {
     #[allow(clippy::unused_self)]
     #[cfg(feature = "async-tokio")]
     pub fn serialize_to_tokio_async_write<W: AsyncWrite + Unpin>(
-        &self,
+        self,
         write: W,
     ) -> ToTokioAsyncWriteRdfXmlWriter<W> {
         ToTokioAsyncWriteRdfXmlWriter {

--- a/lib/oxttl/src/n3.rs
+++ b/lib/oxttl/src/n3.rs
@@ -259,7 +259,7 @@ impl N3Parser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, read: R) -> FromReadN3Reader<R> {
+    pub fn parse_read<R: Read>(self, read: R) -> FromReadN3Reader<R> {
         FromReadN3Reader {
             inner: self.parse().parser.parse_read(read),
         }
@@ -298,7 +298,7 @@ impl N3Parser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         read: R,
     ) -> FromTokioAsyncReadN3Reader<R> {
         FromTokioAsyncReadN3Reader {
@@ -343,9 +343,9 @@ impl N3Parser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse(&self) -> LowLevelN3Reader {
+    pub fn parse(self) -> LowLevelN3Reader {
         LowLevelN3Reader {
-            parser: N3Recognizer::new_parser(self.base.clone(), self.prefixes.clone()),
+            parser: N3Recognizer::new_parser(self.base, self.prefixes),
         }
     }
 }

--- a/lib/oxttl/src/nquads.rs
+++ b/lib/oxttl/src/nquads.rs
@@ -79,7 +79,7 @@ impl NQuadsParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, read: R) -> FromReadNQuadsReader<R> {
+    pub fn parse_read<R: Read>(self, read: R) -> FromReadNQuadsReader<R> {
         FromReadNQuadsReader {
             inner: self.parse().parser.parse_read(read),
         }
@@ -114,7 +114,7 @@ impl NQuadsParser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         read: R,
     ) -> FromTokioAsyncReadNQuadsReader<R> {
         FromTokioAsyncReadNQuadsReader {
@@ -159,7 +159,7 @@ impl NQuadsParser {
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
     #[allow(clippy::unused_self)]
-    pub fn parse(&self) -> LowLevelNQuadsReader {
+    pub fn parse(self) -> LowLevelNQuadsReader {
         LowLevelNQuadsReader {
             parser: NQuadsRecognizer::new_parser(
                 true,
@@ -362,7 +362,7 @@ impl NQuadsSerializer {
     /// );
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn serialize_to_write<W: Write>(&self, write: W) -> ToWriteNQuadsWriter<W> {
+    pub fn serialize_to_write<W: Write>(self, write: W) -> ToWriteNQuadsWriter<W> {
         ToWriteNQuadsWriter {
             write,
             writer: self.serialize(),
@@ -394,7 +394,7 @@ impl NQuadsSerializer {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn serialize_to_tokio_async_write<W: AsyncWrite + Unpin>(
-        &self,
+        self,
         write: W,
     ) -> ToTokioAsyncWriteNQuadsWriter<W> {
         ToTokioAsyncWriteNQuadsWriter {

--- a/lib/oxttl/src/ntriples.rs
+++ b/lib/oxttl/src/ntriples.rs
@@ -80,7 +80,7 @@ impl NTriplesParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, read: R) -> FromReadNTriplesReader<R> {
+    pub fn parse_read<R: Read>(self, read: R) -> FromReadNTriplesReader<R> {
         FromReadNTriplesReader {
             inner: self.parse().parser.parse_read(read),
         }
@@ -115,7 +115,7 @@ impl NTriplesParser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         read: R,
     ) -> FromTokioAsyncReadNTriplesReader<R> {
         FromTokioAsyncReadNTriplesReader {
@@ -160,7 +160,7 @@ impl NTriplesParser {
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
     #[allow(clippy::unused_self)]
-    pub fn parse(&self) -> LowLevelNTriplesReader {
+    pub fn parse(self) -> LowLevelNTriplesReader {
         LowLevelNTriplesReader {
             parser: NQuadsRecognizer::new_parser(
                 false,
@@ -361,7 +361,7 @@ impl NTriplesSerializer {
     /// );
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn serialize_to_write<W: Write>(&self, write: W) -> ToWriteNTriplesWriter<W> {
+    pub fn serialize_to_write<W: Write>(self, write: W) -> ToWriteNTriplesWriter<W> {
         ToWriteNTriplesWriter {
             write,
             writer: self.serialize(),
@@ -392,7 +392,7 @@ impl NTriplesSerializer {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn serialize_to_tokio_async_write<W: AsyncWrite + Unpin>(
-        &self,
+        self,
         write: W,
     ) -> ToTokioAsyncWriteNTriplesWriter<W> {
         ToTokioAsyncWriteNTriplesWriter {

--- a/lib/oxttl/src/trig.rs
+++ b/lib/oxttl/src/trig.rs
@@ -105,7 +105,7 @@ impl TriGParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, read: R) -> FromReadTriGReader<R> {
+    pub fn parse_read<R: Read>(self, read: R) -> FromReadTriGReader<R> {
         FromReadTriGReader {
             inner: self.parse().parser.parse_read(read),
         }
@@ -142,7 +142,7 @@ impl TriGParser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         read: R,
     ) -> FromTokioAsyncReadTriGReader<R> {
         FromTokioAsyncReadTriGReader {
@@ -186,14 +186,14 @@ impl TriGParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse(&self) -> LowLevelTriGReader {
+    pub fn parse(self) -> LowLevelTriGReader {
         LowLevelTriGReader {
             parser: TriGRecognizer::new_parser(
                 true,
                 #[cfg(feature = "rdf-star")]
                 self.with_quoted_triples,
-                self.base.clone(),
-                self.prefixes.clone(),
+                self.base,
+                self.prefixes,
             ),
         }
     }
@@ -395,7 +395,7 @@ impl TriGSerializer {
     /// );
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn serialize_to_write<W: Write>(&self, write: W) -> ToWriteTriGWriter<W> {
+    pub fn serialize_to_write<W: Write>(self, write: W) -> ToWriteTriGWriter<W> {
         ToWriteTriGWriter {
             write,
             writer: self.serialize(),
@@ -427,7 +427,7 @@ impl TriGSerializer {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn serialize_to_tokio_async_write<W: AsyncWrite + Unpin>(
-        &self,
+        self,
         write: W,
     ) -> ToTokioAsyncWriteTriGWriter<W> {
         ToTokioAsyncWriteTriGWriter {

--- a/lib/oxttl/src/turtle.rs
+++ b/lib/oxttl/src/turtle.rs
@@ -107,7 +107,7 @@ impl TurtleParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse_read<R: Read>(&self, read: R) -> FromReadTurtleReader<R> {
+    pub fn parse_read<R: Read>(self, read: R) -> FromReadTurtleReader<R> {
         FromReadTurtleReader {
             inner: self.parse().parser.parse_read(read),
         }
@@ -144,7 +144,7 @@ impl TurtleParser {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn parse_tokio_async_read<R: AsyncRead + Unpin>(
-        &self,
+        self,
         read: R,
     ) -> FromTokioAsyncReadTurtleReader<R> {
         FromTokioAsyncReadTurtleReader {
@@ -188,14 +188,14 @@ impl TurtleParser {
     /// assert_eq!(2, count);
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn parse(&self) -> LowLevelTurtleReader {
+    pub fn parse(self) -> LowLevelTurtleReader {
         LowLevelTurtleReader {
             parser: TriGRecognizer::new_parser(
                 false,
                 #[cfg(feature = "rdf-star")]
                 self.with_quoted_triples,
-                self.base.clone(),
-                self.prefixes.clone(),
+                self.base,
+                self.prefixes,
             ),
         }
     }
@@ -397,7 +397,7 @@ impl TurtleSerializer {
     /// );
     /// # Result::<_,Box<dyn std::error::Error>>::Ok(())
     /// ```
-    pub fn serialize_to_write<W: Write>(&self, write: W) -> ToWriteTurtleWriter<W> {
+    pub fn serialize_to_write<W: Write>(self, write: W) -> ToWriteTurtleWriter<W> {
         ToWriteTurtleWriter {
             inner: self.inner.serialize_to_write(write),
         }
@@ -427,7 +427,7 @@ impl TurtleSerializer {
     /// ```
     #[cfg(feature = "async-tokio")]
     pub fn serialize_to_tokio_async_write<W: AsyncWrite + Unpin>(
-        &self,
+        self,
         write: W,
     ) -> ToTokioAsyncWriteTurtleWriter<W> {
         ToTokioAsyncWriteTurtleWriter {

--- a/lib/src/io/read.rs
+++ b/lib/src/io/read.rs
@@ -65,7 +65,7 @@ impl GraphParser {
     }
 
     /// Executes the parsing itself on a [`Read`] implementation and returns an iterator of triples.
-    pub fn read_triples<R: Read>(&self, reader: R) -> TripleReader<R> {
+    pub fn read_triples<R: Read>(self, reader: R) -> TripleReader<R> {
         TripleReader {
             parser: self.inner.parse_read(reader),
         }
@@ -154,7 +154,7 @@ impl DatasetParser {
     }
 
     /// Executes the parsing itself on a [`Read`] implementation and returns an iterator of quads.
-    pub fn read_quads<R: Read>(&self, reader: R) -> QuadReader<R> {
+    pub fn read_quads<R: Read>(self, reader: R) -> QuadReader<R> {
         QuadReader {
             parser: self.inner.parse_read(reader),
         }

--- a/lib/src/io/write.rs
+++ b/lib/src/io/write.rs
@@ -45,7 +45,7 @@ impl GraphSerializer {
     }
 
     /// Returns a [`TripleWriter`] allowing writing triples into the given [`Write`] implementation
-    pub fn triple_writer<W: Write>(&self, write: W) -> TripleWriter<W> {
+    pub fn triple_writer<W: Write>(self, write: W) -> TripleWriter<W> {
         TripleWriter {
             writer: self.inner.serialize_to_write(write),
         }
@@ -128,7 +128,7 @@ impl DatasetSerializer {
     }
 
     /// Returns a [`QuadWriter`] allowing writing triples into the given [`Write`] implementation
-    pub fn quad_writer<W: Write>(&self, write: W) -> QuadWriter<W> {
+    pub fn quad_writer<W: Write>(self, write: W) -> QuadWriter<W> {
         QuadWriter {
             writer: self.inner.serialize_to_write(write),
         }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -733,18 +733,18 @@ pub fn main() -> anyhow::Result<()> {
 
             match (from_file, to_file) {
                 (Some(from_file), Some(to_file)) => close_file_writer(do_convert(
-                    &parser,
+                    parser,
                     File::open(from_file)?,
-                    &serializer,
+                    serializer,
                     BufWriter::new(File::create(to_file)?),
                     lenient,
                     &from_graph,
                     &to_graph,
                 )?),
                 (Some(from_file), None) => do_convert(
-                    &parser,
+                    parser,
                     File::open(from_file)?,
-                    &serializer,
+                    serializer,
                     stdout().lock(),
                     lenient,
                     &from_graph,
@@ -752,18 +752,18 @@ pub fn main() -> anyhow::Result<()> {
                 )?
                 .flush(),
                 (None, Some(to_file)) => close_file_writer(do_convert(
-                    &parser,
+                    parser,
                     stdin().lock(),
-                    &serializer,
+                    serializer,
                     BufWriter::new(File::create(to_file)?),
                     lenient,
                     &from_graph,
                     &to_graph,
                 )?),
                 (None, None) => do_convert(
-                    &parser,
+                    parser,
                     stdin().lock(),
-                    &serializer,
+                    serializer,
                     stdout().lock(),
                     lenient,
                     &from_graph,
@@ -806,9 +806,9 @@ fn dump<W: Write>(
 }
 
 fn do_convert<R: Read, W: Write>(
-    parser: &RdfParser,
+    parser: RdfParser,
     read: R,
-    serializer: &RdfSerializer,
+    serializer: RdfSerializer,
     write: W,
     lenient: bool,
     from_graph: &Option<GraphName>,


### PR DESCRIPTION
It is very rare to reuse parser and this allows to avoid copies