### PR TITLE
Python and & JS: Renames "mime_type" parameter to "format"

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -197,40 +197,42 @@ Example of update:
 store.update("DELETE WHERE { <http://example.com/s> ?p ?o }")
 ```
 
-#### `Store.prototype.load(String data, String mimeType, NamedNode|String? baseIRI, NamedNode|BlankNode|DefaultGraph? toNamedGraph)`
+#### `Store.prototype.load(String data, String format, NamedNode|String? baseIRI, NamedNode|BlankNode|DefaultGraph? toNamedGraph)`
 
 Loads serialized RDF triples or quad into the store.
 The method arguments are:
 1. `data`: the serialized RDF triples or quads.
-2. `mimeType`: the MIME type of the serialization. See below for the supported mime types.
+2. `format`: the format of the serialization. See below for the supported formats.
 3. `baseIRI`: the base IRI to use to resolve the relative IRIs in the serialization.
 4. `toNamedGraph`: for triple serialization formats, the name of the named graph the triple should be loaded to.
 
 The available formats are:
-* [Turtle](https://www.w3.org/TR/turtle/): `text/turtle`
-* [TriG](https://www.w3.org/TR/trig/): `application/trig`
-* [N-Triples](https://www.w3.org/TR/n-triples/): `application/n-triples`
-* [N-Quads](https://www.w3.org/TR/n-quads/): `application/n-quads`
-* [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/): `application/rdf+xml`
+* [Turtle](https://www.w3.org/TR/turtle/): `text/turtle` or `ttl`
+* [TriG](https://www.w3.org/TR/trig/): `application/trig` or `trig`
+* [N-Triples](https://www.w3.org/TR/n-triples/): `application/n-triples` or `nt`
+* [N-Quads](https://www.w3.org/TR/n-quads/): `application/n-quads` or `nq`
+* [N3](https://w3c.github.io/N3/spec/): `text/n3` or `n3`
+* [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/): `application/rdf+xml` or `rdf`
 
 Example of loading a Turtle file into the named graph `<http://example.com/graph>` with the base IRI `http://example.com`:
 ```js
 store.load("<http://example.com> <http://example.com> <> .", "text/turtle", "http://example.com", oxigraph.namedNode("http://example.com/graph"));
 ```
 
-#### `Store.prototype.dump(String mimeType, NamedNode|BlankNode|DefaultGraph? fromNamedGraph)`
+#### `Store.prototype.dump(String format, NamedNode|BlankNode|DefaultGraph? fromNamedGraph)`
 
 Returns serialized RDF triples or quad from the store.
 The method arguments are:
-1. `mimeType`: the MIME type of the serialization. See below for the supported mime types.
+1. `format`: the format type of the serialization. See below for the supported types.
 2. `fromNamedGraph`: for triple serialization formats, the name of the named graph the triple should be loaded from.
 
 The available formats are:
-* [Turtle](https://www.w3.org/TR/turtle/): `text/turtle`
-* [TriG](https://www.w3.org/TR/trig/): `application/trig`
-* [N-Triples](https://www.w3.org/TR/n-triples/): `application/n-triples`
-* [N-Quads](https://www.w3.org/TR/n-quads/): `application/n-quads`
-* [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/): `application/rdf+xml`
+* [Turtle](https://www.w3.org/TR/turtle/): `text/turtle` or `ttl`
+* [TriG](https://www.w3.org/TR/trig/): `application/trig` or `trig`
+* [N-Triples](https://www.w3.org/TR/n-triples/): `application/n-triples` or `nt`
+* [N-Quads](https://www.w3.org/TR/n-quads/): `application/n-quads` or `nq`
+* [N3](https://w3c.github.io/N3/spec/): `text/n3` or `n3`
+* [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/): `application/rdf+xml` or `rdf`
 
 Example of building a Turtle file from the named graph `<http://example.com/graph>`:
 ```js

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -69,7 +69,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_io_error(self) -> None:
         with self.assertRaises(UnsupportedOperation) as _, TemporaryFile("wb") as fp:
-            list(parse(fp, mime_type="application/n-triples"))
+            list(parse(fp, "nt"))
 
     def test_parse_quad(self) -> None:
         self.assertEqual(

--- a/python/tests/test_store.py
+++ b/python/tests/test_store.py
@@ -225,7 +225,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.load(
             BytesIO(b"<http://foo> <http://bar> <http://baz> ."),
-            mime_type="application/n-triples",
+            "application/n-triples",
         )
         self.assertEqual(set(store), {Quad(foo, bar, baz, DefaultGraph())})
 
@@ -233,7 +233,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.load(
             BytesIO(b"<http://foo> <http://bar> <http://baz> ."),
-            mime_type="application/n-triples",
+            "application/n-triples",
             to_graph=graph,
         )
         self.assertEqual(set(store), {Quad(foo, bar, baz, graph)})
@@ -242,7 +242,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.load(
             BytesIO(b"<http://foo> <http://bar> <> ."),
-            mime_type="text/turtle",
+            "text/turtle",
             base_iri="http://baz",
         )
         self.assertEqual(set(store), {Quad(foo, bar, baz, DefaultGraph())})
@@ -251,7 +251,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.load(
             BytesIO(b"<http://foo> <http://bar> <http://baz> <http://graph>."),
-            mime_type="application/n-quads",
+            "nq",
         )
         self.assertEqual(set(store), {Quad(foo, bar, baz, graph)})
 
@@ -259,7 +259,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.load(
             BytesIO(b"<http://graph> { <http://foo> <http://bar> <> . }"),
-            mime_type="application/trig",
+            "application/trig",
             base_iri="http://baz",
         )
         self.assertEqual(set(store), {Quad(foo, bar, baz, graph)})
@@ -269,13 +269,13 @@ class TestStore(unittest.TestCase):
             file_name = Path(fp.name)
             fp.write(b"<http://foo> <http://bar> <http://baz> <http://graph>.")
         store = Store()
-        store.load(file_name, mime_type="application/n-quads")
+        store.load(file_name, "nq")
         file_name.unlink()
         self.assertEqual(set(store), {Quad(foo, bar, baz, graph)})
 
     def test_load_with_io_error(self) -> None:
         with self.assertRaises(UnsupportedOperation) as _, TemporaryFile("wb") as fp:
-            Store().load(fp, mime_type="application/n-triples")
+            Store().load(fp, "application/n-triples")
 
     def test_dump_ntriples(self) -> None:
         store = Store()
@@ -291,7 +291,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.add(Quad(foo, bar, baz, graph))
         output = BytesIO()
-        store.dump(output, "application/n-quads")
+        store.dump(output, "nq")
         self.assertEqual(
             output.getvalue(),
             b"<http://foo> <http://bar> <http://baz> <http://graph> .\n",
@@ -314,7 +314,7 @@ class TestStore(unittest.TestCase):
             file_name = Path(fp.name)
         store = Store()
         store.add(Quad(foo, bar, baz, graph))
-        store.dump(file_name, "application/n-quads")
+        store.dump(file_name, "nq")
         self.assertEqual(
             file_name.read_text(),
             "<http://foo> <http://bar> <http://baz> <http://graph> .\n",
@@ -324,7 +324,7 @@ class TestStore(unittest.TestCase):
         store = Store()
         store.add(Quad(foo, bar, bar))
         with self.assertRaises(OSError) as _, TemporaryFile("rb") as fp:
-            store.dump(fp, mime_type="application/trig")
+            store.dump(fp, "application/trig")
 
     def test_write_in_read(self) -> None:
         store = Store()


### PR DESCRIPTION
- adds support of extensions
- MIME type is a deprecated wording