### PR TITLE
xsd:duration: properly fails when building not-serializable durations

### DIFF
--- a/lib/oxsdatatypes/src/date_time.rs
+++ b/lib/oxsdatatypes/src/date_time.rs
@@ -1877,11 +1877,11 @@ pub fn since_unix_epoch() -> Duration {
     target_os = "unknown"
 ))]
 fn since_unix_epoch() -> Duration {
-    Duration::new(
-        0,
+    DayTimeDuration::new(
         Decimal::try_from(crate::Double::from(js_sys::Date::now() / 1000.))
             .expect("The current time seems way in the future, it's strange"),
     )
+    .into()
 }
 
 #[cfg(not(any(

--- a/lib/oxsdatatypes/src/lib.rs
+++ b/lib/oxsdatatypes/src/lib.rs
@@ -20,7 +20,8 @@ pub use self::date_time::{
 pub use self::decimal::{Decimal, ParseDecimalError, TooLargeForDecimalError};
 pub use self::double::Double;
 pub use self::duration::{
-    DayTimeDuration, Duration, DurationOverflowError, ParseDurationError, YearMonthDuration,
+    DayTimeDuration, Duration, DurationOverflowError, OppositeSignInDurationComponentsError,
+    ParseDurationError, YearMonthDuration,
 };
 pub use self::float::Float;
 pub use self::integer::{Integer, TooLargeForIntegerError};


### PR DESCRIPTION
P1M1D - P3D is giving 1M and -3D. This is not serializable with xsd:duration formatting