### PR TITLE
SPARQL: Fix ASK + FROM combination

### DIFF
--- a/lib/spargebra/src/parser.rs
+++ b/lib/spargebra/src/parser.rs
@@ -1055,7 +1055,7 @@ parser! {
             }
         rule DescribeQuery_item() -> NamedNodePattern = i:VarOrIri() _ { i }
 
-        rule AskQuery() -> Query = i("ASK") _ d:DatasetClauses() w:WhereClause() _ g:GroupClause()? _ h:HavingClause()? _ o:OrderClause()? _ l:LimitOffsetClauses()? _ v:ValuesClause() {?
+        rule AskQuery() -> Query = i("ASK") _ d:DatasetClauses() _ w:WhereClause() _ g:GroupClause()? _ h:HavingClause()? _ o:OrderClause()? _ l:LimitOffsetClauses()? _ v:ValuesClause() {?
             Ok(Query::Ask {
                 dataset: d,
                 pattern: build_select(Selection::no_op(), w, g, h, o, l, v, state)?,

--- a/testsuite/oxigraph-tests/sparql/ask_from.rq
+++ b/testsuite/oxigraph-tests/sparql/ask_from.rq
@@ -1,0 +1,1 @@
+ASK FROM <scheme://a.graph> WHERE { }

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -16,6 +16,7 @@
     :long_unicode_escape_with_multibytes_char_update
     :describe
     :describe_where
+    :ask_with_from
     :group_concat_with_null
     :single_not_exists
     :property_list_path
@@ -62,6 +63,10 @@
          [ qt:query  <describe_where.rq> ;
            qt:data   <describe_input.ttl> ] ;
     mf:result  <describe_output.ttl> .
+
+:ask_with_from rdf:type mf:PositiveSyntaxTest ;
+    mf:name "ASK with FROM" ;
+    mf:action <ask_from.rq> .
 
 :group_concat_with_null rdf:type mf:QueryEvaluationTest ;
     mf:name "GROUP_CONCAT with NULL" ;


### PR DESCRIPTION
Previously `ASK FROM` only worked without `WHERE`.

This did work:
```sparql
ASK FROM <scheme://a.graph> { FILTER(true) }
```

... but this did not:
```sparql
ASK FROM <scheme://a.graph> WHERE { FILTER(true) }
```