### PR TITLE
Add debug print to test_debian_compatibility

### DIFF
--- a/lints/test_debian_compatibility.py
+++ b/lints/test_debian_compatibility.py
@@ -46,6 +46,7 @@ def fetch_debian_package_desc(debian_name):
                 print(f"Error {e} from {url}, retrying after {wait}s")
                 sleep(wait)
             else:
+                print(f"Failed to fetch debian name {debian_name} from {url}: {e}")
                 raise e
     raise Exception(f"Failed to fetch {url}")
 


### PR DESCRIPTION
Apparently CI began to fail all of a sudden - this prints the reason