### PR TITLE
Use `Self::AssocName` to simplify declarations

### DIFF
--- a/js/src/model.rs
+++ b/js/src/model.rs
@@ -564,7 +564,7 @@ impl From<Quad> for JsTerm {
 impl TryFrom<JsTerm> for NamedNode {
     type Error = JsValue;
 
-    fn try_from(value: JsTerm) -> Result<Self, JsValue> {
+    fn try_from(value: JsTerm) -> Result<Self, Self::Error> {
         match value {
             JsTerm::NamedNode(node) => Ok(node.into()),
             JsTerm::BlankNode(node) => Err(format_err!(
@@ -588,7 +588,7 @@ impl TryFrom<JsTerm> for NamedNode {
 impl TryFrom<JsTerm> for NamedOrBlankNode {
     type Error = JsValue;
 
-    fn try_from(value: JsTerm) -> Result<Self, JsValue> {
+    fn try_from(value: JsTerm) -> Result<Self, Self::Error> {
         match value {
             JsTerm::NamedNode(node) => Ok(node.into()),
             JsTerm::BlankNode(node) => Ok(node.into()),
@@ -614,7 +614,7 @@ impl TryFrom<JsTerm> for NamedOrBlankNode {
 impl TryFrom<JsTerm> for Subject {
     type Error = JsValue;
 
-    fn try_from(value: JsTerm) -> Result<Self, JsValue> {
+    fn try_from(value: JsTerm) -> Result<Self, Self::Error> {
         match value {
             JsTerm::NamedNode(node) => Ok(node.into()),
             JsTerm::BlankNode(node) => Ok(node.into()),
@@ -637,7 +637,7 @@ impl TryFrom<JsTerm> for Subject {
 impl TryFrom<JsTerm> for Term {
     type Error = JsValue;
 
-    fn try_from(value: JsTerm) -> Result<Self, JsValue> {
+    fn try_from(value: JsTerm) -> Result<Self, Self::Error> {
         match value {
             JsTerm::NamedNode(node) => Ok(node.into()),
             JsTerm::BlankNode(node) => Ok(node.into()),
@@ -657,7 +657,7 @@ impl TryFrom<JsTerm> for Term {
 impl TryFrom<JsTerm> for GraphName {
     type Error = JsValue;
 
-    fn try_from(value: JsTerm) -> Result<Self, JsValue> {
+    fn try_from(value: JsTerm) -> Result<Self, Self::Error> {
         match value {
             JsTerm::NamedNode(node) => Ok(node.into()),
             JsTerm::BlankNode(node) => Ok(node.into()),

--- a/lib/oxrdf/src/dataset.rs
+++ b/lib/oxrdf/src/dataset.rs
@@ -927,7 +927,7 @@ impl<'a> IntoIterator for &'a Dataset {
     type Item = QuadRef<'a>;
     type IntoIter = Iter<'a>;
 
-    fn into_iter(self) -> Iter<'a> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
@@ -1285,7 +1285,7 @@ impl<'a> IntoIterator for GraphView<'a> {
     type Item = TripleRef<'a>;
     type IntoIter = GraphViewIter<'a>;
 
-    fn into_iter(self) -> GraphViewIter<'a> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
@@ -1294,7 +1294,7 @@ impl<'a, 'b> IntoIterator for &'b GraphView<'a> {
     type Item = TripleRef<'a>;
     type IntoIter = GraphViewIter<'a>;
 
-    fn into_iter(self) -> GraphViewIter<'a> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
@@ -1496,7 +1496,7 @@ impl<'a> IntoIterator for &'a GraphViewMut<'a> {
     type Item = TripleRef<'a>;
     type IntoIter = GraphViewIter<'a>;
 
-    fn into_iter(self) -> GraphViewIter<'a> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
@@ -1527,7 +1527,7 @@ pub struct Iter<'a> {
 impl<'a> Iterator for Iter<'a> {
     type Item = QuadRef<'a>;
 
-    fn next(&mut self) -> Option<QuadRef<'a>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
             .map(|(s, p, o, g)| self.dataset.decode_spog((s, p, o, g)))
@@ -1551,7 +1551,7 @@ pub struct GraphViewIter<'a> {
 impl<'a> Iterator for GraphViewIter<'a> {
     type Item = TripleRef<'a>;
 
-    fn next(&mut self) -> Option<TripleRef<'a>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
             .map(|(_, s, p, o)| self.dataset.decode_spo((s, p, o)))

--- a/lib/oxrdf/src/graph.rs
+++ b/lib/oxrdf/src/graph.rs
@@ -229,7 +229,7 @@ impl<'a> IntoIterator for &'a Graph {
     type Item = TripleRef<'a>;
     type IntoIter = Iter<'a>;
 
-    fn into_iter(self) -> Iter<'a> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
@@ -276,7 +276,7 @@ pub struct Iter<'a> {
 impl<'a> Iterator for Iter<'a> {
     type Item = TripleRef<'a>;
 
-    fn next(&mut self) -> Option<TripleRef<'a>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }

--- a/lib/oxrdf/src/interning.rs
+++ b/lib/oxrdf/src/interning.rs
@@ -510,8 +510,8 @@ struct IdentityHasherBuilder;
 impl BuildHasher for IdentityHasherBuilder {
     type Hasher = IdentityHasher;
 
-    fn build_hasher(&self) -> IdentityHasher {
-        IdentityHasher::default()
+    fn build_hasher(&self) -> Self::Hasher {
+        Self::Hasher::default()
     }
 }
 

--- a/lib/oxrdf/src/parser.rs
+++ b/lib/oxrdf/src/parser.rs
@@ -25,7 +25,7 @@ impl FromStr for NamedNode {
     ///
     /// assert_eq!(NamedNode::from_str("<http://example.com>").unwrap(), NamedNode::new("http://example.com").unwrap())
     /// ```
-    fn from_str(s: &str) -> Result<Self, TermParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (term, left) = read_named_node(s)?;
         if !left.is_empty() {
             return Err(TermParseError::msg(
@@ -47,7 +47,7 @@ impl FromStr for BlankNode {
     ///
     /// assert_eq!(BlankNode::from_str("_:ex").unwrap(), BlankNode::new("ex").unwrap())
     /// ```
-    fn from_str(s: &str) -> Result<Self, TermParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (term, left) = read_blank_node(s)?;
         if !left.is_empty() {
             return Err(TermParseError::msg(
@@ -75,7 +75,7 @@ impl FromStr for Literal {
     /// assert_eq!(Literal::from_str("-122.23").unwrap(), Literal::new_typed_literal("-122.23", xsd::DECIMAL));
     /// assert_eq!(Literal::from_str("-122e+1").unwrap(), Literal::new_typed_literal("-122e+1", xsd::DOUBLE));
     /// ```
-    fn from_str(s: &str) -> Result<Self, TermParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (term, left) = read_literal(s)?;
         if !left.is_empty() {
             return Err(TermParseError::msg("Invalid literal serialization"));
@@ -100,7 +100,7 @@ impl FromStr for Term {
     ///     Literal::new_simple_literal("o")
     /// ).into());
     /// ```
-    fn from_str(s: &str) -> Result<Self, TermParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (term, left) = read_term(s, 0)?;
         if !left.is_empty() {
             return Err(TermParseError::msg("Invalid term serialization"));
@@ -120,7 +120,7 @@ impl FromStr for Variable {
     ///
     /// assert_eq!(Variable::from_str("$foo").unwrap(), Variable::new("foo").unwrap())
     /// ```
-    fn from_str(s: &str) -> Result<Self, TermParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         if !s.starts_with('?') && !s.starts_with('$') {
             return Err(TermParseError::msg(
                 "Variable serialization should start with ? or $",

--- a/lib/oxrdfio/src/parser.rs
+++ b/lib/oxrdfio/src/parser.rs
@@ -382,7 +382,7 @@ enum FromReadQuadReaderKind<R: Read> {
 impl<R: Read> Iterator for FromReadQuadReader<R> {
     type Item = Result<Quad, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Quad, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(match &mut self.parser {
             FromReadQuadReaderKind::N3(parser) => match parser.next()? {
                 Ok(quad) => self.mapper.map_n3_quad(quad),

--- a/lib/oxrdfxml/src/parser.rs
+++ b/lib/oxrdfxml/src/parser.rs
@@ -212,7 +212,7 @@ pub struct FromReadRdfXmlReader<R: Read> {
 impl<R: Read> Iterator for FromReadRdfXmlReader<R> {
     type Item = Result<Triple, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Triple, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(triple) = self.results.pop() {
                 return Some(Ok(triple));

--- a/lib/oxsdatatypes/src/boolean.rs
+++ b/lib/oxsdatatypes/src/boolean.rs
@@ -66,7 +66,7 @@ impl FromStr for Boolean {
     type Err = ParseBoolError;
 
     #[inline]
-    fn from_str(input: &str) -> Result<Self, ParseBoolError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         Ok(match input {
             "true" | "1" => true,
             "false" | "0" => false,

--- a/lib/oxsdatatypes/src/date_time.rs
+++ b/lib/oxsdatatypes/src/date_time.rs
@@ -256,7 +256,7 @@ impl TryFrom<Date> for DateTime {
     type Error = DateTimeOverflowError;
 
     #[inline]
-    fn try_from(date: Date) -> Result<Self, DateTimeOverflowError> {
+    fn try_from(date: Date) -> Result<Self, Self::Error> {
         Self::new(
             date.year(),
             date.month(),
@@ -272,7 +272,7 @@ impl TryFrom<Date> for DateTime {
 impl FromStr for DateTime {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, date_time_lexical_rep)
     }
 }
@@ -528,7 +528,7 @@ impl From<DateTime> for Time {
 impl FromStr for Time {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, time_lexical_rep)
     }
 }
@@ -762,7 +762,7 @@ impl TryFrom<DateTime> for Date {
     type Error = DateTimeOverflowError;
 
     #[inline]
-    fn try_from(date_time: DateTime) -> Result<Self, DateTimeOverflowError> {
+    fn try_from(date_time: DateTime) -> Result<Self, Self::Error> {
         Self::new(
             date_time.year(),
             date_time.month(),
@@ -775,7 +775,7 @@ impl TryFrom<DateTime> for Date {
 impl FromStr for Date {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, date_lexical_rep)
     }
 }
@@ -896,7 +896,7 @@ impl TryFrom<DateTime> for GYearMonth {
     type Error = DateTimeOverflowError;
 
     #[inline]
-    fn try_from(date_time: DateTime) -> Result<Self, DateTimeOverflowError> {
+    fn try_from(date_time: DateTime) -> Result<Self, Self::Error> {
         Self::new(
             date_time.year(),
             date_time.month(),
@@ -917,7 +917,7 @@ impl From<Date> for GYearMonth {
 impl FromStr for GYearMonth {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, g_year_month_lexical_rep)
     }
 }
@@ -1031,7 +1031,7 @@ impl TryFrom<DateTime> for GYear {
     type Error = DateTimeOverflowError;
 
     #[inline]
-    fn try_from(date_time: DateTime) -> Result<Self, DateTimeOverflowError> {
+    fn try_from(date_time: DateTime) -> Result<Self, Self::Error> {
         Self::new(date_time.year(), date_time.timezone_offset())
     }
 }
@@ -1041,7 +1041,7 @@ impl TryFrom<Date> for GYear {
     type Error = DateTimeOverflowError;
 
     #[inline]
-    fn try_from(date: Date) -> Result<Self, DateTimeOverflowError> {
+    fn try_from(date: Date) -> Result<Self, Self::Error> {
         Self::new(date.year(), date.timezone_offset())
     }
 }
@@ -1050,7 +1050,7 @@ impl TryFrom<GYearMonth> for GYear {
     type Error = DateTimeOverflowError;
 
     #[inline]
-    fn try_from(year_month: GYearMonth) -> Result<Self, DateTimeOverflowError> {
+    fn try_from(year_month: GYearMonth) -> Result<Self, Self::Error> {
         Self::new(year_month.year(), year_month.timezone_offset())
     }
 }
@@ -1058,7 +1058,7 @@ impl TryFrom<GYearMonth> for GYear {
 impl FromStr for GYear {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, g_year_lexical_rep)
     }
 }
@@ -1186,7 +1186,7 @@ impl From<Date> for GMonthDay {
 impl FromStr for GMonthDay {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, g_month_day_lexical_rep)
     }
 }
@@ -1315,7 +1315,7 @@ impl From<GMonthDay> for GMonth {
 impl FromStr for GMonth {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, g_month_lexical_rep)
     }
 }
@@ -1436,7 +1436,7 @@ impl From<GMonthDay> for GDay {
 impl FromStr for GDay {
     type Err = ParseDateTimeError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDateTimeError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure_complete(input, g_day_lexical_rep)
     }
 }
@@ -1499,7 +1499,7 @@ impl TryFrom<DayTimeDuration> for TimezoneOffset {
     type Error = InvalidTimezoneError;
 
     #[inline]
-    fn try_from(value: DayTimeDuration) -> Result<Self, InvalidTimezoneError> {
+    fn try_from(value: DayTimeDuration) -> Result<Self, Self::Error> {
         let offset_in_minutes = value.minutes() + value.hours() * 60;
         let result = Self::new(
             offset_in_minutes
@@ -1519,7 +1519,7 @@ impl TryFrom<Duration> for TimezoneOffset {
     type Error = InvalidTimezoneError;
 
     #[inline]
-    fn try_from(value: Duration) -> Result<Self, InvalidTimezoneError> {
+    fn try_from(value: Duration) -> Result<Self, Self::Error> {
         DayTimeDuration::try_from(value)
             .map_err(|_| InvalidTimezoneError {
                 offset_in_minutes: 0,

--- a/lib/oxsdatatypes/src/decimal.rs
+++ b/lib/oxsdatatypes/src/decimal.rs
@@ -361,7 +361,7 @@ impl TryFrom<i128> for Decimal {
     type Error = TooLargeForDecimalError;
 
     #[inline]
-    fn try_from(value: i128) -> Result<Self, TooLargeForDecimalError> {
+    fn try_from(value: i128) -> Result<Self, Self::Error> {
         Ok(Self {
             value: value
                 .checked_mul(DECIMAL_PART_POW)
@@ -374,7 +374,7 @@ impl TryFrom<u128> for Decimal {
     type Error = TooLargeForDecimalError;
 
     #[inline]
-    fn try_from(value: u128) -> Result<Self, TooLargeForDecimalError> {
+    fn try_from(value: u128) -> Result<Self, Self::Error> {
         Ok(Self {
             value: i128::try_from(value)
                 .map_err(|_| TooLargeForDecimalError)?
@@ -395,7 +395,7 @@ impl TryFrom<Float> for Decimal {
     type Error = TooLargeForDecimalError;
 
     #[inline]
-    fn try_from(value: Float) -> Result<Self, TooLargeForDecimalError> {
+    fn try_from(value: Float) -> Result<Self, Self::Error> {
         Double::from(value).try_into()
     }
 }
@@ -405,7 +405,7 @@ impl TryFrom<Double> for Decimal {
 
     #[inline]
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-    fn try_from(value: Double) -> Result<Self, TooLargeForDecimalError> {
+    fn try_from(value: Double) -> Result<Self, Self::Error> {
         let shifted = f64::from(value) * (DECIMAL_PART_POW as f64);
         if (i128::MIN as f64) <= shifted && shifted <= (i128::MAX as f64) {
             Ok(Self {
@@ -448,7 +448,7 @@ impl TryFrom<Decimal> for Integer {
     type Error = TooLargeForIntegerError;
 
     #[inline]
-    fn try_from(value: Decimal) -> Result<Self, TooLargeForIntegerError> {
+    fn try_from(value: Decimal) -> Result<Self, Self::Error> {
         Ok(i64::try_from(
             value
                 .value
@@ -464,7 +464,7 @@ impl FromStr for Decimal {
     type Err = ParseDecimalError;
 
     /// Parses decimals lexical mapping
-    fn from_str(input: &str) -> Result<Self, ParseDecimalError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         // (\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)
         let input = input.as_bytes();
         if input.is_empty() {

--- a/lib/oxsdatatypes/src/double.rs
+++ b/lib/oxsdatatypes/src/double.rs
@@ -189,7 +189,7 @@ impl FromStr for Double {
     type Err = ParseFloatError;
 
     #[inline]
-    fn from_str(input: &str) -> Result<Self, ParseFloatError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         Ok(f64::from_str(input)?.into())
     }
 }

--- a/lib/oxsdatatypes/src/duration.rs
+++ b/lib/oxsdatatypes/src/duration.rs
@@ -176,7 +176,7 @@ impl TryFrom<StdDuration> for Duration {
     type Error = DurationOverflowError;
 
     #[inline]
-    fn try_from(value: StdDuration) -> Result<Self, DurationOverflowError> {
+    fn try_from(value: StdDuration) -> Result<Self, Self::Error> {
         Ok(DayTimeDuration::try_from(value)?.into())
     }
 }
@@ -184,7 +184,7 @@ impl TryFrom<StdDuration> for Duration {
 impl FromStr for Duration {
     type Err = ParseDurationError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDurationError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parts = ensure_complete(input, duration_parts)?;
         if parts.year_month.is_none() && parts.day_time.is_none() {
             return Err(ParseDurationError::msg("Empty duration"));
@@ -394,7 +394,7 @@ impl TryFrom<Duration> for YearMonthDuration {
     type Error = DurationOverflowError;
 
     #[inline]
-    fn try_from(value: Duration) -> Result<Self, DurationOverflowError> {
+    fn try_from(value: Duration) -> Result<Self, Self::Error> {
         if value.day_time == DayTimeDuration::default() {
             Ok(value.year_month)
         } else {
@@ -406,7 +406,7 @@ impl TryFrom<Duration> for YearMonthDuration {
 impl FromStr for YearMonthDuration {
     type Err = ParseDurationError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDurationError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parts = ensure_complete(input, duration_parts)?;
         if parts.day_time.is_some() {
             return Err(ParseDurationError::msg(
@@ -580,7 +580,7 @@ impl TryFrom<Duration> for DayTimeDuration {
     type Error = DurationOverflowError;
 
     #[inline]
-    fn try_from(value: Duration) -> Result<Self, DurationOverflowError> {
+    fn try_from(value: Duration) -> Result<Self, Self::Error> {
         if value.year_month == YearMonthDuration::default() {
             Ok(value.day_time)
         } else {
@@ -593,7 +593,7 @@ impl TryFrom<StdDuration> for DayTimeDuration {
     type Error = DurationOverflowError;
 
     #[inline]
-    fn try_from(value: StdDuration) -> Result<Self, DurationOverflowError> {
+    fn try_from(value: StdDuration) -> Result<Self, Self::Error> {
         Ok(Self {
             seconds: Decimal::new(
                 i128::try_from(value.as_nanos()).map_err(|_| DurationOverflowError)?,
@@ -608,7 +608,7 @@ impl TryFrom<DayTimeDuration> for StdDuration {
     type Error = DurationOverflowError;
 
     #[inline]
-    fn try_from(value: DayTimeDuration) -> Result<Self, DurationOverflowError> {
+    fn try_from(value: DayTimeDuration) -> Result<Self, Self::Error> {
         if value.seconds.is_negative() {
             return Err(DurationOverflowError);
         }
@@ -636,7 +636,7 @@ impl TryFrom<DayTimeDuration> for StdDuration {
 impl FromStr for DayTimeDuration {
     type Err = ParseDurationError;
 
-    fn from_str(input: &str) -> Result<Self, ParseDurationError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parts = ensure_complete(input, duration_parts)?;
         if parts.year_month.is_some() {
             return Err(ParseDurationError::msg(

--- a/lib/oxsdatatypes/src/float.rs
+++ b/lib/oxsdatatypes/src/float.rs
@@ -179,7 +179,7 @@ impl FromStr for Float {
     type Err = ParseFloatError;
 
     #[inline]
-    fn from_str(input: &str) -> Result<Self, ParseFloatError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         Ok(f32::from_str(input)?.into())
     }
 }

--- a/lib/oxsdatatypes/src/integer.rs
+++ b/lib/oxsdatatypes/src/integer.rs
@@ -228,7 +228,7 @@ impl FromStr for Integer {
     type Err = ParseIntError;
 
     #[inline]
-    fn from_str(input: &str) -> Result<Self, ParseIntError> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         Ok(i64::from_str(input)?.into())
     }
 }
@@ -244,7 +244,7 @@ impl TryFrom<Float> for Integer {
     type Error = TooLargeForIntegerError;
 
     #[inline]
-    fn try_from(value: Float) -> Result<Self, TooLargeForIntegerError> {
+    fn try_from(value: Float) -> Result<Self, Self::Error> {
         Decimal::try_from(value)
             .map_err(|_| TooLargeForIntegerError)?
             .try_into()
@@ -255,7 +255,7 @@ impl TryFrom<Double> for Integer {
     type Error = TooLargeForIntegerError;
 
     #[inline]
-    fn try_from(value: Double) -> Result<Self, TooLargeForIntegerError> {
+    fn try_from(value: Double) -> Result<Self, Self::Error> {
         Decimal::try_from(value)
             .map_err(|_| TooLargeForIntegerError)?
             .try_into()

--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -56,7 +56,7 @@ impl TokenRecognizer for N3Lexer {
         &mut self,
         data: &'a [u8],
         is_ending: bool,
-        options: &N3LexerOptions,
+        options: &Self::Options,
     ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
         match *data.first()? {
             b'<' => match *data.get(1)? {

--- a/lib/oxttl/src/n3.rs
+++ b/lib/oxttl/src/n3.rs
@@ -450,7 +450,7 @@ impl<R: Read> FromReadN3Reader<R> {
 impl<R: Read> Iterator for FromReadN3Reader<R> {
     type Item = Result<N3Quad, ParseError>;
 
-    fn next(&mut self) -> Option<Result<N3Quad, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }

--- a/lib/oxttl/src/nquads.rs
+++ b/lib/oxttl/src/nquads.rs
@@ -215,7 +215,7 @@ pub struct FromReadNQuadsReader<R: Read> {
 impl<R: Read> Iterator for FromReadNQuadsReader<R> {
     type Item = Result<Quad, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Quad, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }

--- a/lib/oxttl/src/ntriples.rs
+++ b/lib/oxttl/src/ntriples.rs
@@ -215,7 +215,7 @@ pub struct FromReadNTriplesReader<R: Read> {
 impl<R: Read> Iterator for FromReadNTriplesReader<R> {
     type Item = Result<Triple, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Triple, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(self.inner.next()?.map(Into::into))
     }
 }

--- a/lib/oxttl/src/trig.rs
+++ b/lib/oxttl/src/trig.rs
@@ -300,7 +300,7 @@ impl<R: Read> FromReadTriGReader<R> {
 impl<R: Read> Iterator for FromReadTriGReader<R> {
     type Item = Result<Quad, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Quad, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }

--- a/lib/oxttl/src/turtle.rs
+++ b/lib/oxttl/src/turtle.rs
@@ -302,7 +302,7 @@ impl<R: Read> FromReadTurtleReader<R> {
 impl<R: Read> Iterator for FromReadTurtleReader<R> {
     type Item = Result<Triple, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Triple, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(self.inner.next()?.map(Into::into))
     }
 }

--- a/lib/sparesults/src/parser.rs
+++ b/lib/sparesults/src/parser.rs
@@ -206,7 +206,7 @@ impl<R: Read> FromReadSolutionsReader<R> {
 impl<R: Read> Iterator for FromReadSolutionsReader<R> {
     type Item = Result<QuerySolution, ParseError>;
 
-    fn next(&mut self) -> Option<Result<QuerySolution, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(
             match &mut self.solutions {
                 SolutionsReaderKind::Xml(reader) => reader.read_next(),

--- a/lib/sparesults/src/solution.rs
+++ b/lib/sparesults/src/solution.rs
@@ -130,7 +130,7 @@ impl<'a> IntoIterator for &'a QuerySolution {
     type IntoIter = Iter<'a>;
 
     #[inline]
-    fn into_iter(self) -> Iter<'a> {
+    fn into_iter(self) -> Self::IntoIter {
         Iter {
             inner: self.variables.iter().zip(&self.values),
         }
@@ -142,7 +142,7 @@ impl Index<usize> for QuerySolution {
 
     #[allow(clippy::panic)]
     #[inline]
-    fn index(&self, index: usize) -> &Term {
+    fn index(&self, index: usize) -> &Self::Output {
         self.get(index)
             .unwrap_or_else(|| panic!("The column {index} is not set in this solution"))
     }
@@ -153,7 +153,7 @@ impl Index<&str> for QuerySolution {
 
     #[allow(clippy::panic)]
     #[inline]
-    fn index(&self, index: &str) -> &Term {
+    fn index(&self, index: &str) -> &Self::Output {
         self.get(index)
             .unwrap_or_else(|| panic!("The variable ?{index} is not set in this solution"))
     }
@@ -164,7 +164,7 @@ impl Index<VariableRef<'_>> for QuerySolution {
 
     #[allow(clippy::panic)]
     #[inline]
-    fn index(&self, index: VariableRef<'_>) -> &Term {
+    fn index(&self, index: VariableRef<'_>) -> &Self::Output {
         self.get(index)
             .unwrap_or_else(|| panic!("The variable {index} is not set in this solution"))
     }
@@ -173,7 +173,7 @@ impl Index<Variable> for QuerySolution {
     type Output = Term;
 
     #[inline]
-    fn index(&self, index: Variable) -> &Term {
+    fn index(&self, index: Variable) -> &Self::Output {
         self.index(index.as_ref())
     }
 }
@@ -182,7 +182,7 @@ impl Index<&Variable> for QuerySolution {
     type Output = Term;
 
     #[inline]
-    fn index(&self, index: &Variable) -> &Term {
+    fn index(&self, index: &Variable) -> &Self::Output {
         self.index(index.as_ref())
     }
 }
@@ -228,7 +228,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (&'a Variable, &'a Term);
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a Variable, &'a Term)> {
+    fn next(&mut self) -> Option<Self::Item> {
         for (variable, value) in &mut self.inner {
             if let Some(value) = value {
                 return Some((variable, value));

--- a/lib/spargebra/src/query.rs
+++ b/lib/spargebra/src/query.rs
@@ -275,7 +275,7 @@ impl fmt::Display for Query {
 impl FromStr for Query {
     type Err = ParseError;
 
-    fn from_str(query: &str) -> Result<Self, ParseError> {
+    fn from_str(query: &str) -> Result<Self, Self::Err> {
         Self::parse(query, None)
     }
 }
@@ -283,7 +283,7 @@ impl FromStr for Query {
 impl<'a> TryFrom<&'a str> for Query {
     type Error = ParseError;
 
-    fn try_from(query: &str) -> Result<Self, ParseError> {
+    fn try_from(query: &str) -> Result<Self, Self::Error> {
         Self::from_str(query)
     }
 }
@@ -291,7 +291,7 @@ impl<'a> TryFrom<&'a str> for Query {
 impl<'a> TryFrom<&'a String> for Query {
     type Error = ParseError;
 
-    fn try_from(query: &String) -> Result<Self, ParseError> {
+    fn try_from(query: &String) -> Result<Self, Self::Error> {
         Self::from_str(query)
     }
 }

--- a/lib/spargebra/src/term.rs
+++ b/lib/spargebra/src/term.rs
@@ -48,7 +48,7 @@ impl TryFrom<Subject> for GroundSubject {
     type Error = ();
 
     #[inline]
-    fn try_from(subject: Subject) -> Result<Self, ()> {
+    fn try_from(subject: Subject) -> Result<Self, Self::Error> {
         match subject {
             Subject::NamedNode(t) => Ok(t.into()),
             Subject::BlankNode(_) => Err(()),
@@ -62,7 +62,7 @@ impl TryFrom<GroundTerm> for GroundSubject {
     type Error = ();
 
     #[inline]
-    fn try_from(term: GroundTerm) -> Result<Self, ()> {
+    fn try_from(term: GroundTerm) -> Result<Self, Self::Error> {
         match term {
             GroundTerm::NamedNode(t) => Ok(t.into()),
             GroundTerm::Literal(_) => Err(()),
@@ -125,7 +125,7 @@ impl TryFrom<Term> for GroundTerm {
     type Error = ();
 
     #[inline]
-    fn try_from(term: Term) -> Result<Self, ()> {
+    fn try_from(term: Term) -> Result<Self, Self::Error> {
         match term {
             Term::NamedNode(t) => Ok(t.into()),
             Term::BlankNode(_) => Err(()),
@@ -171,7 +171,7 @@ impl TryFrom<Triple> for GroundTriple {
     type Error = ();
 
     #[inline]
-    fn try_from(triple: Triple) -> Result<Self, ()> {
+    fn try_from(triple: Triple) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: triple.subject.try_into()?,
             predicate: triple.predicate,
@@ -221,7 +221,7 @@ impl TryFrom<GraphNamePattern> for GraphName {
     type Error = ();
 
     #[inline]
-    fn try_from(pattern: GraphNamePattern) -> Result<Self, ()> {
+    fn try_from(pattern: GraphNamePattern) -> Result<Self, Self::Error> {
         match pattern {
             GraphNamePattern::NamedNode(t) => Ok(t.into()),
             GraphNamePattern::DefaultGraph => Ok(Self::DefaultGraph),
@@ -295,7 +295,7 @@ impl TryFrom<QuadPattern> for Quad {
     type Error = ();
 
     #[inline]
-    fn try_from(quad: QuadPattern) -> Result<Self, ()> {
+    fn try_from(quad: QuadPattern) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: quad.subject.try_into()?,
             predicate: quad.predicate.try_into()?,
@@ -370,7 +370,7 @@ impl TryFrom<Quad> for GroundQuad {
     type Error = ();
 
     #[inline]
-    fn try_from(quad: Quad) -> Result<Self, ()> {
+    fn try_from(quad: Quad) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: quad.subject.try_into()?,
             predicate: quad.predicate,
@@ -425,7 +425,7 @@ impl TryFrom<NamedNodePattern> for NamedNode {
     type Error = ();
 
     #[inline]
-    fn try_from(pattern: NamedNodePattern) -> Result<Self, ()> {
+    fn try_from(pattern: NamedNodePattern) -> Result<Self, Self::Error> {
         match pattern {
             NamedNodePattern::NamedNode(t) => Ok(t),
             NamedNodePattern::Variable(_) => Err(()),
@@ -559,7 +559,7 @@ impl TryFrom<TermPattern> for Subject {
     type Error = ();
 
     #[inline]
-    fn try_from(term: TermPattern) -> Result<Self, ()> {
+    fn try_from(term: TermPattern) -> Result<Self, Self::Error> {
         match term {
             TermPattern::NamedNode(t) => Ok(t.into()),
             TermPattern::BlankNode(t) => Ok(t.into()),
@@ -574,7 +574,7 @@ impl TryFrom<TermPattern> for Term {
     type Error = ();
 
     #[inline]
-    fn try_from(pattern: TermPattern) -> Result<Self, ()> {
+    fn try_from(pattern: TermPattern) -> Result<Self, Self::Error> {
         match pattern {
             TermPattern::NamedNode(t) => Ok(t.into()),
             TermPattern::BlankNode(t) => Ok(t.into()),
@@ -686,7 +686,7 @@ impl TryFrom<TermPattern> for GroundTermPattern {
     type Error = ();
 
     #[inline]
-    fn try_from(pattern: TermPattern) -> Result<Self, ()> {
+    fn try_from(pattern: TermPattern) -> Result<Self, Self::Error> {
         Ok(match pattern {
             TermPattern::NamedNode(named_node) => named_node.into(),
             TermPattern::BlankNode(_) => return Err(()),
@@ -828,7 +828,7 @@ impl TryFrom<TriplePattern> for Triple {
     type Error = ();
 
     #[inline]
-    fn try_from(triple: TriplePattern) -> Result<Self, ()> {
+    fn try_from(triple: TriplePattern) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: triple.subject.try_into()?,
             predicate: triple.predicate.try_into()?,
@@ -1000,7 +1000,7 @@ impl TryFrom<QuadPattern> for GroundQuadPattern {
     type Error = ();
 
     #[inline]
-    fn try_from(pattern: QuadPattern) -> Result<Self, ()> {
+    fn try_from(pattern: QuadPattern) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: pattern.subject.try_into()?,
             predicate: pattern.predicate,

--- a/lib/spargebra/src/update.rs
+++ b/lib/spargebra/src/update.rs
@@ -70,7 +70,7 @@ impl fmt::Display for Update {
 impl FromStr for Update {
     type Err = ParseError;
 
-    fn from_str(update: &str) -> Result<Self, ParseError> {
+    fn from_str(update: &str) -> Result<Self, Self::Err> {
         Self::parse(update, None)
     }
 }
@@ -78,7 +78,7 @@ impl FromStr for Update {
 impl<'a> TryFrom<&'a str> for Update {
     type Error = ParseError;
 
-    fn try_from(update: &str) -> Result<Self, ParseError> {
+    fn try_from(update: &str) -> Result<Self, Self::Error> {
         Self::from_str(update)
     }
 }
@@ -86,7 +86,7 @@ impl<'a> TryFrom<&'a str> for Update {
 impl<'a> TryFrom<&'a String> for Update {
     type Error = ParseError;
 
-    fn try_from(update: &String) -> Result<Self, ParseError> {
+    fn try_from(update: &String) -> Result<Self, Self::Error> {
         Self::from_str(update)
     }
 }

--- a/lib/src/io/format.rs
+++ b/lib/src/io/format.rs
@@ -258,7 +258,7 @@ impl TryFrom<DatasetFormat> for GraphFormat {
 
     /// Attempts to find a graph format that is a subset of this [`DatasetFormat`].
     #[inline]
-    fn try_from(value: DatasetFormat) -> Result<Self, ()> {
+    fn try_from(value: DatasetFormat) -> Result<Self, Self::Error> {
         match value {
             DatasetFormat::NQuads => Ok(Self::NTriples),
             DatasetFormat::TriG => Ok(Self::Turtle),
@@ -271,7 +271,7 @@ impl TryFrom<GraphFormat> for DatasetFormat {
 
     /// Attempts to find a dataset format that is a superset of this [`GraphFormat`].
     #[inline]
-    fn try_from(value: GraphFormat) -> Result<Self, ()> {
+    fn try_from(value: GraphFormat) -> Result<Self, Self::Error> {
         match value {
             GraphFormat::NTriples => Ok(Self::NQuads),
             GraphFormat::Turtle => Ok(Self::TriG),

--- a/lib/src/io/read.rs
+++ b/lib/src/io/read.rs
@@ -95,7 +95,7 @@ pub struct TripleReader<R: Read> {
 impl<R: Read> Iterator for TripleReader<R> {
     type Item = Result<Triple, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Triple, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(self.parser.next()?.map(Into::into).map_err(Into::into))
     }
 }
@@ -184,7 +184,7 @@ pub struct QuadReader<R: Read> {
 impl<R: Read> Iterator for QuadReader<R> {
     type Item = Result<Quad, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Quad, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(self.parser.next()?.map_err(Into::into))
     }
 }

--- a/lib/src/sparql/algebra.rs
+++ b/lib/src/sparql/algebra.rs
@@ -65,7 +65,7 @@ impl fmt::Display for Query {
 impl FromStr for Query {
     type Err = spargebra::ParseError;
 
-    fn from_str(query: &str) -> Result<Self, spargebra::ParseError> {
+    fn from_str(query: &str) -> Result<Self, Self::Err> {
         Self::parse(query, None)
     }
 }
@@ -73,7 +73,7 @@ impl FromStr for Query {
 impl TryFrom<&str> for Query {
     type Error = spargebra::ParseError;
 
-    fn try_from(query: &str) -> Result<Self, spargebra::ParseError> {
+    fn try_from(query: &str) -> Result<Self, Self::Error> {
         Self::from_str(query)
     }
 }
@@ -81,7 +81,7 @@ impl TryFrom<&str> for Query {
 impl TryFrom<&String> for Query {
     type Error = spargebra::ParseError;
 
-    fn try_from(query: &String) -> Result<Self, spargebra::ParseError> {
+    fn try_from(query: &String) -> Result<Self, Self::Error> {
         Self::from_str(query)
     }
 }
@@ -158,7 +158,7 @@ impl fmt::Display for Update {
 impl FromStr for Update {
     type Err = spargebra::ParseError;
 
-    fn from_str(update: &str) -> Result<Self, spargebra::ParseError> {
+    fn from_str(update: &str) -> Result<Self, Self::Err> {
         Self::parse(update, None)
     }
 }
@@ -166,7 +166,7 @@ impl FromStr for Update {
 impl TryFrom<&str> for Update {
     type Error = spargebra::ParseError;
 
-    fn try_from(update: &str) -> Result<Self, spargebra::ParseError> {
+    fn try_from(update: &str) -> Result<Self, Self::Error> {
         Self::from_str(update)
     }
 }
@@ -174,7 +174,7 @@ impl TryFrom<&str> for Update {
 impl TryFrom<&String> for Update {
     type Error = spargebra::ParseError;
 
-    fn try_from(update: &String) -> Result<Self, spargebra::ParseError> {
+    fn try_from(update: &String) -> Result<Self, Self::Error> {
         Self::from_str(update)
     }
 }

--- a/lib/src/sparql/eval.rs
+++ b/lib/src/sparql/eval.rs
@@ -4732,7 +4732,7 @@ struct CartesianProductJoinIterator {
 impl Iterator for CartesianProductJoinIterator {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(result) = self.buffered_results.pop() {
                 return Some(result);
@@ -4767,7 +4767,7 @@ struct HashJoinIterator {
 impl Iterator for HashJoinIterator {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(result) = self.buffered_results.pop() {
                 return Some(result);
@@ -4806,7 +4806,7 @@ struct HashLeftJoinIterator {
 impl Iterator for HashLeftJoinIterator {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(result) = self.buffered_results.pop() {
                 return Some(result);
@@ -4854,7 +4854,7 @@ struct ForLoopLeftJoinIterator {
 impl Iterator for ForLoopLeftJoinIterator {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if let Some(tuple) = self.current_right.next() {
             return Some(tuple);
         }
@@ -4881,7 +4881,7 @@ struct UnionIterator {
 impl Iterator for UnionIterator {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(tuple) = self.current_iterator.next() {
                 return Some(tuple);
@@ -4903,7 +4903,7 @@ struct ConsecutiveDeduplication {
 impl Iterator for ConsecutiveDeduplication {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         // Basic idea. We buffer the previous result and we only emit it when we kow the next one or it's the end
         loop {
             if let Some(next) = self.inner.next() {
@@ -4944,7 +4944,7 @@ struct ConstructIterator {
 impl Iterator for ConstructIterator {
     type Item = Result<Triple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<Triple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(result) = self.buffered_results.pop() {
                 return Some(result);
@@ -5046,7 +5046,7 @@ struct DescribeIterator {
 impl Iterator for DescribeIterator {
     type Item = Result<Triple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<Triple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(quad) = self.quads.next() {
                 return Some(match quad {
@@ -5097,7 +5097,7 @@ impl<T1, T2, I1: Iterator<Item = T1>, I2: Iterator<Item = T2>> Iterator
 {
     type Item = (Option<T1>, Option<T2>);
 
-    fn next(&mut self) -> Option<(Option<T1>, Option<T2>)> {
+    fn next(&mut self) -> Option<Self::Item> {
         match (self.a.next(), self.b.next()) {
             (None, None) => None,
             r => Some(r),
@@ -5220,7 +5220,7 @@ impl<
 {
     type Item = Result<O, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<O, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current) = &mut self.current {
                 if let Some(next) = current.next() {
@@ -5629,7 +5629,7 @@ struct StatsIterator {
 impl Iterator for StatsIterator {
     type Item = Result<EncodedTuple, EvaluationError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTuple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         let start = Timer::now();
         let result = self.inner.next();
         self.stats.exec_duration.set(

--- a/lib/src/sparql/model.rs
+++ b/lib/src/sparql/model.rs
@@ -221,7 +221,7 @@ impl Iterator for QuerySolutionIter {
     type Item = Result<QuerySolution, EvaluationError>;
 
     #[inline]
-    fn next(&mut self) -> Option<Result<QuerySolution, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 
@@ -253,7 +253,7 @@ impl Iterator for QueryTripleIter {
     type Item = Result<Triple, EvaluationError>;
 
     #[inline]
-    fn next(&mut self) -> Option<Result<Triple, EvaluationError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 

--- a/lib/src/sparql/service.rs
+++ b/lib/src/sparql/service.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 /// impl ServiceHandler for TestServiceHandler {
 ///     type Error = EvaluationError;
 ///
-///     fn handle(&self,service_name: NamedNode, query: Query) -> Result<QueryResults,EvaluationError> {
+///     fn handle(&self, service_name: NamedNode, query: Query) -> Result<QueryResults, Self::Error> {
 ///         if service_name == "http://example.com/service" {
 ///             self.store.query(query)
 ///         } else {
@@ -61,7 +61,7 @@ pub struct EmptyServiceHandler;
 impl ServiceHandler for EmptyServiceHandler {
     type Error = EvaluationError;
 
-    fn handle(&self, name: NamedNode, _: Query) -> Result<QueryResults, EvaluationError> {
+    fn handle(&self, name: NamedNode, _: Query) -> Result<QueryResults, Self::Error> {
         Err(EvaluationError::UnsupportedService(name))
     }
 }
@@ -79,11 +79,7 @@ impl<S: ServiceHandler> ErrorConversionServiceHandler<S> {
 impl<S: ServiceHandler> ServiceHandler for ErrorConversionServiceHandler<S> {
     type Error = EvaluationError;
 
-    fn handle(
-        &self,
-        service_name: NamedNode,
-        query: Query,
-    ) -> Result<QueryResults, EvaluationError> {
+    fn handle(&self, service_name: NamedNode, query: Query) -> Result<QueryResults, Self::Error> {
         self.handler
             .handle(service_name, query)
             .map_err(|e| EvaluationError::Service(Box::new(e)))
@@ -105,11 +101,7 @@ impl SimpleServiceHandler {
 impl ServiceHandler for SimpleServiceHandler {
     type Error = EvaluationError;
 
-    fn handle(
-        &self,
-        service_name: NamedNode,
-        query: Query,
-    ) -> Result<QueryResults, EvaluationError> {
+    fn handle(&self, service_name: NamedNode, query: Query) -> Result<QueryResults, Self::Error> {
         let (content_type, body) = self
             .client
             .post(

--- a/lib/src/storage/backend/rocksdb.rs
+++ b/lib/src/storage/backend/rocksdb.rs
@@ -1157,7 +1157,7 @@ impl Drop for PinnableSlice {
 impl Deref for PinnableSlice {
     type Target = [u8];
 
-    fn deref(&self) -> &[u8] {
+    fn deref(&self) -> &Self::Target {
         unsafe {
             let mut len = 0;
             let val = rocksdb_pinnableslice_value(self.0, &mut len);
@@ -1200,7 +1200,7 @@ impl Drop for Buffer {
 impl Deref for Buffer {
     type Target = [u8];
 
-    fn deref(&self) -> &[u8] {
+    fn deref(&self) -> &Self::Target {
         unsafe { slice::from_raw_parts(self.base, self.len) }
     }
 }

--- a/lib/src/storage/mod.rs
+++ b/lib/src/storage/mod.rs
@@ -814,7 +814,7 @@ impl ChainedDecodingQuadIterator {
 impl Iterator for ChainedDecodingQuadIterator {
     type Item = Result<EncodedQuad, StorageError>;
 
-    fn next(&mut self) -> Option<Result<EncodedQuad, StorageError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if let Some(result) = self.first.next() {
             Some(result)
         } else if let Some(second) = self.second.as_mut() {
@@ -833,7 +833,7 @@ pub struct DecodingQuadIterator {
 impl Iterator for DecodingQuadIterator {
     type Item = Result<EncodedQuad, StorageError>;
 
-    fn next(&mut self) -> Option<Result<EncodedQuad, StorageError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if let Err(e) = self.iter.status() {
             return Some(Err(e));
         }
@@ -850,7 +850,7 @@ pub struct DecodingGraphIterator {
 impl Iterator for DecodingGraphIterator {
     type Item = Result<EncodedTerm, StorageError>;
 
-    fn next(&mut self) -> Option<Result<EncodedTerm, StorageError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if let Err(e) = self.iter.status() {
             return Some(Err(e));
         }

--- a/lib/src/storage/small_string.rs
+++ b/lib/src/storage/small_string.rs
@@ -65,7 +65,7 @@ impl Deref for SmallString {
     type Target = str;
 
     #[inline]
-    fn deref(&self) -> &str {
+    fn deref(&self) -> &Self::Target {
         self.as_str()
     }
 }
@@ -146,7 +146,7 @@ impl FromStr for SmallString {
     type Err = BadSmallStringError;
 
     #[inline]
-    fn from_str(value: &str) -> Result<Self, BadSmallStringError> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if value.len() <= 15 {
             let mut inner = [0; 16];
             inner[..value.len()].copy_from_slice(value.as_bytes());
@@ -165,7 +165,7 @@ impl<'a> TryFrom<&'a str> for SmallString {
     type Error = BadSmallStringError;
 
     #[inline]
-    fn try_from(value: &'a str) -> Result<Self, BadSmallStringError> {
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         Self::from_str(value)
     }
 }

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -1471,7 +1471,7 @@ pub struct QuadIter {
 impl Iterator for QuadIter {
     type Item = Result<Quad, StorageError>;
 
-    fn next(&mut self) -> Option<Result<Quad, StorageError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(match self.iter.next()? {
             Ok(quad) => self.reader.decode_quad(&quad),
             Err(error) => Err(error),
@@ -1488,7 +1488,7 @@ pub struct GraphNameIter {
 impl Iterator for GraphNameIter {
     type Item = Result<NamedOrBlankNode, StorageError>;
 
-    fn next(&mut self) -> Option<Result<NamedOrBlankNode, StorageError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some(
             self.iter
                 .next()?

--- a/testsuite/src/manifest.rs
+++ b/testsuite/src/manifest.rs
@@ -58,7 +58,7 @@ pub struct TestManifest {
 impl Iterator for TestManifest {
     type Item = Result<Test>;
 
-    fn next(&mut self) -> Option<Result<Test>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(next) = self.next_test().transpose() {
                 return Some(next);
@@ -355,7 +355,7 @@ impl<'a> RdfListIterator<'a> {
 impl<'a> Iterator for RdfListIterator<'a> {
     type Item = Term;
 
-    fn next(&mut self) -> Option<Term> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.current_node {
             Some(current) => {
                 let result = self

--- a/testsuite/src/sparql_evaluator.rs
+++ b/testsuite/src/sparql_evaluator.rs
@@ -727,7 +727,7 @@ impl Drop for StoreRef {
 impl Deref for StoreRef {
     type Target = Store;
 
-    fn deref(&self) -> &Store {
+    fn deref(&self) -> &Self::Target {
         &self.store
     }
 }


### PR DESCRIPTION
To keep with DRY principle, I think it makes it a bit less redundant to reuse the Self::<associated_type_name> structure in the well known trait implementations - keeps it consistent with the trait decl too.