### PR TITLE
Linting: Impl ordering, Self refs

### DIFF
--- a/lib/oxrdf/src/dataset.rs
+++ b/lib/oxrdf/src/dataset.rs
@@ -925,8 +925,8 @@ impl PartialEq for Dataset {
 impl Eq for Dataset {}
 
 impl<'a> IntoIterator for &'a Dataset {
-    type IntoIter = Iter<'a>;
     type Item = QuadRef<'a>;
+    type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -1283,8 +1283,8 @@ impl<'a> GraphView<'a> {
 }
 
 impl<'a> IntoIterator for GraphView<'a> {
-    type IntoIter = GraphViewIter<'a>;
     type Item = TripleRef<'a>;
+    type IntoIter = GraphViewIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -1292,8 +1292,8 @@ impl<'a> IntoIterator for GraphView<'a> {
 }
 
 impl<'a, 'b> IntoIterator for &'b GraphView<'a> {
-    type IntoIter = GraphViewIter<'a>;
     type Item = TripleRef<'a>;
+    type IntoIter = GraphViewIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -1494,8 +1494,8 @@ impl<'a, 'b, T: Into<TripleRef<'b>>> Extend<T> for GraphViewMut<'a> {
 }
 
 impl<'a> IntoIterator for &'a GraphViewMut<'a> {
-    type IntoIter = GraphViewIter<'a>;
     type Item = TripleRef<'a>;
+    type IntoIter = GraphViewIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/lib/oxrdf/src/graph.rs
+++ b/lib/oxrdf/src/graph.rs
@@ -229,8 +229,8 @@ impl PartialEq for Graph {
 impl Eq for Graph {}
 
 impl<'a> IntoIterator for &'a Graph {
-    type IntoIter = Iter<'a>;
     type Item = TripleRef<'a>;
+    type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -57,7 +57,7 @@ impl TokenRecognizer for N3Lexer {
         data: &'a [u8],
         is_ending: bool,
         options: &Self::Options,
-    ) -> Option<(usize, Result<Self::Token<'a>, TokenRecognizerError>)> {
+    ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
         match *data.first()? {
             b'<' => match *data.get(1)? {
                 b'<' => Some((2, Ok(N3Token::Punctuation("<<")))),

--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -49,15 +49,15 @@ pub struct N3Lexer {
 // TODO: simplify by not giving is_end and fail with an "unexpected eof" is none is returned when is_end=true?
 
 impl TokenRecognizer for N3Lexer {
-    type Options = N3LexerOptions;
     type Token<'a> = N3Token<'a>;
+    type Options = N3LexerOptions;
 
     fn recognize_next_token<'a>(
         &mut self,
         data: &'a [u8],
         is_ending: bool,
         options: &Self::Options,
-    ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
+    ) -> Option<(usize, Result<Self::Token<'a>, TokenRecognizerError>)> {
         match *data.first()? {
             b'<' => match *data.get(1)? {
                 b'<' => Some((2, Ok(N3Token::Punctuation("<<")))),

--- a/lib/oxttl/src/line_formats.rs
+++ b/lib/oxttl/src/line_formats.rs
@@ -54,8 +54,8 @@ impl RuleRecognizer for NQuadsRecognizer {
     fn recognize_next(
         mut self,
         token: N3Token<'_>,
-        context: &mut Self::Context,
-        results: &mut Vec<Self::Output>,
+        context: &mut NQuadsRecognizerContext,
+        results: &mut Vec<Quad>,
         errors: &mut Vec<RuleRecognizerError>,
     ) -> Self {
         if let Some(state) = self.stack.pop() {
@@ -235,8 +235,8 @@ impl RuleRecognizer for NQuadsRecognizer {
 
     fn recognize_end(
         mut self,
-        _context: &mut Self::Context,
-        results: &mut Vec<Self::Output>,
+        _context: &mut NQuadsRecognizerContext,
+        results: &mut Vec<Quad>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
         match &*self.stack {
@@ -255,7 +255,7 @@ impl RuleRecognizer for NQuadsRecognizer {
         }
     }
 
-    fn lexer_options(context: &Self::Context) -> &N3LexerOptions {
+    fn lexer_options(context: &NQuadsRecognizerContext) -> &N3LexerOptions {
         &context.lexer_options
     }
 }

--- a/lib/oxttl/src/line_formats.rs
+++ b/lib/oxttl/src/line_formats.rs
@@ -39,9 +39,9 @@ enum NQuadsState {
 }
 
 impl RuleRecognizer for NQuadsRecognizer {
-    type Context = NQuadsRecognizerContext;
-    type Output = Quad;
     type TokenRecognizer = N3Lexer;
+    type Output = Quad;
+    type Context = NQuadsRecognizerContext;
 
     fn error_recovery_state(mut self) -> Self {
         self.stack.clear();
@@ -54,8 +54,8 @@ impl RuleRecognizer for NQuadsRecognizer {
     fn recognize_next(
         mut self,
         token: N3Token<'_>,
-        context: &mut NQuadsRecognizerContext,
-        results: &mut Vec<Quad>,
+        context: &mut Self::Context,
+        results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) -> Self {
         if let Some(state) = self.stack.pop() {
@@ -235,8 +235,8 @@ impl RuleRecognizer for NQuadsRecognizer {
 
     fn recognize_end(
         mut self,
-        _context: &mut NQuadsRecognizerContext,
-        results: &mut Vec<Quad>,
+        _context: &mut Self::Context,
+        results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
         match &*self.stack {
@@ -255,7 +255,7 @@ impl RuleRecognizer for NQuadsRecognizer {
         }
     }
 
-    fn lexer_options(context: &NQuadsRecognizerContext) -> &N3LexerOptions {
+    fn lexer_options(context: &Self::Context) -> &N3LexerOptions {
         &context.lexer_options
     }
 }

--- a/lib/oxttl/src/n3.rs
+++ b/lib/oxttl/src/n3.rs
@@ -722,8 +722,8 @@ impl RuleRecognizer for N3Recognizer {
     fn recognize_next(
         mut self,
         token: N3Token<'_>,
-        context: &mut Self::Context,
-        results: &mut Vec<Self::Output>,
+        context: &mut N3RecognizerContext,
+        results: &mut Vec<N3Quad>,
         errors: &mut Vec<RuleRecognizerError>,
     ) -> Self {
         while let Some(rule) = self.stack.pop() {
@@ -1195,7 +1195,7 @@ impl RuleRecognizer for N3Recognizer {
 
     fn recognize_end(
         self,
-        _state: &mut Self::Context,
+        _state: &mut N3RecognizerContext,
         _results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
@@ -1205,7 +1205,7 @@ impl RuleRecognizer for N3Recognizer {
         }
     }
 
-    fn lexer_options(context: &Self::Context) -> &N3LexerOptions {
+    fn lexer_options(context: &N3RecognizerContext) -> &N3LexerOptions {
         &context.lexer_options
     }
 }

--- a/lib/oxttl/src/n3.rs
+++ b/lib/oxttl/src/n3.rs
@@ -707,9 +707,9 @@ struct N3RecognizerContext {
 }
 
 impl RuleRecognizer for N3Recognizer {
-    type Context = N3RecognizerContext;
-    type Output = N3Quad;
     type TokenRecognizer = N3Lexer;
+    type Output = N3Quad;
+    type Context = N3RecognizerContext;
 
     fn error_recovery_state(mut self) -> Self {
         self.stack.clear();
@@ -722,8 +722,8 @@ impl RuleRecognizer for N3Recognizer {
     fn recognize_next(
         mut self,
         token: N3Token<'_>,
-        context: &mut N3RecognizerContext,
-        results: &mut Vec<N3Quad>,
+        context: &mut Self::Context,
+        results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) -> Self {
         while let Some(rule) = self.stack.pop() {
@@ -1195,7 +1195,7 @@ impl RuleRecognizer for N3Recognizer {
 
     fn recognize_end(
         self,
-        _state: &mut N3RecognizerContext,
+        _state: &mut Self::Context,
         _results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
@@ -1205,7 +1205,7 @@ impl RuleRecognizer for N3Recognizer {
         }
     }
 
-    fn lexer_options(context: &N3RecognizerContext) -> &N3LexerOptions {
+    fn lexer_options(context: &Self::Context) -> &N3LexerOptions {
         &context.lexer_options
     }
 }

--- a/lib/oxttl/src/terse.rs
+++ b/lib/oxttl/src/terse.rs
@@ -44,8 +44,8 @@ impl RuleRecognizer for TriGRecognizer {
     fn recognize_next(
         mut self,
         token: N3Token<'_>,
-        context: &mut Self::Context,
-        results: &mut Vec<Self::Output>,
+        context: &mut TriGRecognizerContext,
+        results: &mut Vec<Quad>,
         errors: &mut Vec<RuleRecognizerError>,
     ) -> Self {
         if let Some(rule) = self.stack.pop() {
@@ -792,7 +792,7 @@ impl RuleRecognizer for TriGRecognizer {
 
     fn recognize_end(
         mut self,
-        _context: &mut Self::Context,
+        _context: &mut TriGRecognizerContext,
         results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
@@ -821,7 +821,7 @@ impl RuleRecognizer for TriGRecognizer {
         }
     }
 
-    fn lexer_options(context: &Self::Context) -> &N3LexerOptions {
+    fn lexer_options(context: &TriGRecognizerContext) -> &N3LexerOptions {
         &context.lexer_options
     }
 }

--- a/lib/oxttl/src/terse.rs
+++ b/lib/oxttl/src/terse.rs
@@ -28,9 +28,9 @@ pub struct TriGRecognizerContext {
 }
 
 impl RuleRecognizer for TriGRecognizer {
-    type Context = TriGRecognizerContext;
-    type Output = Quad;
     type TokenRecognizer = N3Lexer;
+    type Output = Quad;
+    type Context = TriGRecognizerContext;
 
     fn error_recovery_state(mut self) -> Self {
         self.stack.clear();
@@ -44,8 +44,8 @@ impl RuleRecognizer for TriGRecognizer {
     fn recognize_next(
         mut self,
         token: N3Token<'_>,
-        context: &mut TriGRecognizerContext,
-        results: &mut Vec<Quad>,
+        context: &mut Self::Context,
+        results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) -> Self {
         if let Some(rule) = self.stack.pop() {
@@ -792,7 +792,7 @@ impl RuleRecognizer for TriGRecognizer {
 
     fn recognize_end(
         mut self,
-        _context: &mut TriGRecognizerContext,
+        _context: &mut Self::Context,
         results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
@@ -821,7 +821,7 @@ impl RuleRecognizer for TriGRecognizer {
         }
     }
 
-    fn lexer_options(context: &TriGRecognizerContext) -> &N3LexerOptions {
+    fn lexer_options(context: &Self::Context) -> &N3LexerOptions {
         &context.lexer_options
     }
 }

--- a/lib/sparesults/src/solution.rs
+++ b/lib/sparesults/src/solution.rs
@@ -171,8 +171,8 @@ impl<V: Into<Arc<[Variable]>>, S: Into<Vec<Option<Term>>>> From<(V, S)> for Quer
 }
 
 impl<'a> IntoIterator for &'a QuerySolution {
-    type IntoIter = Iter<'a>;
     type Item = (&'a Variable, &'a Term);
+    type IntoIter = Iter<'a>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {

--- a/lib/src/sparql/eval.rs
+++ b/lib/src/sparql/eval.rs
@@ -111,8 +111,8 @@ impl EncodedTuple {
 }
 
 impl IntoIterator for EncodedTuple {
-    type IntoIter = std::vec::IntoIter<Option<EncodedTerm>>;
     type Item = Option<EncodedTerm>;
+    type IntoIter = std::vec::IntoIter<Option<EncodedTerm>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()


### PR DESCRIPTION
For consistency, ordered implementation of a traits the same way as they are declared.

Used `Self::<assoc>` in a few last spots