### PR TITLE
Removes all debuginfo from release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,9 @@ zero_sized_map_values = "warn"
 [profile.release]
 lto = true
 codegen-units = 1
+strip = "debuginfo"
 
 [profile.release.package.oxigraph-js]
+codegen-units = 1
 opt-level = "z"
-
+strip = "debuginfo"


### PR DESCRIPTION
Smaller binaries, most of them where stripped out anyway