### PR TITLE
Optimize `write!` performance with `write_str`

### DIFF
--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -351,7 +351,7 @@ pub struct BlankNodeIdParseError;
 impl fmt::Display for BlankNodeIdParseError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "The blank node identifier is invalid")
+        f.write_str("The blank node identifier is invalid")
     }
 }
 

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -983,7 +983,7 @@ impl fmt::Display for GraphNameRef<'_> {
         match self {
             Self::NamedNode(node) => node.fmt(f),
             Self::BlankNode(node) => node.fmt(f),
-            Self::DefaultGraph => write!(f, "DEFAULT"),
+            Self::DefaultGraph => f.write_str("DEFAULT"),
         }
     }
 }

--- a/lib/oxrdf/src/variable.rs
+++ b/lib/oxrdf/src/variable.rs
@@ -218,7 +218,7 @@ pub struct VariableNameParseError;
 impl fmt::Display for VariableNameParseError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "The variable name is invalid")
+        f.write_str("The variable name is invalid")
     }
 }
 

--- a/lib/oxrdfio/src/error.rs
+++ b/lib/oxrdfio/src/error.rs
@@ -144,7 +144,7 @@ impl fmt::Display for SyntaxError {
         match &self.inner {
             SyntaxErrorKind::Turtle(e) => e.fmt(f),
             SyntaxErrorKind::RdfXml(e) => e.fmt(f),
-            SyntaxErrorKind::Msg { msg } => write!(f, "{msg}"),
+            SyntaxErrorKind::Msg { msg } => f.write_str(msg),
         }
     }
 }

--- a/lib/oxsdatatypes/src/date_time.rs
+++ b/lib/oxsdatatypes/src/date_time.rs
@@ -281,7 +281,7 @@ impl fmt::Display for DateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let year = self.year();
         if year < 0 {
-            write!(f, "-")?;
+            f.write_str("-")?;
         }
         let second = self.second();
         write!(
@@ -783,7 +783,7 @@ impl fmt::Display for Date {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let year = self.year();
         if year < 0 {
-            write!(f, "-")?;
+            f.write_str("-")?;
         }
         write!(f, "{:04}-{:02}-{:02}", year.abs(), self.month(), self.day())?;
         if let Some(timezone_offset) = self.timezone_offset() {
@@ -925,7 +925,7 @@ impl fmt::Display for GYearMonth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let year = self.year();
         if year < 0 {
-            write!(f, "-")?;
+            f.write_str("-")?;
         }
         write!(f, "{:04}-{:02}", year.abs(), self.month())?;
         if let Some(timezone_offset) = self.timezone_offset() {
@@ -1066,7 +1066,7 @@ impl fmt::Display for GYear {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let year = self.year();
         if year < 0 {
-            write!(f, "-")?;
+            f.write_str("-")?;
         }
         write!(f, "{:04}", year.abs())?;
         if let Some(timezone_offset) = self.timezone_offset() {
@@ -1544,7 +1544,7 @@ impl fmt::Display for TimezoneOffset {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.offset {
-            0 => write!(f, "Z"),
+            0 => f.write_str("Z"),
             offset if offset < 0 => write!(f, "-{:02}:{:02}", -offset / 60, -offset % 60),
             offset => write!(f, "+{:02}:{:02}", offset / 60, offset % 60),
         }
@@ -2060,7 +2060,7 @@ impl fmt::Display for ParseDateTimeError {
             }
             ParseDateTimeErrorKind::Overflow(error) => error.fmt(f),
             ParseDateTimeErrorKind::InvalidTimezone(error) => error.fmt(f),
-            ParseDateTimeErrorKind::Message(msg) => write!(f, "{msg}"),
+            ParseDateTimeErrorKind::Message(msg) => f.write_str(msg),
         }
     }
 }
@@ -2415,7 +2415,7 @@ pub struct DateTimeOverflowError;
 
 impl fmt::Display for DateTimeOverflowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "overflow during xsd:dateTime computation")
+        f.write_str("overflow during xsd:dateTime computation")
     }
 }
 

--- a/lib/oxsdatatypes/src/decimal.rs
+++ b/lib/oxsdatatypes/src/decimal.rs
@@ -638,10 +638,10 @@ const PARSE_UNEXPECTED_END: ParseDecimalError = ParseDecimalError {
 impl fmt::Display for ParseDecimalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            DecimalParseErrorKind::Overflow => write!(f, "Value overflow"),
-            DecimalParseErrorKind::Underflow => write!(f, "Value underflow"),
-            DecimalParseErrorKind::UnexpectedChar => write!(f, "Unexpected character"),
-            DecimalParseErrorKind::UnexpectedEnd => write!(f, "Unexpected end of string"),
+            DecimalParseErrorKind::Overflow => f.write_str("Value overflow"),
+            DecimalParseErrorKind::Underflow => f.write_str("Value underflow"),
+            DecimalParseErrorKind::UnexpectedChar => f.write_str("Unexpected character"),
+            DecimalParseErrorKind::UnexpectedEnd => f.write_str("Unexpected end of string"),
         }
     }
 }
@@ -664,7 +664,7 @@ pub struct TooLargeForDecimalError;
 
 impl fmt::Display for TooLargeForDecimalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Value too large for xsd:decimal internal representation")
+        f.write_str("Value too large for xsd:decimal internal representation")
     }
 }
 

--- a/lib/oxsdatatypes/src/duration.rs
+++ b/lib/oxsdatatypes/src/duration.rs
@@ -206,12 +206,12 @@ impl fmt::Display for Duration {
             return Err(fmt::Error); // Not able to format with only a part of the duration that is negative
         }
         if ym < 0 || ss < 0.into() {
-            write!(f, "-")?;
+            f.write_str("-")?;
         }
-        write!(f, "P")?;
+        f.write_str("P")?;
 
         if ym == 0 && ss == 0.into() {
-            return write!(f, "T0S");
+            return f.write_str("T0S");
         }
 
         {
@@ -245,7 +245,7 @@ impl fmt::Display for Duration {
             }
 
             if h != 0 || m != 0 || s != 0.into() {
-                write!(f, "T")?;
+                f.write_str("T")?;
                 if h != 0 {
                     write!(f, "{}H", h.abs())?;
                 }
@@ -423,7 +423,7 @@ impl fmt::Display for YearMonthDuration {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.months == 0 {
-            write!(f, "P0M")
+            f.write_str("P0M")
         } else {
             Duration::from(*self).fmt(f)
         }
@@ -948,7 +948,7 @@ const OVERFLOW_ERROR: ParseDurationError = ParseDurationError {
 
 impl fmt::Display for ParseDurationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.msg)
+        f.write_str(self.msg)
     }
 }
 
@@ -968,7 +968,7 @@ pub struct DurationOverflowError;
 
 impl fmt::Display for DurationOverflowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "overflow during xsd:duration computation")
+        f.write_str("overflow during xsd:duration computation")
     }
 }
 
@@ -980,7 +980,7 @@ pub struct OppositeSignInDurationComponentsError;
 
 impl fmt::Display for OppositeSignInDurationComponentsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "The xsd:yearMonthDuration and xsd:dayTimeDuration components of a xsd:duration can't have opposite sign")
+        f.write_str("The xsd:yearMonthDuration and xsd:dayTimeDuration components of a xsd:duration can't have opposite sign")
     }
 }
 

--- a/lib/oxsdatatypes/src/integer.rs
+++ b/lib/oxsdatatypes/src/integer.rs
@@ -269,7 +269,7 @@ pub struct TooLargeForIntegerError;
 
 impl fmt::Display for TooLargeForIntegerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Value too large for xsd:integer internal representation")
+        f.write_str("Value too large for xsd:integer internal representation")
     }
 }
 

--- a/lib/oxttl/src/trig.rs
+++ b/lib/oxttl/src/trig.rs
@@ -987,7 +987,7 @@ struct TurtlePredicate<'a> {
 impl<'a> fmt::Display for TurtlePredicate<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.named_node == rdf::TYPE {
-            write!(f, "a")
+            f.write_str("a")
         } else {
             TurtleTerm {
                 term: self.named_node.into(),
@@ -1027,7 +1027,7 @@ impl<'a> fmt::Display for TurtleTerm<'a> {
                     _ => false,
                 };
                 if inline {
-                    write!(f, "{value}")
+                    f.write_str(value)
                 } else if v.is_plain() {
                     write!(f, "{v}")
                 } else {

--- a/lib/spargebra/src/algebra.rs
+++ b/lib/spargebra/src/algebra.rs
@@ -23,45 +23,45 @@ impl PropertyPathExpression {
         match self {
             Self::NamedNode(p) => write!(f, "{p}"),
             Self::Reverse(p) => {
-                write!(f, "(reverse ")?;
+                f.write_str("(reverse ")?;
                 p.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Alternative(a, b) => {
-                write!(f, "(alt ")?;
+                f.write_str("(alt ")?;
                 a.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 b.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Sequence(a, b) => {
-                write!(f, "(seq ")?;
+                f.write_str("(seq ")?;
                 a.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 b.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::ZeroOrMore(p) => {
-                write!(f, "(path* ")?;
+                f.write_str("(path* ")?;
                 p.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::OneOrMore(p) => {
-                write!(f, "(path+ ")?;
+                f.write_str("(path+ ")?;
                 p.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::ZeroOrOne(p) => {
-                write!(f, "(path? ")?;
+                f.write_str("(path? ")?;
                 p.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::NegatedPropertySet(p) => {
-                write!(f, "(notoneof")?;
+                f.write_str("(notoneof")?;
                 for p in p {
                     write!(f, " {p}")?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -78,14 +78,14 @@ impl fmt::Display for PropertyPathExpression {
             Self::OneOrMore(p) => write!(f, "({p})+"),
             Self::ZeroOrOne(p) => write!(f, "({p})?"),
             Self::NegatedPropertySet(p) => {
-                write!(f, "!(")?;
+                f.write_str("!(")?;
                 for (i, c) in p.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " | ")?;
+                        f.write_str(" | ")?;
                     }
                     write!(f, "{c}")?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -161,13 +161,13 @@ impl Expression {
             Self::Less(a, b) => fmt_sse_binary_expression(f, "<", a, b),
             Self::LessOrEqual(a, b) => fmt_sse_binary_expression(f, "<=", a, b),
             Self::In(a, b) => {
-                write!(f, "(in ")?;
+                f.write_str("(in ")?;
                 a.fmt_sse(f)?;
                 for p in b {
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                     p.fmt_sse(f)?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Add(a, b) => fmt_sse_binary_expression(f, "+", a, b),
             Self::Subtract(a, b) => fmt_sse_binary_expression(f, "-", a, b),
@@ -177,38 +177,38 @@ impl Expression {
             Self::UnaryMinus(e) => fmt_sse_unary_expression(f, "-", e),
             Self::Not(e) => fmt_sse_unary_expression(f, "!", e),
             Self::FunctionCall(function, parameters) => {
-                write!(f, "( ")?;
+                f.write_str("( ")?;
                 function.fmt_sse(f)?;
                 for p in parameters {
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                     p.fmt_sse(f)?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Exists(p) => {
-                write!(f, "(exists ")?;
+                f.write_str("(exists ")?;
                 p.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Bound(v) => {
                 write!(f, "(bound {v})")
             }
             Self::If(a, b, c) => {
-                write!(f, "(if ")?;
+                f.write_str("(if ")?;
                 a.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 b.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 c.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Coalesce(parameters) => {
-                write!(f, "(coalesce")?;
+                f.write_str("(coalesce")?;
                 for p in parameters {
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                     p.fmt_sse(f)?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -239,7 +239,7 @@ impl fmt::Display for Expression {
             Self::In(a, b) => {
                 write!(f, "({a} IN ")?;
                 write_arg_list(b, f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Add(a, b) => {
                 write!(f, "{a} + {b}")
@@ -267,7 +267,7 @@ impl fmt::Display for Expression {
             Self::Exists(p) => write!(f, "EXISTS {{ {p} }}"),
             Self::If(a, b, c) => write!(f, "IF({a}, {b}, {c})"),
             Self::Coalesce(parameters) => {
-                write!(f, "COALESCE")?;
+                f.write_str("COALESCE")?;
                 write_arg_list(parameters, f)
             }
         }
@@ -305,16 +305,16 @@ fn write_arg_list(
     params: impl IntoIterator<Item = impl fmt::Display>,
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
-    write!(f, "(")?;
+    f.write_str("(")?;
     let mut cont = false;
     for p in params {
         if cont {
-            write!(f, ", ")?;
+            f.write_str(", ")?;
         }
         p.fmt(f)?;
         cont = true;
     }
-    write!(f, ")")
+    f.write_str(")")
 }
 
 /// A function name.
@@ -385,64 +385,64 @@ impl Function {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
-            Self::Str => write!(f, "str"),
-            Self::Lang => write!(f, "lang"),
-            Self::LangMatches => write!(f, "langmatches"),
-            Self::Datatype => write!(f, "datatype"),
-            Self::Iri => write!(f, "iri"),
-            Self::BNode => write!(f, "bnode"),
-            Self::Rand => write!(f, "rand"),
-            Self::Abs => write!(f, "abs"),
-            Self::Ceil => write!(f, "ceil"),
-            Self::Floor => write!(f, "floor"),
-            Self::Round => write!(f, "round"),
-            Self::Concat => write!(f, "concat"),
-            Self::SubStr => write!(f, "substr"),
-            Self::StrLen => write!(f, "strlen"),
-            Self::Replace => write!(f, "replace"),
-            Self::UCase => write!(f, "ucase"),
-            Self::LCase => write!(f, "lcase"),
-            Self::EncodeForUri => write!(f, "encode_for_uri"),
-            Self::Contains => write!(f, "contains"),
-            Self::StrStarts => write!(f, "strstarts"),
-            Self::StrEnds => write!(f, "strends"),
-            Self::StrBefore => write!(f, "strbefore"),
-            Self::StrAfter => write!(f, "strafter"),
-            Self::Year => write!(f, "year"),
-            Self::Month => write!(f, "month"),
-            Self::Day => write!(f, "day"),
-            Self::Hours => write!(f, "hours"),
-            Self::Minutes => write!(f, "minutes"),
-            Self::Seconds => write!(f, "seconds"),
-            Self::Timezone => write!(f, "timezone"),
-            Self::Tz => write!(f, "tz"),
-            Self::Now => write!(f, "now"),
-            Self::Uuid => write!(f, "uuid"),
-            Self::StrUuid => write!(f, "struuid"),
-            Self::Md5 => write!(f, "md5"),
-            Self::Sha1 => write!(f, "sha1"),
-            Self::Sha256 => write!(f, "sha256"),
-            Self::Sha384 => write!(f, "sha384"),
-            Self::Sha512 => write!(f, "sha512"),
-            Self::StrLang => write!(f, "strlang"),
-            Self::StrDt => write!(f, "strdt"),
-            Self::IsIri => write!(f, "isiri"),
-            Self::IsBlank => write!(f, "isblank"),
-            Self::IsLiteral => write!(f, "isliteral"),
-            Self::IsNumeric => write!(f, "isnumeric"),
-            Self::Regex => write!(f, "regex"),
+            Self::Str => f.write_str("str"),
+            Self::Lang => f.write_str("lang"),
+            Self::LangMatches => f.write_str("langmatches"),
+            Self::Datatype => f.write_str("datatype"),
+            Self::Iri => f.write_str("iri"),
+            Self::BNode => f.write_str("bnode"),
+            Self::Rand => f.write_str("rand"),
+            Self::Abs => f.write_str("abs"),
+            Self::Ceil => f.write_str("ceil"),
+            Self::Floor => f.write_str("floor"),
+            Self::Round => f.write_str("round"),
+            Self::Concat => f.write_str("concat"),
+            Self::SubStr => f.write_str("substr"),
+            Self::StrLen => f.write_str("strlen"),
+            Self::Replace => f.write_str("replace"),
+            Self::UCase => f.write_str("ucase"),
+            Self::LCase => f.write_str("lcase"),
+            Self::EncodeForUri => f.write_str("encode_for_uri"),
+            Self::Contains => f.write_str("contains"),
+            Self::StrStarts => f.write_str("strstarts"),
+            Self::StrEnds => f.write_str("strends"),
+            Self::StrBefore => f.write_str("strbefore"),
+            Self::StrAfter => f.write_str("strafter"),
+            Self::Year => f.write_str("year"),
+            Self::Month => f.write_str("month"),
+            Self::Day => f.write_str("day"),
+            Self::Hours => f.write_str("hours"),
+            Self::Minutes => f.write_str("minutes"),
+            Self::Seconds => f.write_str("seconds"),
+            Self::Timezone => f.write_str("timezone"),
+            Self::Tz => f.write_str("tz"),
+            Self::Now => f.write_str("now"),
+            Self::Uuid => f.write_str("uuid"),
+            Self::StrUuid => f.write_str("struuid"),
+            Self::Md5 => f.write_str("md5"),
+            Self::Sha1 => f.write_str("sha1"),
+            Self::Sha256 => f.write_str("sha256"),
+            Self::Sha384 => f.write_str("sha384"),
+            Self::Sha512 => f.write_str("sha512"),
+            Self::StrLang => f.write_str("strlang"),
+            Self::StrDt => f.write_str("strdt"),
+            Self::IsIri => f.write_str("isiri"),
+            Self::IsBlank => f.write_str("isblank"),
+            Self::IsLiteral => f.write_str("isliteral"),
+            Self::IsNumeric => f.write_str("isnumeric"),
+            Self::Regex => f.write_str("regex"),
             #[cfg(feature = "rdf-star")]
-            Self::Triple => write!(f, "triple"),
+            Self::Triple => f.write_str("triple"),
             #[cfg(feature = "rdf-star")]
-            Self::Subject => write!(f, "subject"),
+            Self::Subject => f.write_str("subject"),
             #[cfg(feature = "rdf-star")]
-            Self::Predicate => write!(f, "predicate"),
+            Self::Predicate => f.write_str("predicate"),
             #[cfg(feature = "rdf-star")]
-            Self::Object => write!(f, "object"),
+            Self::Object => f.write_str("object"),
             #[cfg(feature = "rdf-star")]
-            Self::IsTriple => write!(f, "istriple"),
+            Self::IsTriple => f.write_str("istriple"),
             #[cfg(feature = "sep-0002")]
-            Self::Adjust => write!(f, "adjust"),
+            Self::Adjust => f.write_str("adjust"),
             Self::Custom(iri) => write!(f, "{iri}"),
         }
     }
@@ -451,64 +451,64 @@ impl Function {
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Str => write!(f, "STR"),
-            Self::Lang => write!(f, "LANG"),
-            Self::LangMatches => write!(f, "LANGMATCHES"),
-            Self::Datatype => write!(f, "DATATYPE"),
-            Self::Iri => write!(f, "IRI"),
-            Self::BNode => write!(f, "BNODE"),
-            Self::Rand => write!(f, "RAND"),
-            Self::Abs => write!(f, "ABS"),
-            Self::Ceil => write!(f, "CEIL"),
-            Self::Floor => write!(f, "FLOOR"),
-            Self::Round => write!(f, "ROUND"),
-            Self::Concat => write!(f, "CONCAT"),
-            Self::SubStr => write!(f, "SUBSTR"),
-            Self::StrLen => write!(f, "STRLEN"),
-            Self::Replace => write!(f, "REPLACE"),
-            Self::UCase => write!(f, "UCASE"),
-            Self::LCase => write!(f, "LCASE"),
-            Self::EncodeForUri => write!(f, "ENCODE_FOR_URI"),
-            Self::Contains => write!(f, "CONTAINS"),
-            Self::StrStarts => write!(f, "STRSTARTS"),
-            Self::StrEnds => write!(f, "STRENDS"),
-            Self::StrBefore => write!(f, "STRBEFORE"),
-            Self::StrAfter => write!(f, "STRAFTER"),
-            Self::Year => write!(f, "YEAR"),
-            Self::Month => write!(f, "MONTH"),
-            Self::Day => write!(f, "DAY"),
-            Self::Hours => write!(f, "HOURS"),
-            Self::Minutes => write!(f, "MINUTES"),
-            Self::Seconds => write!(f, "SECONDS"),
-            Self::Timezone => write!(f, "TIMEZONE"),
-            Self::Tz => write!(f, "TZ"),
-            Self::Now => write!(f, "NOW"),
-            Self::Uuid => write!(f, "UUID"),
-            Self::StrUuid => write!(f, "STRUUID"),
-            Self::Md5 => write!(f, "MD5"),
-            Self::Sha1 => write!(f, "SHA1"),
-            Self::Sha256 => write!(f, "SHA256"),
-            Self::Sha384 => write!(f, "SHA384"),
-            Self::Sha512 => write!(f, "SHA512"),
-            Self::StrLang => write!(f, "STRLANG"),
-            Self::StrDt => write!(f, "STRDT"),
-            Self::IsIri => write!(f, "isIRI"),
-            Self::IsBlank => write!(f, "isBLANK"),
-            Self::IsLiteral => write!(f, "isLITERAL"),
-            Self::IsNumeric => write!(f, "isNUMERIC"),
-            Self::Regex => write!(f, "REGEX"),
+            Self::Str => f.write_str("STR"),
+            Self::Lang => f.write_str("LANG"),
+            Self::LangMatches => f.write_str("LANGMATCHES"),
+            Self::Datatype => f.write_str("DATATYPE"),
+            Self::Iri => f.write_str("IRI"),
+            Self::BNode => f.write_str("BNODE"),
+            Self::Rand => f.write_str("RAND"),
+            Self::Abs => f.write_str("ABS"),
+            Self::Ceil => f.write_str("CEIL"),
+            Self::Floor => f.write_str("FLOOR"),
+            Self::Round => f.write_str("ROUND"),
+            Self::Concat => f.write_str("CONCAT"),
+            Self::SubStr => f.write_str("SUBSTR"),
+            Self::StrLen => f.write_str("STRLEN"),
+            Self::Replace => f.write_str("REPLACE"),
+            Self::UCase => f.write_str("UCASE"),
+            Self::LCase => f.write_str("LCASE"),
+            Self::EncodeForUri => f.write_str("ENCODE_FOR_URI"),
+            Self::Contains => f.write_str("CONTAINS"),
+            Self::StrStarts => f.write_str("STRSTARTS"),
+            Self::StrEnds => f.write_str("STRENDS"),
+            Self::StrBefore => f.write_str("STRBEFORE"),
+            Self::StrAfter => f.write_str("STRAFTER"),
+            Self::Year => f.write_str("YEAR"),
+            Self::Month => f.write_str("MONTH"),
+            Self::Day => f.write_str("DAY"),
+            Self::Hours => f.write_str("HOURS"),
+            Self::Minutes => f.write_str("MINUTES"),
+            Self::Seconds => f.write_str("SECONDS"),
+            Self::Timezone => f.write_str("TIMEZONE"),
+            Self::Tz => f.write_str("TZ"),
+            Self::Now => f.write_str("NOW"),
+            Self::Uuid => f.write_str("UUID"),
+            Self::StrUuid => f.write_str("STRUUID"),
+            Self::Md5 => f.write_str("MD5"),
+            Self::Sha1 => f.write_str("SHA1"),
+            Self::Sha256 => f.write_str("SHA256"),
+            Self::Sha384 => f.write_str("SHA384"),
+            Self::Sha512 => f.write_str("SHA512"),
+            Self::StrLang => f.write_str("STRLANG"),
+            Self::StrDt => f.write_str("STRDT"),
+            Self::IsIri => f.write_str("isIRI"),
+            Self::IsBlank => f.write_str("isBLANK"),
+            Self::IsLiteral => f.write_str("isLITERAL"),
+            Self::IsNumeric => f.write_str("isNUMERIC"),
+            Self::Regex => f.write_str("REGEX"),
             #[cfg(feature = "rdf-star")]
-            Self::Triple => write!(f, "TRIPLE"),
+            Self::Triple => f.write_str("TRIPLE"),
             #[cfg(feature = "rdf-star")]
-            Self::Subject => write!(f, "SUBJECT"),
+            Self::Subject => f.write_str("SUBJECT"),
             #[cfg(feature = "rdf-star")]
-            Self::Predicate => write!(f, "PREDICATE"),
+            Self::Predicate => f.write_str("PREDICATE"),
             #[cfg(feature = "rdf-star")]
-            Self::Object => write!(f, "OBJECT"),
+            Self::Object => f.write_str("OBJECT"),
             #[cfg(feature = "rdf-star")]
-            Self::IsTriple => write!(f, "isTRIPLE"),
+            Self::IsTriple => f.write_str("isTRIPLE"),
             #[cfg(feature = "sep-0002")]
-            Self::Adjust => write!(f, "ADJUST"),
+            Self::Adjust => f.write_str("ADJUST"),
             Self::Custom(iri) => iri.fmt(f),
         }
     }
@@ -665,29 +665,29 @@ impl fmt::Display for GraphPattern {
                 variables,
                 bindings,
             } => {
-                write!(f, "VALUES ( ")?;
+                f.write_str("VALUES ( ")?;
                 for var in variables {
                     write!(f, "{var} ")?;
                 }
-                write!(f, ") {{ ")?;
+                f.write_str(") { ")?;
                 for row in bindings {
-                    write!(f, "( ")?;
+                    f.write_str("( ")?;
                     for val in row {
                         match val {
                             Some(val) => write!(f, "{val} "),
-                            None => write!(f, "UNDEF "),
+                            None => f.write_str("UNDEF "),
                         }?;
                     }
-                    write!(f, ") ")?;
+                    f.write_str(") ")?;
                 }
-                write!(f, " }}")
+                f.write_str(" }")
             }
             Self::Group {
                 inner,
                 variables,
                 aggregates,
             } => {
-                write!(f, "{{SELECT")?;
+                f.write_str("{SELECT")?;
                 for (a, v) in aggregates {
                     write!(f, " ({v} AS {a})")?;
                 }
@@ -696,12 +696,12 @@ impl fmt::Display for GraphPattern {
                 }
                 write!(f, " WHERE {{ {inner} }}")?;
                 if !variables.is_empty() {
-                    write!(f, " GROUP BY")?;
+                    f.write_str(" GROUP BY")?;
                     for v in variables {
                         write!(f, " {v}")?;
                     }
                 }
-                write!(f, "}}")
+                f.write_str("}")
             }
             p => write!(
                 f,
@@ -728,76 +728,76 @@ impl GraphPattern {
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
             Self::Bgp { patterns } => {
-                write!(f, "(bgp")?;
+                f.write_str("(bgp")?;
                 for pattern in patterns {
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                     pattern.fmt_sse(f)?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Path {
                 subject,
                 path,
                 object,
             } => {
-                write!(f, "(path ")?;
+                f.write_str("(path ")?;
                 subject.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 path.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 object.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Join { left, right } => {
-                write!(f, "(join ")?;
+                f.write_str("(join ")?;
                 left.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 right.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::LeftJoin {
                 left,
                 right,
                 expression,
             } => {
-                write!(f, "(leftjoin ")?;
+                f.write_str("(leftjoin ")?;
                 left.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 right.fmt_sse(f)?;
                 if let Some(expr) = expression {
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                     expr.fmt_sse(f)?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             #[cfg(feature = "sep-0006")]
             Self::Lateral { left, right } => {
-                write!(f, "(lateral ")?;
+                f.write_str("(lateral ")?;
                 left.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 right.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Filter { expr, inner } => {
-                write!(f, "(filter ")?;
+                f.write_str("(filter ")?;
                 expr.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Union { left, right } => {
-                write!(f, "(union ")?;
+                f.write_str("(union ")?;
                 left.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 right.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Graph { name, inner } => {
-                write!(f, "(graph ")?;
+                f.write_str("(graph ")?;
                 name.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Extend {
                 inner,
@@ -806,109 +806,109 @@ impl GraphPattern {
             } => {
                 write!(f, "(extend (({variable} ")?;
                 expression.fmt_sse(f)?;
-                write!(f, ")) ")?;
+                f.write_str(")) ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Minus { left, right } => {
-                write!(f, "(minus ")?;
+                f.write_str("(minus ")?;
                 left.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 right.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Service {
                 name,
                 inner,
                 silent,
             } => {
-                write!(f, "(service ")?;
+                f.write_str("(service ")?;
                 if *silent {
-                    write!(f, "silent ")?;
+                    f.write_str("silent ")?;
                 }
                 name.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Group {
                 inner,
                 variables,
                 aggregates,
             } => {
-                write!(f, "(group (")?;
+                f.write_str("(group (")?;
                 for (i, v) in variables.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     write!(f, "{v}")?;
                 }
-                write!(f, ") (")?;
+                f.write_str(") (")?;
                 for (i, (v, a)) in aggregates.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
-                    write!(f, "(")?;
+                    f.write_str("(")?;
                     a.fmt_sse(f)?;
                     write!(f, " {v})")?;
                 }
-                write!(f, ") ")?;
+                f.write_str(") ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Values {
                 variables,
                 bindings,
             } => {
-                write!(f, "(table (vars")?;
+                f.write_str("(table (vars")?;
                 for var in variables {
                     write!(f, " {var}")?;
                 }
-                write!(f, ")")?;
+                f.write_str(")")?;
                 for row in bindings {
-                    write!(f, " (row")?;
+                    f.write_str(" (row")?;
                     for (value, var) in row.iter().zip(variables) {
                         if let Some(value) = value {
                             write!(f, " ({var} {value})")?;
                         }
                     }
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::OrderBy { inner, expression } => {
-                write!(f, "(order (")?;
+                f.write_str("(order (")?;
                 for (i, c) in expression.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     c.fmt_sse(f)?;
                 }
-                write!(f, ") ")?;
+                f.write_str(") ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Project { inner, variables } => {
-                write!(f, "(project (")?;
+                f.write_str("(project (")?;
                 for (i, v) in variables.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     write!(f, "{v}")?;
                 }
-                write!(f, ") ")?;
+                f.write_str(") ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Distinct { inner } => {
-                write!(f, "(distinct ")?;
+                f.write_str("(distinct ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Reduced { inner } => {
-                write!(f, "(reduced ")?;
+                f.write_str("(reduced ")?;
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Slice {
                 inner,
@@ -921,7 +921,7 @@ impl GraphPattern {
                     write!(f, "(slice {start} _ ")?;
                 }
                 inner.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -1074,15 +1074,15 @@ impl<'a> fmt::Display for SparqlGraphRootPattern<'a> {
                     child = inner;
                 }
                 p => {
-                    write!(f, "SELECT")?;
+                    f.write_str("SELECT")?;
                     if distinct {
-                        write!(f, " DISTINCT")?;
+                        f.write_str(" DISTINCT")?;
                     }
                     if reduced {
-                        write!(f, " REDUCED")?;
+                        f.write_str(" REDUCED")?;
                     }
                     if project.is_empty() {
-                        write!(f, " *")?;
+                        f.write_str(" *")?;
                     } else {
                         for v in project {
                             write!(f, " {v}")?;
@@ -1093,7 +1093,7 @@ impl<'a> fmt::Display for SparqlGraphRootPattern<'a> {
                     }
                     write!(f, " WHERE {{ {p} }}")?;
                     if let Some(order) = order {
-                        write!(f, " ORDER BY")?;
+                        f.write_str(" ORDER BY")?;
                         for c in order {
                             write!(f, " {c}")?;
                         }
@@ -1128,11 +1128,11 @@ impl AggregateExpression {
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
             Self::CountSolutions { distinct } => {
-                write!(f, "(count")?;
+                f.write_str("(count")?;
                 if *distinct {
-                    write!(f, " distinct")?;
+                    f.write_str(" distinct")?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::FunctionCall {
                 name:
@@ -1142,9 +1142,9 @@ impl AggregateExpression {
                 expr,
                 distinct,
             } => {
-                write!(f, "(group_concat ")?;
+                f.write_str("(group_concat ")?;
                 if *distinct {
-                    write!(f, "distinct ")?;
+                    f.write_str("distinct ")?;
                 }
                 expr.fmt_sse(f)?;
                 write!(f, " {})", LiteralRef::new_simple_literal(separator))
@@ -1154,14 +1154,14 @@ impl AggregateExpression {
                 expr,
                 distinct,
             } => {
-                write!(f, "(")?;
+                f.write_str("(")?;
                 name.fmt_sse(f)?;
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 if *distinct {
-                    write!(f, "distinct ")?;
+                    f.write_str("distinct ")?;
                 }
                 expr.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -1172,9 +1172,9 @@ impl fmt::Display for AggregateExpression {
         match self {
             Self::CountSolutions { distinct } => {
                 if *distinct {
-                    write!(f, "COUNT(DISTINCT *)")
+                    f.write_str("COUNT(DISTINCT *)")
                 } else {
-                    write!(f, "COUNT(*)")
+                    f.write_str("COUNT(*)")
                 }
             }
             Self::FunctionCall {
@@ -1242,13 +1242,13 @@ impl AggregateFunction {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
-            Self::Count => write!(f, "count"),
-            Self::Sum => write!(f, "sum"),
-            Self::Avg => write!(f, "avg"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
-            Self::GroupConcat { .. } => write!(f, "group_concat"),
-            Self::Sample => write!(f, "sample"),
+            Self::Count => f.write_str("count"),
+            Self::Sum => f.write_str("sum"),
+            Self::Avg => f.write_str("avg"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
+            Self::GroupConcat { .. } => f.write_str("group_concat"),
+            Self::Sample => f.write_str("sample"),
             Self::Custom(iri) => write!(f, "{iri}"),
         }
     }
@@ -1257,13 +1257,13 @@ impl AggregateFunction {
 impl fmt::Display for AggregateFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Count => write!(f, "COUNT"),
-            Self::Sum => write!(f, "SUM"),
-            Self::Avg => write!(f, "AVG"),
-            Self::Min => write!(f, "MIN"),
-            Self::Max => write!(f, "MAX"),
-            Self::GroupConcat { .. } => write!(f, "GROUP_CONCAT"),
-            Self::Sample => write!(f, "SAMPLE"),
+            Self::Count => f.write_str("COUNT"),
+            Self::Sum => f.write_str("SUM"),
+            Self::Avg => f.write_str("AVG"),
+            Self::Min => f.write_str("MIN"),
+            Self::Max => f.write_str("MAX"),
+            Self::GroupConcat { .. } => f.write_str("GROUP_CONCAT"),
+            Self::Sample => f.write_str("SAMPLE"),
             Self::Custom(iri) => iri.fmt(f),
         }
     }
@@ -1283,14 +1283,14 @@ impl OrderExpression {
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
             Self::Asc(e) => {
-                write!(f, "(asc ")?;
+                f.write_str("(asc ")?;
                 e.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Desc(e) => {
-                write!(f, "(desc ")?;
+                f.write_str("(desc ")?;
                 e.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -1315,22 +1315,22 @@ pub struct QueryDataset {
 impl QueryDataset {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        write!(f, "(")?;
+        f.write_str("(")?;
         for (i, graph_name) in self.default.iter().enumerate() {
             if i > 0 {
-                write!(f, " ")?;
+                f.write_str(" ")?;
             }
             write!(f, "{graph_name}")?;
         }
         if let Some(named) = &self.named {
             for (i, graph_name) in named.iter().enumerate() {
                 if !self.default.is_empty() || i > 0 {
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                 }
                 write!(f, "(named {graph_name})")?;
             }
         }
-        write!(f, ")")
+        f.write_str(")")
     }
 }
 
@@ -1364,9 +1364,9 @@ impl GraphTarget {
     pub(crate) fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
             Self::NamedNode(node) => write!(f, "{node}"),
-            Self::DefaultGraph => write!(f, "default"),
-            Self::NamedGraphs => write!(f, "named"),
-            Self::AllGraphs => write!(f, "all"),
+            Self::DefaultGraph => f.write_str("default"),
+            Self::NamedGraphs => f.write_str("named"),
+            Self::AllGraphs => f.write_str("all"),
         }
     }
 }
@@ -1375,9 +1375,9 @@ impl fmt::Display for GraphTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NamedNode(node) => write!(f, "GRAPH {node}"),
-            Self::DefaultGraph => write!(f, "DEFAULT"),
-            Self::NamedGraphs => write!(f, "NAMED"),
-            Self::AllGraphs => write!(f, "ALL"),
+            Self::DefaultGraph => f.write_str("DEFAULT"),
+            Self::NamedGraphs => f.write_str("NAMED"),
+            Self::AllGraphs => f.write_str("ALL"),
         }
     }
 }
@@ -1401,7 +1401,7 @@ impl From<GraphName> for GraphTarget {
 fn fmt_sse_unary_expression(f: &mut impl fmt::Write, name: &str, e: &Expression) -> fmt::Result {
     write!(f, "({name} ")?;
     e.fmt_sse(f)?;
-    write!(f, ")")
+    f.write_str(")")
 }
 
 #[inline]
@@ -1413,7 +1413,7 @@ fn fmt_sse_binary_expression(
 ) -> fmt::Result {
     write!(f, "({name} ")?;
     a.fmt_sse(f)?;
-    write!(f, " ")?;
+    f.write_str(" ")?;
     b.fmt_sse(f)?;
-    write!(f, ")")
+    f.write_str(")")
 }

--- a/lib/spargebra/src/query.rs
+++ b/lib/spargebra/src/query.rs
@@ -86,16 +86,16 @@ impl Query {
                     write!(f, "(base <{base_iri}> ")?;
                 }
                 if let Some(dataset) = dataset {
-                    write!(f, "(dataset ")?;
+                    f.write_str("(dataset ")?;
                     dataset.fmt_sse(f)?;
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                 }
                 pattern.fmt_sse(f)?;
                 if dataset.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
                 if base_iri.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
                 Ok(())
             }
@@ -108,26 +108,26 @@ impl Query {
                 if let Some(base_iri) = base_iri {
                     write!(f, "(base <{base_iri}> ")?;
                 }
-                write!(f, "(construct (")?;
+                f.write_str("(construct (")?;
                 for (i, t) in template.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     t.fmt_sse(f)?;
                 }
-                write!(f, ") ")?;
+                f.write_str(") ")?;
                 if let Some(dataset) = dataset {
-                    write!(f, "(dataset ")?;
+                    f.write_str("(dataset ")?;
                     dataset.fmt_sse(f)?;
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                 }
                 pattern.fmt_sse(f)?;
                 if dataset.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
-                write!(f, ")")?;
+                f.write_str(")")?;
                 if base_iri.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
                 Ok(())
             }
@@ -139,19 +139,19 @@ impl Query {
                 if let Some(base_iri) = base_iri {
                     write!(f, "(base <{base_iri}> ")?;
                 }
-                write!(f, "(describe ")?;
+                f.write_str("(describe ")?;
                 if let Some(dataset) = dataset {
-                    write!(f, "(dataset ")?;
+                    f.write_str("(dataset ")?;
                     dataset.fmt_sse(f)?;
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                 }
                 pattern.fmt_sse(f)?;
                 if dataset.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
-                write!(f, ")")?;
+                f.write_str(")")?;
                 if base_iri.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
                 Ok(())
             }
@@ -163,19 +163,19 @@ impl Query {
                 if let Some(base_iri) = base_iri {
                     write!(f, "(base <{base_iri}> ")?;
                 }
-                write!(f, "(ask ")?;
+                f.write_str("(ask ")?;
                 if let Some(dataset) = dataset {
-                    write!(f, "(dataset ")?;
+                    f.write_str("(dataset ")?;
                     dataset.fmt_sse(f)?;
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                 }
                 pattern.fmt_sse(f)?;
                 if dataset.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
-                write!(f, ")")?;
+                f.write_str(")")?;
                 if base_iri.is_some() {
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
                 Ok(())
             }
@@ -212,11 +212,11 @@ impl fmt::Display for Query {
                 if let Some(base_iri) = base_iri {
                     writeln!(f, "BASE <{base_iri}>")?;
                 }
-                write!(f, "CONSTRUCT {{ ")?;
+                f.write_str("CONSTRUCT { ")?;
                 for triple in template {
                     write!(f, "{triple} . ")?;
                 }
-                write!(f, "}}")?;
+                f.write_str("}")?;
                 if let Some(dataset) = dataset {
                     dataset.fmt(f)?;
                 }
@@ -237,7 +237,7 @@ impl fmt::Display for Query {
                 if let Some(base_iri) = base_iri {
                     writeln!(f, "BASE <{}>", base_iri.as_str())?;
                 }
-                write!(f, "DESCRIBE *")?;
+                f.write_str("DESCRIBE *")?;
                 if let Some(dataset) = dataset {
                     dataset.fmt(f)?;
                 }
@@ -258,7 +258,7 @@ impl fmt::Display for Query {
                 if let Some(base_iri) = base_iri {
                     writeln!(f, "BASE <{base_iri}>")?;
                 }
-                write!(f, "ASK")?;
+                f.write_str("ASK")?;
                 if let Some(dataset) = dataset {
                     dataset.fmt(f)?;
                 }

--- a/lib/spargebra/src/term.rs
+++ b/lib/spargebra/src/term.rs
@@ -196,7 +196,7 @@ impl GraphName {
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         match self {
             Self::NamedNode(node) => write!(f, "{node}"),
-            Self::DefaultGraph => write!(f, "default"),
+            Self::DefaultGraph => f.write_str("default"),
         }
     }
 }
@@ -206,7 +206,7 @@ impl fmt::Display for GraphName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NamedNode(node) => node.fmt(f),
-            Self::DefaultGraph => write!(f, "DEFAULT"),
+            Self::DefaultGraph => f.write_str("DEFAULT"),
         }
     }
 }
@@ -261,9 +261,9 @@ impl Quad {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         if self.graph_name != GraphName::DefaultGraph {
-            write!(f, "(graph ")?;
+            f.write_str("(graph ")?;
             self.graph_name.fmt_sse(f)?;
-            write!(f, " (")?;
+            f.write_str(" (")?;
         }
         write!(
             f,
@@ -271,7 +271,7 @@ impl Quad {
             self.subject, self.predicate, self.object
         )?;
         if self.graph_name != GraphName::DefaultGraph {
-            write!(f, "))")?;
+            f.write_str("))")?;
         }
         Ok(())
     }
@@ -336,9 +336,9 @@ impl GroundQuad {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         if self.graph_name != GraphName::DefaultGraph {
-            write!(f, "(graph ")?;
+            f.write_str("(graph ")?;
             self.graph_name.fmt_sse(f)?;
-            write!(f, " (")?;
+            f.write_str(" (")?;
         }
         write!(
             f,
@@ -346,7 +346,7 @@ impl GroundQuad {
             self.subject, self.predicate, self.object
         )?;
         if self.graph_name != GraphName::DefaultGraph {
-            write!(f, "))")?;
+            f.write_str("))")?;
         }
         Ok(())
     }
@@ -712,7 +712,7 @@ impl GraphNamePattern {
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         match self {
             Self::NamedNode(node) => write!(f, "{node}"),
-            Self::DefaultGraph => write!(f, "default"),
+            Self::DefaultGraph => f.write_str("default"),
             Self::Variable(var) => write!(f, "{var}"),
         }
     }
@@ -723,7 +723,7 @@ impl fmt::Display for GraphNamePattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NamedNode(node) => node.fmt(f),
-            Self::DefaultGraph => write!(f, "DEFAULT"),
+            Self::DefaultGraph => f.write_str("DEFAULT"),
             Self::Variable(var) => var.fmt(f),
         }
     }
@@ -786,13 +786,13 @@ impl TriplePattern {
 
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
-        write!(f, "(triple ")?;
+        f.write_str("(triple ")?;
         self.subject.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.predicate.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.object.fmt_sse(f)?;
-        write!(f, ")")
+        f.write_str(")")
     }
 }
 
@@ -850,13 +850,13 @@ impl GroundTriplePattern {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     #[allow(dead_code)]
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
-        write!(f, "(triple ")?;
+        f.write_str("(triple ")?;
         self.subject.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.predicate.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.object.fmt_sse(f)?;
-        write!(f, ")")
+        f.write_str(")")
     }
 }
 
@@ -918,19 +918,19 @@ impl QuadPattern {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         if self.graph_name != GraphNamePattern::DefaultGraph {
-            write!(f, "(graph ")?;
+            f.write_str("(graph ")?;
             self.graph_name.fmt_sse(f)?;
-            write!(f, " (")?;
+            f.write_str(" (")?;
         }
-        write!(f, "(triple ")?;
+        f.write_str("(triple ")?;
         self.subject.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.predicate.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.object.fmt_sse(f)?;
-        write!(f, ")")?;
+        f.write_str(")")?;
         if self.graph_name != GraphNamePattern::DefaultGraph {
-            write!(f, "))")?;
+            f.write_str("))")?;
         }
         Ok(())
     }
@@ -964,19 +964,19 @@ impl GroundQuadPattern {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         if self.graph_name != GraphNamePattern::DefaultGraph {
-            write!(f, "(graph ")?;
+            f.write_str("(graph ")?;
             self.graph_name.fmt_sse(f)?;
-            write!(f, " (")?;
+            f.write_str(" (")?;
         }
-        write!(f, "(triple ")?;
+        f.write_str("(triple ")?;
         self.subject.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.predicate.fmt_sse(f)?;
-        write!(f, " ")?;
+        f.write_str(" ")?;
         self.object.fmt_sse(f)?;
-        write!(f, ")")?;
+        f.write_str(")")?;
         if self.graph_name != GraphNamePattern::DefaultGraph {
-            write!(f, "))")?;
+            f.write_str("))")?;
         }
         Ok(())
     }

--- a/lib/spargebra/src/update.rs
+++ b/lib/spargebra/src/update.rs
@@ -42,14 +42,14 @@ impl Update {
         if let Some(base_iri) = &self.base_iri {
             write!(f, "(base <{base_iri}> ")?;
         }
-        write!(f, "(update")?;
+        f.write_str("(update")?;
         for op in &self.operations {
-            write!(f, " ")?;
+            f.write_str(" ")?;
             op.fmt_sse(f)?;
         }
-        write!(f, ")")?;
+        f.write_str(")")?;
         if self.base_iri.is_some() {
-            write!(f, ")")?;
+            f.write_str(")")?;
         }
         Ok(())
     }
@@ -124,24 +124,24 @@ impl GraphUpdateOperation {
     fn fmt_sse(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
             Self::InsertData { data } => {
-                write!(f, "(insertData (")?;
+                f.write_str("(insertData (")?;
                 for (i, t) in data.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     t.fmt_sse(f)?;
                 }
-                write!(f, "))")
+                f.write_str("))")
             }
             Self::DeleteData { data } => {
-                write!(f, "(deleteData (")?;
+                f.write_str("(deleteData (")?;
                 for (i, t) in data.iter().enumerate() {
                     if i > 0 {
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     t.fmt_sse(f)?;
                 }
-                write!(f, "))")
+                f.write_str("))")
             }
             Self::DeleteInsert {
                 delete,
@@ -149,73 +149,73 @@ impl GraphUpdateOperation {
                 using,
                 pattern,
             } => {
-                write!(f, "(modify ")?;
+                f.write_str("(modify ")?;
                 if let Some(using) = using {
-                    write!(f, " (using ")?;
+                    f.write_str(" (using ")?;
                     using.fmt_sse(f)?;
-                    write!(f, " ")?;
+                    f.write_str(" ")?;
                     pattern.fmt_sse(f)?;
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 } else {
                     pattern.fmt_sse(f)?;
                 }
                 if !delete.is_empty() {
-                    write!(f, " (delete (")?;
+                    f.write_str(" (delete (")?;
                     for (i, t) in delete.iter().enumerate() {
                         if i > 0 {
-                            write!(f, " ")?;
+                            f.write_str(" ")?;
                         }
                         t.fmt_sse(f)?;
                     }
-                    write!(f, "))")?;
+                    f.write_str("))")?;
                 }
                 if !insert.is_empty() {
-                    write!(f, " (insert (")?;
+                    f.write_str(" (insert (")?;
                     for (i, t) in insert.iter().enumerate() {
                         if i > 0 {
-                            write!(f, " ")?;
+                            f.write_str(" ")?;
                         }
                         t.fmt_sse(f)?;
                     }
-                    write!(f, "))")?;
+                    f.write_str("))")?;
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Load {
                 silent,
                 source,
                 destination,
             } => {
-                write!(f, "(load ")?;
+                f.write_str("(load ")?;
                 if *silent {
-                    write!(f, "silent ")?;
+                    f.write_str("silent ")?;
                 }
                 write!(f, "{source} ")?;
                 destination.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Clear { silent, graph } => {
-                write!(f, "(clear ")?;
+                f.write_str("(clear ")?;
                 if *silent {
-                    write!(f, "silent ")?;
+                    f.write_str("silent ")?;
                 }
                 graph.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Self::Create { silent, graph } => {
-                write!(f, "(create ")?;
+                f.write_str("(create ")?;
                 if *silent {
-                    write!(f, "silent ")?;
+                    f.write_str("silent ")?;
                 }
                 write!(f, "{graph})")
             }
             Self::Drop { silent, graph } => {
-                write!(f, "(drop ")?;
+                f.write_str("(drop ")?;
                 if *silent {
-                    write!(f, "silent ")?;
+                    f.write_str("silent ")?;
                 }
                 graph.fmt_sse(f)?;
-                write!(f, ")")
+                f.write_str(")")
             }
         }
     }
@@ -227,12 +227,12 @@ impl fmt::Display for GraphUpdateOperation {
             Self::InsertData { data } => {
                 writeln!(f, "INSERT DATA {{")?;
                 write_quads(data, f)?;
-                write!(f, "}}")
+                f.write_str("}")
             }
             Self::DeleteData { data } => {
                 writeln!(f, "DELETE DATA {{")?;
                 write_ground_quads(data, f)?;
-                write!(f, "}}")
+                f.write_str("}")
             }
             Self::DeleteInsert {
                 delete,
@@ -278,9 +278,9 @@ impl fmt::Display for GraphUpdateOperation {
                 source,
                 destination,
             } => {
-                write!(f, "LOAD ")?;
+                f.write_str("LOAD ")?;
                 if *silent {
-                    write!(f, "SILENT ")?;
+                    f.write_str("SILENT ")?;
                 }
                 write!(f, "{source}")?;
                 if destination != &GraphName::DefaultGraph {
@@ -289,23 +289,23 @@ impl fmt::Display for GraphUpdateOperation {
                 Ok(())
             }
             Self::Clear { silent, graph } => {
-                write!(f, "CLEAR ")?;
+                f.write_str("CLEAR ")?;
                 if *silent {
-                    write!(f, "SILENT ")?;
+                    f.write_str("SILENT ")?;
                 }
                 write!(f, "{graph}")
             }
             Self::Create { silent, graph } => {
-                write!(f, "CREATE ")?;
+                f.write_str("CREATE ")?;
                 if *silent {
-                    write!(f, "SILENT ")?;
+                    f.write_str("SILENT ")?;
                 }
                 write!(f, "GRAPH {graph}")
             }
             Self::Drop { silent, graph } => {
-                write!(f, "DROP ")?;
+                f.write_str("DROP ")?;
                 if *silent {
-                    write!(f, "SILENT ")?;
+                    f.write_str("SILENT ")?;
                 }
                 write!(f, "{graph}")
             }

--- a/lib/sparql-smith/src/lib.rs
+++ b/lib/sparql-smith/src/lib.rs
@@ -147,15 +147,15 @@ enum SelectProjection {
 
 impl fmt::Display for SelectClause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SELECT")?;
+        f.write_str("SELECT")?;
         if let Some(option) = &self.option {
             match option {
-                SelectOption::Distinct => write!(f, " DISTINCT"),
-                SelectOption::Reduced => write!(f, " REDUCED"),
+                SelectOption::Distinct => f.write_str(" DISTINCT"),
+                SelectOption::Reduced => f.write_str(" REDUCED"),
             }?;
         }
         match &self.values {
-            SelectValues::Star => write!(f, " *"),
+            SelectValues::Star => f.write_str(" *"),
             SelectValues::Projection { start, others } => {
                 for e in once(start).chain(others) {
                     match e {
@@ -179,7 +179,7 @@ struct WhereClause {
 impl fmt::Display for WhereClause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.with_where {
-            write!(f, " WHERE ")?;
+            f.write_str(" WHERE ")?;
         }
         write!(f, "{}", self.group_graph_pattern)
     }
@@ -400,12 +400,12 @@ enum GroupGraphPattern {
 
 impl fmt::Display for GroupGraphPattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, " {{ ")?;
+        f.write_str(" { ")?;
         match self {
             Self::GroupGraphPatternSub(p) => write!(f, "{p}"),
             Self::SubSelect(s) => write!(f, "{s}"),
         }?;
-        write!(f, " }} ")
+        f.write_str(" } ")
     }
 }
 
@@ -431,7 +431,7 @@ impl fmt::Display for GroupGraphPatternSub {
         for other in &self.others {
             write!(f, "{}", other.start)?;
             if other.with_dot {
-                write!(f, " . ")?;
+                f.write_str(" . ")?;
             }
             if let Some(end) = &other.end {
                 write!(f, "{end}")?;
@@ -452,7 +452,7 @@ impl fmt::Display for TriplesBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.start)?;
         if let Some(end) = &self.end {
-            write!(f, " . ")?;
+            f.write_str(" . ")?;
             if let Some(end) = end {
                 write!(f, "{end}")?;
             }
@@ -617,19 +617,19 @@ impl<'a> Arbitrary<'a> for InlineDataFull {
 
 impl fmt::Display for InlineDataFull {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "( ")?;
+        f.write_str("( ")?;
         for v in &self.vars {
             write!(f, " {v}")?;
         }
-        write!(f, " ) {{")?;
+        f.write_str(" ) {")?;
         for vs in &self.values {
-            write!(f, " (")?;
+            f.write_str(" (")?;
             for v in vs {
                 write!(f, " {v}")?;
             }
-            write!(f, " )")?;
+            f.write_str(" )")?;
         }
-        write!(f, " }}")
+        f.write_str(" }")
     }
 }
 
@@ -646,7 +646,7 @@ impl fmt::Display for DataBlockValue {
         match self {
             Self::Iri(i) => write!(f, "{i}"),
             Self::Literal(l) => write!(f, "{l}"),
-            Self::Undef => write!(f, "UNDEF"),
+            Self::Undef => f.write_str("UNDEF"),
         }
     }
 }
@@ -736,14 +736,14 @@ enum ArgList {
 
 impl fmt::Display for ArgList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(")?;
+        f.write_str("(")?;
         if let Self::NotNil { start, others } = self {
             write!(f, "{start}")?;
             for e in others {
                 write!(f, ", {e}")?;
             }
         }
-        write!(f, ")")
+        f.write_str(")")
     }
 }
 
@@ -755,14 +755,14 @@ struct ExpressionList {
 
 impl fmt::Display for ExpressionList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(")?;
+        f.write_str("(")?;
         for (i, e) in self.inner.iter().enumerate() {
             if i > 0 {
-                write!(f, ", ")?;
+                f.write_str(", ")?;
             }
             write!(f, "{e}")?;
         }
-        write!(f, ")")
+        f.write_str(")")
     }
 }
 
@@ -784,7 +784,7 @@ impl fmt::Display for PropertyListNotEmpty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.start_predicate, self.start_object)?;
         for other in &self.others {
-            write!(f, " ; ")?;
+            f.write_str(" ; ")?;
             if let Some(e) = other {
                 write!(f, "{} {}", e.predicate, e.object)?;
             }
@@ -804,7 +804,7 @@ impl fmt::Display for Verb {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::VarOrIri(iri) => write!(f, "{iri}"),
-            Self::A => write!(f, " a "),
+            Self::A => f.write_str(" a "),
         }
     }
 }
@@ -820,7 +820,7 @@ impl fmt::Display for ObjectList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.start)?;
         for other in &self.others {
-            write!(f, " , ")?;
+            f.write_str(" , ")?;
             write!(f, "{other}")?;
         }
         Ok(())
@@ -906,7 +906,7 @@ impl fmt::Display for PropertyListPathNotEmpty {
         }?;
         write!(f, "{}", self.start_object)?;
         for other in &self.others {
-            write!(f, " ; ")?;
+            f.write_str(" ; ")?;
             if let Some(e) = other {
                 match &e.predicate {
                     PropertyListPathNotEmptyVerb::VerbPath(p) => write!(f, "{p}"),
@@ -1026,9 +1026,9 @@ enum PathMod {
 impl fmt::Display for PathMod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::ZeroOrOne => write!(f, " ? "),
-            Self::ZeroOrMore => write!(f, " * "),
-            Self::OneOrMore => write!(f, " + "),
+            Self::ZeroOrOne => f.write_str(" ? "),
+            Self::ZeroOrMore => f.write_str(" * "),
+            Self::OneOrMore => f.write_str(" + "),
         }
     }
 }
@@ -1046,7 +1046,7 @@ impl fmt::Display for PathPrimary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Iri(iri) => write!(f, "{iri}"),
-            Self::A => write!(f, " a "),
+            Self::A => f.write_str(" a "),
             Self::Negated(n) => write!(f, "!{n}"),
             Self::Child(c) => write!(f, "({c})"),
         }
@@ -1072,7 +1072,7 @@ impl fmt::Display for PathNegatedPropertySet {
                 for other in others {
                     write!(f, " | {other}")?;
                 }
-                write!(f, " ) ")
+                f.write_str(" ) ")
             }
         }
     }
@@ -1091,9 +1091,9 @@ impl fmt::Display for PathOneInPropertySet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Iri(iri) => write!(f, "{iri}"),
-            Self::A => write!(f, " a "),
+            Self::A => f.write_str(" a "),
             Self::NegatedIri(iri) => write!(f, "^{iri}"),
-            Self::NegatedA => write!(f, " ^a "),
+            Self::NegatedA => f.write_str(" ^a "),
         }
     }
 }
@@ -1167,7 +1167,7 @@ impl fmt::Display for Collection {
         for e in &self.others {
             write!(f, " {e}")?;
         }
-        write!(f, " )")
+        f.write_str(" )")
     }
 }
 
@@ -1184,7 +1184,7 @@ impl fmt::Display for CollectionPath {
         for e in &self.others {
             write!(f, " {e}")?;
         }
-        write!(f, " )")
+        f.write_str(" )")
     }
 }
 
@@ -1289,7 +1289,7 @@ impl fmt::Display for GraphTerm {
         match self {
             Self::Iri(iri) => write!(f, "{iri}"),
             Self::Literal(l) => write!(f, "{l}"),
-            Self::Nil => write!(f, " () "),
+            Self::Nil => f.write_str(" () "),
         }
     }
 }

--- a/lib/src/sparql/error.rs
+++ b/lib/src/sparql/error.rs
@@ -51,7 +51,9 @@ impl fmt::Display for EvaluationError {
             Self::Service(error) => error.fmt(f),
             Self::GraphAlreadyExists(graph) => write!(f, "The graph {graph} already exists"),
             Self::GraphDoesNotExist(graph) => write!(f, "The graph {graph} does not exist"),
-            Self::UnboundService => write!(f, "The variable encoding the service name is unbound"),
+            Self::UnboundService => {
+                f.write_str("The variable encoding the service name is unbound")
+            }
             Self::UnsupportedService(service) => {
                 write!(f, "The service {service} is not supported")
             }
@@ -62,7 +64,7 @@ impl fmt::Display for EvaluationError {
                 f,
                 "The service is not returning solutions but a boolean or a graph"
             ),
-            Self::NotAGraph => write!(f, "The query results are not a RDF graph"),
+            Self::NotAGraph => f.write_str("The query results are not a RDF graph"),
         }
     }
 }

--- a/testsuite/src/sparql_evaluator.rs
+++ b/testsuite/src/sparql_evaluator.rs
@@ -629,12 +629,12 @@ fn solutions_to_string(solutions: Vec<Vec<(Variable, Term)>>, ordered: bool) -> 
         .into_iter()
         .map(|mut s| {
             let mut out = String::new();
-            write!(&mut out, "{{").unwrap();
+            out.write_str("{").unwrap();
             s.sort_unstable_by(|(v1, _), (v2, _)| v1.cmp(v2));
             for (variable, value) in s {
                 write!(&mut out, "{variable} = {value} ").unwrap();
             }
-            write!(&mut out, "}}").unwrap();
+            out.write_str("}").unwrap();
             out
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
As seen in the https://rust.godbolt.org/z/Y8djWsq1P - `write!` macro produces significantly more code than a `write_str` call, so this change should have somewhat better performance.  To my knowledge, a lot of ppl tried to solve this optimization in the compiler, but no luck yet, so may help compiler ourselves for now.