### PR TITLE
Rename ParseError and SyntaxError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,11 @@ zstd = ">=0.12, <0.14"
 # Internal dependencies
 oxigraph = { version = "0.4.0-alpha.3-dev", path = "lib/oxigraph" }
 oxrdf = { version = "0.2.0-alpha.2", path = "lib/oxrdf" }
-oxrdfio = { version = "0.1.0-alpha.2", path = "lib/oxrdfio" }
-oxrdfxml = { version = "0.1.0-alpha.2", path = "lib/oxrdfxml" }
+oxrdfio = { version = "0.1.0-alpha.3-dev", path = "lib/oxrdfio" }
+oxrdfxml = { version = "0.1.0-alpha.3-dev", path = "lib/oxrdfxml" }
 oxrocksdb-sys = { version = "0.4.0-alpha.3-dev", path = "./oxrocksdb-sys" }
 oxsdatatypes = { version = "0.2.0-alpha.1", path = "lib/oxsdatatypes" }
-oxttl = { version = "0.1.0-alpha.2", path = "lib/oxttl" }
+oxttl = { version = "0.1.0-alpha.3-dev", path = "lib/oxttl" }
 sparesults = { version = "0.2.0-alpha.2", path = "lib/sparesults" }
 spargebra = { version = "0.3.0-alpha.2", path = "lib/spargebra" }
 sparopt = { version = "0.1.0-alpha.2", path = "lib/sparopt" }

--- a/lib/oxigraph/src/io/read.rs
+++ b/lib/oxigraph/src/io/read.rs
@@ -5,7 +5,7 @@
 use crate::io::{DatasetFormat, GraphFormat};
 use crate::model::*;
 use oxiri::IriParseError;
-use oxrdfio::{FromReadQuadReader, ParseError, RdfParser};
+use oxrdfio::{FromReadQuadReader, RdfParseError, RdfParser};
 use std::io::Read;
 
 /// Parsers for RDF graph serialization formats.
@@ -100,7 +100,7 @@ pub struct TripleReader<R: Read> {
 }
 
 impl<R: Read> Iterator for TripleReader<R> {
-    type Item = Result<Triple, ParseError>;
+    type Item = Result<Triple, RdfParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.parser.next()?.map(Into::into).map_err(Into::into))
@@ -192,7 +192,7 @@ pub struct QuadReader<R: Read> {
 }
 
 impl<R: Read> Iterator for QuadReader<R> {
-    type Item = Result<Quad, ParseError>;
+    type Item = Result<Quad, RdfParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.parser.next()?.map_err(Into::into))

--- a/lib/oxigraph/src/sparql/algebra.rs
+++ b/lib/oxigraph/src/sparql/algebra.rs
@@ -38,7 +38,10 @@ pub struct Query {
 
 impl Query {
     /// Parses a SPARQL query with an optional base IRI to resolve relative IRIs in the query.
-    pub fn parse(query: &str, base_iri: Option<&str>) -> Result<Self, spargebra::ParseError> {
+    pub fn parse(
+        query: &str,
+        base_iri: Option<&str>,
+    ) -> Result<Self, spargebra::SparqlSyntaxError> {
         let start = Timer::now();
         let query = Self::from(spargebra::Query::parse(query, base_iri)?);
         Ok(Self {
@@ -66,7 +69,7 @@ impl fmt::Display for Query {
 }
 
 impl FromStr for Query {
-    type Err = spargebra::ParseError;
+    type Err = spargebra::SparqlSyntaxError;
 
     fn from_str(query: &str) -> Result<Self, Self::Err> {
         Self::parse(query, None)
@@ -74,7 +77,7 @@ impl FromStr for Query {
 }
 
 impl TryFrom<&str> for Query {
-    type Error = spargebra::ParseError;
+    type Error = spargebra::SparqlSyntaxError;
 
     fn try_from(query: &str) -> Result<Self, Self::Error> {
         Self::from_str(query)
@@ -82,7 +85,7 @@ impl TryFrom<&str> for Query {
 }
 
 impl TryFrom<&String> for Query {
-    type Error = spargebra::ParseError;
+    type Error = spargebra::SparqlSyntaxError;
 
     fn try_from(query: &String) -> Result<Self, Self::Error> {
         Self::from_str(query)
@@ -113,7 +116,7 @@ impl From<spargebra::Query> for Query {
 /// let update = Update::parse(update_str, None)?;
 ///
 /// assert_eq!(update.to_string().trim(), update_str);
-/// # Ok::<_, oxigraph::sparql::ParseError>(())
+/// # Ok::<_, oxigraph::sparql::SparqlSyntaxError>(())
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct Update {
@@ -123,7 +126,10 @@ pub struct Update {
 
 impl Update {
     /// Parses a SPARQL update with an optional base IRI to resolve relative IRIs in the query.
-    pub fn parse(update: &str, base_iri: Option<&str>) -> Result<Self, spargebra::ParseError> {
+    pub fn parse(
+        update: &str,
+        base_iri: Option<&str>,
+    ) -> Result<Self, spargebra::SparqlSyntaxError> {
         let update = spargebra::Update::parse(update, base_iri)?;
         Ok(Self {
             using_datasets: update
@@ -159,7 +165,7 @@ impl fmt::Display for Update {
 }
 
 impl FromStr for Update {
-    type Err = spargebra::ParseError;
+    type Err = spargebra::SparqlSyntaxError;
 
     fn from_str(update: &str) -> Result<Self, Self::Err> {
         Self::parse(update, None)
@@ -167,7 +173,7 @@ impl FromStr for Update {
 }
 
 impl TryFrom<&str> for Update {
-    type Error = spargebra::ParseError;
+    type Error = spargebra::SparqlSyntaxError;
 
     fn try_from(update: &str) -> Result<Self, Self::Error> {
         Self::from_str(update)
@@ -175,7 +181,7 @@ impl TryFrom<&str> for Update {
 }
 
 impl TryFrom<&String> for Update {
-    type Error = spargebra::ParseError;
+    type Error = spargebra::SparqlSyntaxError;
 
     fn try_from(update: &String) -> Result<Self, Self::Error> {
         Self::from_str(update)

--- a/lib/oxigraph/src/sparql/error.rs
+++ b/lib/oxigraph/src/sparql/error.rs
@@ -1,7 +1,7 @@
-use crate::io::ParseError as RdfParseError;
+use crate::io::RdfParseError;
 use crate::model::NamedNode;
-use crate::sparql::results::ParseError as ResultsParseError;
-use crate::sparql::ParseError;
+use crate::sparql::results::QueryResultsParseError as ResultsParseError;
+use crate::sparql::SparqlSyntaxError;
 use crate::storage::StorageError;
 use std::convert::Infallible;
 use std::error::Error;
@@ -13,7 +13,7 @@ use std::io;
 pub enum EvaluationError {
     /// An error in SPARQL parsing.
     #[error(transparent)]
-    Parsing(#[from] ParseError),
+    Parsing(#[from] SparqlSyntaxError),
     /// An error from the storage.
     #[error(transparent)]
     Storage(#[from] StorageError),

--- a/lib/oxigraph/src/sparql/mod.rs
+++ b/lib/oxigraph/src/sparql/mod.rs
@@ -25,7 +25,7 @@ use crate::storage::StorageReader;
 use json_event_parser::{JsonEvent, ToWriteJsonWriter};
 pub use oxrdf::{Variable, VariableNameParseError};
 use oxsdatatypes::{DayTimeDuration, Float};
-pub use spargebra::ParseError;
+pub use spargebra::SparqlSyntaxError;
 use sparopt::algebra::GraphPattern;
 use sparopt::Optimizer;
 use std::collections::HashMap;

--- a/lib/oxigraph/src/sparql/model.rs
+++ b/lib/oxigraph/src/sparql/model.rs
@@ -2,8 +2,8 @@ use crate::io::{RdfFormat, RdfSerializer};
 use crate::model::*;
 use crate::sparql::error::EvaluationError;
 use crate::sparql::results::{
-    FromReadQueryResultsReader, FromReadSolutionsReader, ParseError, QueryResultsFormat,
-    QueryResultsParser, QueryResultsSerializer,
+    FromReadQueryResultsReader, FromReadSolutionsReader, QueryResultsFormat,
+    QueryResultsParseError, QueryResultsParser, QueryResultsSerializer,
 };
 use oxrdf::{Variable, VariableRef};
 pub use sparesults::QuerySolution;
@@ -22,7 +22,10 @@ pub enum QueryResults {
 
 impl QueryResults {
     /// Reads a SPARQL query results serialization.
-    pub fn read(read: impl Read + 'static, format: QueryResultsFormat) -> Result<Self, ParseError> {
+    pub fn read(
+        read: impl Read + 'static,
+        format: QueryResultsFormat,
+    ) -> Result<Self, QueryResultsParseError> {
         Ok(QueryResultsParser::from_format(format)
             .parse_read(read)?
             .into())

--- a/lib/oxigraph/src/storage/error.rs
+++ b/lib/oxigraph/src/storage/error.rs
@@ -1,4 +1,4 @@
-use crate::io::{ParseError, RdfFormat};
+use crate::io::{RdfFormat, RdfParseError};
 use crate::storage::numeric_encoder::EncodedTerm;
 use oxiri::IriParseError;
 use oxrdf::TermRef;
@@ -83,7 +83,7 @@ impl From<CorruptionError> for io::Error {
 pub enum LoaderError {
     /// An error raised while reading the file.
     #[error(transparent)]
-    Parsing(#[from] ParseError),
+    Parsing(#[from] RdfParseError),
     /// An error raised during the insertion in the store.
     #[error(transparent)]
     Storage(#[from] StorageError),

--- a/lib/oxigraph/src/store.rs
+++ b/lib/oxigraph/src/store.rs
@@ -26,7 +26,7 @@
 //! # Result::<_, Box<dyn std::error::Error>>::Ok(())
 //! ```
 #[cfg(not(target_family = "wasm"))]
-use crate::io::ParseError;
+use crate::io::RdfParseError;
 use crate::io::{RdfFormat, RdfParser, RdfSerializer};
 use crate::model::*;
 use crate::sparql::{
@@ -1592,7 +1592,7 @@ impl Iterator for GraphNameIter {
 #[must_use]
 pub struct BulkLoader {
     storage: StorageBulkLoader,
-    on_parse_error: Option<Box<dyn Fn(ParseError) -> Result<(), ParseError>>>,
+    on_parse_error: Option<Box<dyn Fn(RdfParseError) -> Result<(), RdfParseError>>>,
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -1647,7 +1647,7 @@ impl BulkLoader {
     /// By default the parsing fails.
     pub fn on_parse_error(
         mut self,
-        callback: impl Fn(ParseError) -> Result<(), ParseError> + 'static,
+        callback: impl Fn(RdfParseError) -> Result<(), RdfParseError> + 'static,
     ) -> Self {
         self.on_parse_error = Some(Box::new(callback));
         self

--- a/lib/oxrdfio/Cargo.toml
+++ b/lib/oxrdfio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxrdfio"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3-dev"
 authors.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/lib/oxrdfio/src/error.rs
+++ b/lib/oxrdfio/src/error.rs
@@ -3,61 +3,61 @@ use std::ops::Range;
 
 /// Error returned during RDF format parsing.
 #[derive(Debug, thiserror::Error)]
-pub enum ParseError {
+pub enum RdfParseError {
     /// I/O error during parsing (file not found...).
     #[error(transparent)]
     Io(#[from] io::Error),
     /// An error in the file syntax.
     #[error(transparent)]
-    Syntax(#[from] SyntaxError),
+    Syntax(#[from] RdfSyntaxError),
 }
 
-impl ParseError {
+impl RdfParseError {
     pub(crate) fn msg(msg: &'static str) -> Self {
-        Self::Syntax(SyntaxError(SyntaxErrorKind::Msg(msg)))
+        Self::Syntax(RdfSyntaxError(SyntaxErrorKind::Msg(msg)))
     }
 }
 
-impl From<oxttl::SyntaxError> for SyntaxError {
+impl From<oxttl::TurtleSyntaxError> for RdfSyntaxError {
     #[inline]
-    fn from(error: oxttl::SyntaxError) -> Self {
+    fn from(error: oxttl::TurtleSyntaxError) -> Self {
         Self(SyntaxErrorKind::Turtle(error))
     }
 }
 
-impl From<oxttl::ParseError> for ParseError {
+impl From<oxttl::TurtleParseError> for RdfParseError {
     #[inline]
-    fn from(error: oxttl::ParseError) -> Self {
+    fn from(error: oxttl::TurtleParseError) -> Self {
         match error {
-            oxttl::ParseError::Syntax(e) => Self::Syntax(e.into()),
-            oxttl::ParseError::Io(e) => Self::Io(e),
+            oxttl::TurtleParseError::Syntax(e) => Self::Syntax(e.into()),
+            oxttl::TurtleParseError::Io(e) => Self::Io(e),
         }
     }
 }
 
-impl From<oxrdfxml::SyntaxError> for SyntaxError {
+impl From<oxrdfxml::RdfXmlSyntaxError> for RdfSyntaxError {
     #[inline]
-    fn from(error: oxrdfxml::SyntaxError) -> Self {
+    fn from(error: oxrdfxml::RdfXmlSyntaxError) -> Self {
         Self(SyntaxErrorKind::RdfXml(error))
     }
 }
 
-impl From<oxrdfxml::ParseError> for ParseError {
+impl From<oxrdfxml::RdfXmlParseError> for RdfParseError {
     #[inline]
-    fn from(error: oxrdfxml::ParseError) -> Self {
+    fn from(error: oxrdfxml::RdfXmlParseError) -> Self {
         match error {
-            oxrdfxml::ParseError::Syntax(e) => Self::Syntax(e.into()),
-            oxrdfxml::ParseError::Io(e) => Self::Io(e),
+            oxrdfxml::RdfXmlParseError::Syntax(e) => Self::Syntax(e.into()),
+            oxrdfxml::RdfXmlParseError::Io(e) => Self::Io(e),
         }
     }
 }
 
-impl From<ParseError> for io::Error {
+impl From<RdfParseError> for io::Error {
     #[inline]
-    fn from(error: ParseError) -> Self {
+    fn from(error: RdfParseError) -> Self {
         match error {
-            ParseError::Io(error) => error,
-            ParseError::Syntax(error) => error.into(),
+            RdfParseError::Io(error) => error,
+            RdfParseError::Syntax(error) => error.into(),
         }
     }
 }
@@ -65,20 +65,20 @@ impl From<ParseError> for io::Error {
 /// An error in the syntax of the parsed file.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
-pub struct SyntaxError(#[from] SyntaxErrorKind);
+pub struct RdfSyntaxError(#[from] SyntaxErrorKind);
 
 /// An error in the syntax of the parsed file.
 #[derive(Debug, thiserror::Error)]
 enum SyntaxErrorKind {
     #[error(transparent)]
-    Turtle(#[from] oxttl::SyntaxError),
+    Turtle(#[from] oxttl::TurtleSyntaxError),
     #[error(transparent)]
-    RdfXml(#[from] oxrdfxml::SyntaxError),
+    RdfXml(#[from] oxrdfxml::RdfXmlSyntaxError),
     #[error("{0}")]
     Msg(&'static str),
 }
 
-impl SyntaxError {
+impl RdfSyntaxError {
     /// The location of the error inside of the file.
     #[inline]
     pub fn location(&self) -> Option<Range<TextPosition>> {
@@ -102,9 +102,9 @@ impl SyntaxError {
     }
 }
 
-impl From<SyntaxError> for io::Error {
+impl From<RdfSyntaxError> for io::Error {
     #[inline]
-    fn from(error: SyntaxError) -> Self {
+    fn from(error: RdfSyntaxError) -> Self {
         match error.0 {
             SyntaxErrorKind::Turtle(error) => error.into(),
             SyntaxErrorKind::RdfXml(error) => error.into(),

--- a/lib/oxrdfio/src/lib.rs
+++ b/lib/oxrdfio/src/lib.rs
@@ -9,7 +9,7 @@ mod format;
 mod parser;
 mod serializer;
 
-pub use error::{ParseError, SyntaxError, TextPosition};
+pub use error::{RdfParseError, RdfSyntaxError, TextPosition};
 pub use format::RdfFormat;
 #[cfg(feature = "async-tokio")]
 pub use parser::FromTokioAsyncReadQuadReader;

--- a/lib/oxrdfxml/Cargo.toml
+++ b/lib/oxrdfxml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxrdfxml"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3-dev"
 authors.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/lib/oxrdfxml/src/lib.rs
+++ b/lib/oxrdfxml/src/lib.rs
@@ -9,7 +9,7 @@ mod parser;
 mod serializer;
 mod utils;
 
-pub use error::{ParseError, SyntaxError};
+pub use error::{RdfXmlParseError, RdfXmlSyntaxError};
 #[cfg(feature = "async-tokio")]
 pub use parser::FromTokioAsyncReadRdfXmlReader;
 pub use parser::{FromReadRdfXmlReader, RdfXmlParser};

--- a/lib/oxttl/Cargo.toml
+++ b/lib/oxttl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxttl"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3-dev"
 authors.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/lib/oxttl/src/lib.rs
+++ b/lib/oxttl/src/lib.rs
@@ -17,7 +17,7 @@ pub mod turtle;
 pub use crate::n3::N3Parser;
 pub use crate::nquads::{NQuadsParser, NQuadsSerializer};
 pub use crate::ntriples::{NTriplesParser, NTriplesSerializer};
-pub use crate::toolkit::{ParseError, SyntaxError, TextPosition};
+pub use crate::toolkit::{TextPosition, TurtleParseError, TurtleSyntaxError};
 pub use crate::trig::{TriGParser, TriGSerializer};
 pub use crate::turtle::{TurtleParser, TurtleSerializer};
 

--- a/lib/oxttl/src/n3.rs
+++ b/lib/oxttl/src/n3.rs
@@ -4,9 +4,9 @@ use crate::lexer::{resolve_local_name, N3Lexer, N3LexerMode, N3LexerOptions, N3T
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::FromTokioAsyncReadIterator;
 use crate::toolkit::{
-    FromReadIterator, Lexer, Parser, RuleRecognizer, RuleRecognizerError, SyntaxError,
+    FromReadIterator, Lexer, Parser, RuleRecognizer, RuleRecognizerError, TurtleSyntaxError,
 };
-use crate::{ParseError, MAX_BUFFER_SIZE, MIN_BUFFER_SIZE};
+use crate::{TurtleParseError, MAX_BUFFER_SIZE, MIN_BUFFER_SIZE};
 use oxiri::{Iri, IriParseError};
 use oxrdf::vocab::{rdf, xsd};
 #[cfg(feature = "rdf-star")]
@@ -291,7 +291,7 @@ impl N3Parser {
     /// use oxttl::n3::{N3Parser, N3Term};
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -461,7 +461,7 @@ impl<R: Read> FromReadN3Reader<R> {
 }
 
 impl<R: Read> Iterator for FromReadN3Reader<R> {
-    type Item = Result<N3Quad, ParseError>;
+    type Item = Result<N3Quad, TurtleParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -477,7 +477,7 @@ impl<R: Read> Iterator for FromReadN3Reader<R> {
 /// use oxttl::n3::{N3Parser, N3Term};
 ///
 /// # #[tokio::main(flavor = "current_thread")]
-/// # async fn main() -> Result<(), oxttl::ParseError> {
+/// # async fn main() -> Result<(), oxttl::TurtleParseError> {
 /// let file = br#"@base <http://example.com/> .
 /// @prefix schema: <http://schema.org/> .
 /// <foo> a schema:Person ;
@@ -508,7 +508,7 @@ pub struct FromTokioAsyncReadN3Reader<R: AsyncRead + Unpin> {
 #[cfg(feature = "async-tokio")]
 impl<R: AsyncRead + Unpin> FromTokioAsyncReadN3Reader<R> {
     /// Reads the next triple or returns `None` if the file is finished.
-    pub async fn next(&mut self) -> Option<Result<N3Quad, ParseError>> {
+    pub async fn next(&mut self) -> Option<Result<N3Quad, TurtleParseError>> {
         Some(self.inner.next().await?.map(Into::into))
     }
 
@@ -522,7 +522,7 @@ impl<R: AsyncRead + Unpin> FromTokioAsyncReadN3Reader<R> {
     /// use oxttl::N3Parser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -551,7 +551,7 @@ impl<R: AsyncRead + Unpin> FromTokioAsyncReadN3Reader<R> {
     /// use oxttl::N3Parser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -641,7 +641,7 @@ impl LowLevelN3Reader {
     ///
     /// Returns [`None`] if the parsing is finished or more data is required.
     /// If it is the case more data should be fed using [`extend_from_slice`](Self::extend_from_slice).
-    pub fn read_next(&mut self) -> Option<Result<N3Quad, SyntaxError>> {
+    pub fn read_next(&mut self) -> Option<Result<N3Quad, TurtleSyntaxError>> {
         self.parser.read_next()
     }
 

--- a/lib/oxttl/src/nquads.rs
+++ b/lib/oxttl/src/nquads.rs
@@ -4,7 +4,7 @@
 use crate::line_formats::NQuadsRecognizer;
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::FromTokioAsyncReadIterator;
-use crate::toolkit::{FromReadIterator, ParseError, Parser, SyntaxError};
+use crate::toolkit::{FromReadIterator, Parser, TurtleParseError, TurtleSyntaxError};
 use oxrdf::{Quad, QuadRef};
 use std::io::{self, Read, Write};
 #[cfg(feature = "async-tokio")]
@@ -106,7 +106,7 @@ impl NQuadsParser {
     /// use oxttl::NQuadsParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"<http://example.com/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
     /// <http://example.com/foo> <http://schema.org/name> "Foo" .
     /// <http://example.com/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
@@ -213,7 +213,7 @@ pub struct FromReadNQuadsReader<R: Read> {
 }
 
 impl<R: Read> Iterator for FromReadNQuadsReader<R> {
-    type Item = Result<Quad, ParseError>;
+    type Item = Result<Quad, TurtleParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -228,7 +228,7 @@ impl<R: Read> Iterator for FromReadNQuadsReader<R> {
 /// use oxttl::NQuadsParser;
 ///
 /// # #[tokio::main(flavor = "current_thread")]
-/// # async fn main() -> Result<(), oxttl::ParseError> {
+/// # async fn main() -> Result<(), oxttl::TurtleParseError> {
 /// let file = br#"<http://example.com/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
 /// <http://example.com/foo> <http://schema.org/name> "Foo" .
 /// <http://example.com/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
@@ -256,7 +256,7 @@ pub struct FromTokioAsyncReadNQuadsReader<R: AsyncRead + Unpin> {
 #[cfg(feature = "async-tokio")]
 impl<R: AsyncRead + Unpin> FromTokioAsyncReadNQuadsReader<R> {
     /// Reads the next triple or returns `None` if the file is finished.
-    pub async fn next(&mut self) -> Option<Result<Quad, ParseError>> {
+    pub async fn next(&mut self) -> Option<Result<Quad, TurtleParseError>> {
         Some(self.inner.next().await?.map(Into::into))
     }
 }
@@ -323,7 +323,7 @@ impl LowLevelNQuadsReader {
     ///
     /// Returns [`None`] if the parsing is finished or more data is required.
     /// If it is the case more data should be fed using [`extend_from_slice`](Self::extend_from_slice).
-    pub fn read_next(&mut self) -> Option<Result<Quad, SyntaxError>> {
+    pub fn read_next(&mut self) -> Option<Result<Quad, TurtleSyntaxError>> {
         self.parser.read_next()
     }
 }

--- a/lib/oxttl/src/ntriples.rs
+++ b/lib/oxttl/src/ntriples.rs
@@ -4,7 +4,7 @@
 use crate::line_formats::NQuadsRecognizer;
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::FromTokioAsyncReadIterator;
-use crate::toolkit::{FromReadIterator, ParseError, Parser, SyntaxError};
+use crate::toolkit::{FromReadIterator, Parser, TurtleParseError, TurtleSyntaxError};
 use oxrdf::{Triple, TripleRef};
 use std::io::{self, Read, Write};
 #[cfg(feature = "async-tokio")]
@@ -106,7 +106,7 @@ impl NTriplesParser {
     /// use oxttl::NTriplesParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"<http://example.com/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
     /// <http://example.com/foo> <http://schema.org/name> "Foo" .
     /// <http://example.com/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
@@ -213,7 +213,7 @@ pub struct FromReadNTriplesReader<R: Read> {
 }
 
 impl<R: Read> Iterator for FromReadNTriplesReader<R> {
-    type Item = Result<Triple, ParseError>;
+    type Item = Result<Triple, TurtleParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.inner.next()?.map(Into::into))
@@ -228,7 +228,7 @@ impl<R: Read> Iterator for FromReadNTriplesReader<R> {
 /// use oxttl::NTriplesParser;
 ///
 /// # #[tokio::main(flavor = "current_thread")]
-/// # async fn main() -> Result<(), oxttl::ParseError> {
+/// # async fn main() -> Result<(), oxttl::TurtleParseError> {
 /// let file = br#"<http://example.com/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
 /// <http://example.com/foo> <http://schema.org/name> "Foo" .
 /// <http://example.com/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
@@ -256,7 +256,7 @@ pub struct FromTokioAsyncReadNTriplesReader<R: AsyncRead + Unpin> {
 #[cfg(feature = "async-tokio")]
 impl<R: AsyncRead + Unpin> FromTokioAsyncReadNTriplesReader<R> {
     /// Reads the next triple or returns `None` if the file is finished.
-    pub async fn next(&mut self) -> Option<Result<Triple, ParseError>> {
+    pub async fn next(&mut self) -> Option<Result<Triple, TurtleParseError>> {
         Some(self.inner.next().await?.map(Into::into))
     }
 }
@@ -323,7 +323,7 @@ impl LowLevelNTriplesReader {
     ///
     /// Returns [`None`] if the parsing is finished or more data is required.
     /// If it is the case more data should be fed using [`extend_from_slice`](Self::extend_from_slice).
-    pub fn read_next(&mut self) -> Option<Result<Triple, SyntaxError>> {
+    pub fn read_next(&mut self) -> Option<Result<Triple, TurtleSyntaxError>> {
         Some(self.parser.read_next()?.map(Into::into))
     }
 }

--- a/lib/oxttl/src/toolkit/error.rs
+++ b/lib/oxttl/src/toolkit/error.rs
@@ -13,12 +13,12 @@ pub struct TextPosition {
 ///
 /// It is composed of a message and a byte range in the input.
 #[derive(Debug, thiserror::Error)]
-pub struct SyntaxError {
+pub struct TurtleSyntaxError {
     pub(super) location: Range<TextPosition>,
     pub(super) message: String,
 }
 
-impl SyntaxError {
+impl TurtleSyntaxError {
     /// The location of the error inside of the file.
     #[inline]
     pub fn location(&self) -> Range<TextPosition> {
@@ -32,7 +32,7 @@ impl SyntaxError {
     }
 }
 
-impl fmt::Display for SyntaxError {
+impl fmt::Display for TurtleSyntaxError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.location.start.offset + 1 >= self.location.end.offset {
@@ -66,32 +66,32 @@ impl fmt::Display for SyntaxError {
     }
 }
 
-impl From<SyntaxError> for io::Error {
+impl From<TurtleSyntaxError> for io::Error {
     #[inline]
-    fn from(error: SyntaxError) -> Self {
+    fn from(error: TurtleSyntaxError) -> Self {
         Self::new(io::ErrorKind::InvalidData, error)
     }
 }
 
 /// A parsing error.
 ///
-/// It is the union of [`SyntaxError`] and [`io::Error`].
+/// It is the union of [`TurtleSyntaxError`] and [`io::Error`].
 #[derive(Debug, thiserror::Error)]
-pub enum ParseError {
+pub enum TurtleParseError {
     /// I/O error during parsing (file not found...).
     #[error(transparent)]
     Io(#[from] io::Error),
     /// An error in the file syntax.
     #[error(transparent)]
-    Syntax(#[from] SyntaxError),
+    Syntax(#[from] TurtleSyntaxError),
 }
 
-impl From<ParseError> for io::Error {
+impl From<TurtleParseError> for io::Error {
     #[inline]
-    fn from(error: ParseError) -> Self {
+    fn from(error: TurtleParseError) -> Self {
         match error {
-            ParseError::Syntax(e) => e.into(),
-            ParseError::Io(e) => e,
+            TurtleParseError::Syntax(e) => e.into(),
+            TurtleParseError::Io(e) => e,
         }
     }
 }

--- a/lib/oxttl/src/toolkit/lexer.rs
+++ b/lib/oxttl/src/toolkit/lexer.rs
@@ -1,4 +1,4 @@
-use crate::toolkit::error::{SyntaxError, TextPosition};
+use crate::toolkit::error::{TextPosition, TurtleSyntaxError};
 use memchr::{memchr2, memchr2_iter};
 use std::borrow::Cow;
 use std::cmp::min;
@@ -163,7 +163,10 @@ impl<R: TokenRecognizer> Lexer<R> {
     }
 
     #[allow(clippy::unwrap_in_result)]
-    pub fn read_next(&mut self, options: &R::Options) -> Option<Result<R::Token<'_>, SyntaxError>> {
+    pub fn read_next(
+        &mut self,
+        options: &R::Options,
+    ) -> Option<Result<R::Token<'_>, TurtleSyntaxError>> {
         self.skip_whitespaces_and_comments()?;
         self.previous_position = self.position;
         let Some((consumed, result)) = self.parser.recognize_next_token(
@@ -194,7 +197,7 @@ impl<R: TokenRecognizer> Lexer<R> {
                         ),
                         offset: self.position.global_offset,
                     };
-                    let error = SyntaxError {
+                    let error = TurtleSyntaxError {
                         location: new_position..new_position,
                         message: "Unexpected end of file".into(),
                     };
@@ -224,7 +227,7 @@ impl<R: TokenRecognizer> Lexer<R> {
         self.position.buffer_offset += consumed;
         self.position.global_offset += u64::try_from(consumed).unwrap();
         self.position.global_line += new_line_jumps;
-        Some(result.map_err(|e| SyntaxError {
+        Some(result.map_err(|e| TurtleSyntaxError {
             location: self.location_from_buffer_offset_range(e.location),
             message: e.message,
         }))

--- a/lib/oxttl/src/toolkit/mod.rs
+++ b/lib/oxttl/src/toolkit/mod.rs
@@ -6,7 +6,7 @@ mod error;
 mod lexer;
 mod parser;
 
-pub use self::error::{ParseError, SyntaxError, TextPosition};
+pub use self::error::{TextPosition, TurtleParseError, TurtleSyntaxError};
 pub use self::lexer::{Lexer, TokenRecognizer, TokenRecognizerError};
 #[cfg(feature = "async-tokio")]
 pub use self::parser::FromTokioAsyncReadIterator;

--- a/lib/oxttl/src/trig.rs
+++ b/lib/oxttl/src/trig.rs
@@ -5,7 +5,7 @@ use crate::lexer::N3Lexer;
 use crate::terse::TriGRecognizer;
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::FromTokioAsyncReadIterator;
-use crate::toolkit::{FromReadIterator, ParseError, Parser, SyntaxError};
+use crate::toolkit::{FromReadIterator, Parser, TurtleParseError, TurtleSyntaxError};
 use oxiri::{Iri, IriParseError};
 use oxrdf::vocab::{rdf, xsd};
 use oxrdf::{
@@ -140,7 +140,7 @@ impl TriGParser {
     /// use oxttl::TriGParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -314,7 +314,7 @@ impl<R: Read> FromReadTriGReader<R> {
 }
 
 impl<R: Read> Iterator for FromReadTriGReader<R> {
-    type Item = Result<Quad, ParseError>;
+    type Item = Result<Quad, TurtleParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -330,7 +330,7 @@ impl<R: Read> Iterator for FromReadTriGReader<R> {
 /// use oxttl::TriGParser;
 ///
 /// # #[tokio::main(flavor = "current_thread")]
-/// # async fn main() -> Result<(), oxttl::ParseError> {
+/// # async fn main() -> Result<(), oxttl::TurtleParseError> {
 /// let file = br#"@base <http://example.com/> .
 /// @prefix schema: <http://schema.org/> .
 /// <foo> a schema:Person ;
@@ -360,7 +360,7 @@ pub struct FromTokioAsyncReadTriGReader<R: AsyncRead + Unpin> {
 #[cfg(feature = "async-tokio")]
 impl<R: AsyncRead + Unpin> FromTokioAsyncReadTriGReader<R> {
     /// Reads the next triple or returns `None` if the file is finished.
-    pub async fn next(&mut self) -> Option<Result<Quad, ParseError>> {
+    pub async fn next(&mut self) -> Option<Result<Quad, TurtleParseError>> {
         Some(self.inner.next().await?.map(Into::into))
     }
 
@@ -374,7 +374,7 @@ impl<R: AsyncRead + Unpin> FromTokioAsyncReadTriGReader<R> {
     /// use oxttl::TriGParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -403,7 +403,7 @@ impl<R: AsyncRead + Unpin> FromTokioAsyncReadTriGReader<R> {
     /// use oxttl::TriGParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -492,7 +492,7 @@ impl LowLevelTriGReader {
     ///
     /// Returns [`None`] if the parsing is finished or more data is required.
     /// If it is the case more data should be fed using [`extend_from_slice`](Self::extend_from_slice).
-    pub fn read_next(&mut self) -> Option<Result<Quad, SyntaxError>> {
+    pub fn read_next(&mut self) -> Option<Result<Quad, TurtleSyntaxError>> {
         self.parser.read_next()
     }
 

--- a/lib/oxttl/src/turtle.rs
+++ b/lib/oxttl/src/turtle.rs
@@ -4,7 +4,7 @@
 use crate::terse::TriGRecognizer;
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::FromTokioAsyncReadIterator;
-use crate::toolkit::{FromReadIterator, ParseError, Parser, SyntaxError};
+use crate::toolkit::{FromReadIterator, Parser, TurtleParseError, TurtleSyntaxError};
 #[cfg(feature = "async-tokio")]
 use crate::trig::ToTokioAsyncWriteTriGWriter;
 use crate::trig::{LowLevelTriGWriter, ToWriteTriGWriter, TriGSerializer};
@@ -138,7 +138,7 @@ impl TurtleParser {
     /// use oxttl::TurtleParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -312,7 +312,7 @@ impl<R: Read> FromReadTurtleReader<R> {
 }
 
 impl<R: Read> Iterator for FromReadTurtleReader<R> {
-    type Item = Result<Triple, ParseError>;
+    type Item = Result<Triple, TurtleParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.inner.next()?.map(Into::into))
@@ -328,7 +328,7 @@ impl<R: Read> Iterator for FromReadTurtleReader<R> {
 /// use oxttl::TurtleParser;
 ///
 /// # #[tokio::main(flavor = "current_thread")]
-/// # async fn main() -> Result<(), oxttl::ParseError> {
+/// # async fn main() -> Result<(), oxttl::TurtleParseError> {
 /// let file = br#"@base <http://example.com/> .
 /// @prefix schema: <http://schema.org/> .
 /// <foo> a schema:Person ;
@@ -358,7 +358,7 @@ pub struct FromTokioAsyncReadTurtleReader<R: AsyncRead + Unpin> {
 #[cfg(feature = "async-tokio")]
 impl<R: AsyncRead + Unpin> FromTokioAsyncReadTurtleReader<R> {
     /// Reads the next triple or returns `None` if the file is finished.
-    pub async fn next(&mut self) -> Option<Result<Triple, ParseError>> {
+    pub async fn next(&mut self) -> Option<Result<Triple, TurtleParseError>> {
         Some(self.inner.next().await?.map(Into::into))
     }
 
@@ -372,7 +372,7 @@ impl<R: AsyncRead + Unpin> FromTokioAsyncReadTurtleReader<R> {
     /// use oxttl::TurtleParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -401,7 +401,7 @@ impl<R: AsyncRead + Unpin> FromTokioAsyncReadTurtleReader<R> {
     /// use oxttl::TurtleParser;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), oxttl::ParseError> {
+    /// # async fn main() -> Result<(), oxttl::TurtleParseError> {
     /// let file = br#"@base <http://example.com/> .
     /// @prefix schema: <http://schema.org/> .
     /// <foo> a schema:Person ;
@@ -490,7 +490,7 @@ impl LowLevelTurtleReader {
     ///
     /// Returns [`None`] if the parsing is finished or more data is required.
     /// If it is the case more data should be fed using [`extend_from_slice`](Self::extend_from_slice).
-    pub fn read_next(&mut self) -> Option<Result<Triple, SyntaxError>> {
+    pub fn read_next(&mut self) -> Option<Result<Triple, TurtleSyntaxError>> {
         Some(self.parser.read_next()?.map(Into::into))
     }
 

--- a/lib/sparesults/src/lib.rs
+++ b/lib/sparesults/src/lib.rs
@@ -13,7 +13,7 @@ mod serializer;
 pub mod solution;
 mod xml;
 
-pub use crate::error::{ParseError, SyntaxError, TextPosition};
+pub use crate::error::{QueryResultsParseError, QueryResultsSyntaxError, TextPosition};
 pub use crate::format::QueryResultsFormat;
 pub use crate::parser::{FromReadQueryResultsReader, FromReadSolutionsReader, QueryResultsParser};
 pub use crate::serializer::{QueryResultsSerializer, ToWriteSolutionsWriter};

--- a/lib/spargebra/src/lib.rs
+++ b/lib/spargebra/src/lib.rs
@@ -10,6 +10,6 @@ mod query;
 pub mod term;
 mod update;
 
-pub use parser::ParseError;
+pub use parser::SparqlSyntaxError;
 pub use query::*;
 pub use update::*;

--- a/lib/spargebra/src/query.rs
+++ b/lib/spargebra/src/query.rs
@@ -1,5 +1,5 @@
 use crate::algebra::*;
-use crate::parser::{parse_query, ParseError};
+use crate::parser::{parse_query, SparqlSyntaxError};
 use crate::term::*;
 use oxiri::Iri;
 use std::fmt;
@@ -17,7 +17,7 @@ use std::str::FromStr;
 ///     query.to_sse(),
 ///     "(project (?s ?p ?o) (bgp (triple ?s ?p ?o)))"
 /// );
-/// # Ok::<_, spargebra::ParseError>(())
+/// # Ok::<_, spargebra::SparqlSyntaxError>(())
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub enum Query {
@@ -63,7 +63,7 @@ pub enum Query {
 
 impl Query {
     /// Parses a SPARQL query with an optional base IRI to resolve relative IRIs in the query.
-    pub fn parse(query: &str, base_iri: Option<&str>) -> Result<Self, ParseError> {
+    pub fn parse(query: &str, base_iri: Option<&str>) -> Result<Self, SparqlSyntaxError> {
         parse_query(query, base_iri)
     }
 
@@ -276,7 +276,7 @@ impl fmt::Display for Query {
 }
 
 impl FromStr for Query {
-    type Err = ParseError;
+    type Err = SparqlSyntaxError;
 
     fn from_str(query: &str) -> Result<Self, Self::Err> {
         Self::parse(query, None)
@@ -284,7 +284,7 @@ impl FromStr for Query {
 }
 
 impl<'a> TryFrom<&'a str> for Query {
-    type Error = ParseError;
+    type Error = SparqlSyntaxError;
 
     fn try_from(query: &str) -> Result<Self, Self::Error> {
         Self::from_str(query)
@@ -292,7 +292,7 @@ impl<'a> TryFrom<&'a str> for Query {
 }
 
 impl<'a> TryFrom<&'a String> for Query {
-    type Error = ParseError;
+    type Error = SparqlSyntaxError;
 
     fn try_from(query: &String) -> Result<Self, Self::Error> {
         Self::from_str(query)

--- a/lib/spargebra/src/update.rs
+++ b/lib/spargebra/src/update.rs
@@ -1,5 +1,5 @@
 use crate::algebra::*;
-use crate::parser::{parse_update, ParseError};
+use crate::parser::{parse_update, SparqlSyntaxError};
 use crate::term::*;
 use oxiri::Iri;
 use std::fmt;
@@ -14,7 +14,7 @@ use std::str::FromStr;
 /// let update = Update::parse(update_str, None)?;
 /// assert_eq!(update.to_string().trim(), update_str);
 /// assert_eq!(update.to_sse(), "(update (clear all))");
-/// # Ok::<_, spargebra::ParseError>(())
+/// # Ok::<_, spargebra::SparqlSyntaxError>(())
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct Update {
@@ -26,7 +26,7 @@ pub struct Update {
 
 impl Update {
     /// Parses a SPARQL update with an optional base IRI to resolve relative IRIs in the query.
-    pub fn parse(update: &str, base_iri: Option<&str>) -> Result<Self, ParseError> {
+    pub fn parse(update: &str, base_iri: Option<&str>) -> Result<Self, SparqlSyntaxError> {
         parse_update(update, base_iri)
     }
 
@@ -68,7 +68,7 @@ impl fmt::Display for Update {
 }
 
 impl FromStr for Update {
-    type Err = ParseError;
+    type Err = SparqlSyntaxError;
 
     fn from_str(update: &str) -> Result<Self, Self::Err> {
         Self::parse(update, None)
@@ -76,7 +76,7 @@ impl FromStr for Update {
 }
 
 impl<'a> TryFrom<&'a str> for Update {
-    type Error = ParseError;
+    type Error = SparqlSyntaxError;
 
     fn try_from(update: &str) -> Result<Self, Self::Error> {
         Self::from_str(update)
@@ -84,7 +84,7 @@ impl<'a> TryFrom<&'a str> for Update {
 }
 
 impl<'a> TryFrom<&'a String> for Update {
-    type Error = ParseError;
+    type Error = SparqlSyntaxError;
 
     fn try_from(update: &String) -> Result<Self, Self::Error> {
         Self::from_str(update)

--- a/python/src/io.rs
+++ b/python/src/io.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::needless_option_as_deref)]
 
 use crate::model::{hash, PyQuad, PyTriple};
-use oxigraph::io::{FromReadQuadReader, ParseError, RdfFormat, RdfParser, RdfSerializer};
+use oxigraph::io::{FromReadQuadReader, RdfFormat, RdfParseError, RdfParser, RdfSerializer};
 use oxigraph::model::QuadRef;
 use pyo3::exceptions::{PyDeprecationWarning, PySyntaxError, PyValueError};
 use pyo3::intern;
@@ -556,9 +556,9 @@ pub enum PyRdfFormatInput {
     MediaType(String),
 }
 
-pub fn map_parse_error(error: ParseError, file_path: Option<PathBuf>) -> PyErr {
+pub fn map_parse_error(error: RdfParseError, file_path: Option<PathBuf>) -> PyErr {
     match error {
-        ParseError::Syntax(error) => {
+        RdfParseError::Syntax(error) => {
             // Python 3.9 does not support end line and end column
             if python_version() >= (3, 10) {
                 let params = if let Some(location) = error.location() {
@@ -588,7 +588,7 @@ pub fn map_parse_error(error: ParseError, file_path: Option<PathBuf>) -> PyErr {
                 PySyntaxError::new_err((error.to_string(), params))
             }
         }
-        ParseError::Io(error) => error.into(),
+        RdfParseError::Io(error) => error.into(),
     }
 }
 

--- a/python/src/sparql.rs
+++ b/python/src/sparql.rs
@@ -4,8 +4,8 @@ use crate::store::map_storage_error;
 use oxigraph::io::RdfSerializer;
 use oxigraph::model::Term;
 use oxigraph::sparql::results::{
-    FromReadQueryResultsReader, FromReadSolutionsReader, ParseError, QueryResultsFormat,
-    QueryResultsParser, QueryResultsSerializer,
+    FromReadQueryResultsReader, FromReadSolutionsReader, QueryResultsFormat,
+    QueryResultsParseError, QueryResultsParser, QueryResultsSerializer,
 };
 use oxigraph::sparql::{
     EvaluationError, Query, QueryResults, QuerySolution, QuerySolutionIter, QueryTripleIter,
@@ -699,9 +699,12 @@ pub fn map_evaluation_error(error: EvaluationError) -> PyErr {
     }
 }
 
-pub fn map_query_results_parse_error(error: ParseError, file_path: Option<PathBuf>) -> PyErr {
+pub fn map_query_results_parse_error(
+    error: QueryResultsParseError,
+    file_path: Option<PathBuf>,
+) -> PyErr {
     match error {
-        ParseError::Syntax(error) => {
+        QueryResultsParseError::Syntax(error) => {
             // Python 3.9 does not support end line and end column
             if python_version() >= (3, 10) {
                 let params = if let Some(location) = error.location() {
@@ -731,6 +734,6 @@ pub fn map_query_results_parse_error(error: ParseError, file_path: Option<PathBu
                 PySyntaxError::new_err((error.to_string(), params))
             }
         }
-        ParseError::Io(error) => error.into(),
+        QueryResultsParseError::Io(error) => error.into(),
     }
 }


### PR DESCRIPTION
While reading the code, I kept being really confused by which ParseError and SyntaxError belong to which crate, esp when they are converted from one to another and back.  I noticed that even in one case you had aliased the name of it to a more specific one to use inside the file, so I think this will make the code a bit more readable.

```rust
oxrdfio::error::ParseError -> RdfParseError
oxrdfio::error::SyntaxError -> RdfSyntaxError 

spargebra::parser::ParseError -> QueryParseError

sparesults::error::ParseError -> ResultsParseError
sparesults::error::SyntaxError -> ResultsSyntaxError

in lib/spargebra/src/parser.rs:
enum ParseErrorKind {
  Parser -> SyntaxError
}
```

See https://github.com/oxigraph/oxigraph/pull/775#discussion_r1484586466