### PR TITLE
feat: Support casting of `Term`

### DIFF
--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -114,7 +114,7 @@ impl TryFrom<Term> for BlankNode {
             Ok(node)
         } else {
             Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert a term to a blank node: {}",
+                "Cannot convert term to a blank node: {}",
                 term
             ))
             .into())

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -103,22 +103,6 @@ impl fmt::Display for BlankNode {
     }
 }
 
-impl TryFrom<Term> for BlankNode {
-    type Error = TermCastError;
-
-    #[inline]
-    fn try_from(term: Term) -> Result<Self, Self::Error> {
-        if let Term::BlankNode(node) = term {
-            Ok(node)
-        } else {
-            Err(
-                TermCastErrorKind::Msg(format!("Cannot convert term to a blank node: {}", term))
-                    .into(),
-            )
-        }
-    }
-}
-
 impl Default for BlankNode {
     /// Builds a new RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node) with a unique id.
     #[inline]
@@ -246,6 +230,22 @@ impl<'a> From<BlankNodeRef<'a>> for BlankNode {
     #[inline]
     fn from(node: BlankNodeRef<'a>) -> Self {
         node.into_owned()
+    }
+}
+
+impl TryFrom<Term> for BlankNode {
+    type Error = TermCastError;
+
+    #[inline]
+    fn try_from(term: Term) -> Result<Self, Self::Error> {
+        if let Term::BlankNode(node) = term {
+            Ok(node)
+        } else {
+            Err(
+                TermCastErrorKind::Msg(format!("Cannot convert term to a blank node: {}", term))
+                    .into(),
+            )
+        }
     }
 }
 

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -1,7 +1,7 @@
+use crate::{Term, TermCastError, TermCastErrorKind};
 use rand::random;
 use std::io::Write;
 use std::{fmt, str};
-use crate::{TermCastError, TermCastErrorKind, Term};
 
 /// An owned RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 ///
@@ -111,11 +111,10 @@ impl TryFrom<Term> for BlankNode {
         if let Term::BlankNode(node) = term {
             Ok(node)
         } else {
-            Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert term to a blank node: {}",
-                term
-            ))
-            .into())
+            Err(
+                TermCastErrorKind::Msg(format!("Cannot convert term to a blank node: {}", term))
+                    .into(),
+            )
         }
     }
 }
@@ -382,13 +381,16 @@ mod tests {
 
     #[test]
     fn casting() {
-        let bnode: Result<BlankNode, TermCastError> = Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
+        let bnode: Result<BlankNode, TermCastError> =
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         assert_eq!(bnode.unwrap(), BlankNode::new_from_unique_id(0x42));
 
-        let literal: Result<BlankNode, TermCastError> = Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
+        let literal: Result<BlankNode, TermCastError> =
+            Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         assert_eq!(literal.is_err(), true);
 
-        let named_node: Result<BlankNode, TermCastError> = Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
+        let named_node: Result<BlankNode, TermCastError> =
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         assert_eq!(named_node.is_err(), true);
     }
 

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -2,6 +2,8 @@ use rand::random;
 use std::io::Write;
 use std::{fmt, str};
 
+use crate::Term;
+
 /// An owned RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 ///
 /// The common way to create a new blank node is to use the [`BlankNode::default()`] function.
@@ -99,6 +101,16 @@ impl fmt::Display for BlankNode {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_ref().fmt(f)
+    }
+}
+
+impl From<Term> for Option<BlankNode> {
+    #[inline]
+    fn from(term: Term) -> Self {
+        match term {
+            Term::BlankNode(node) => Some(node),
+            _ => None,
+        }
     }
 }
 
@@ -352,12 +364,26 @@ pub struct BlankNodeIdParseError;
 mod tests {
     #![allow(clippy::panic_in_result_fn)]
 
+    use crate::{Literal, NamedNode};
+
     use super::*;
 
     #[test]
     fn as_str_partial() {
         let b = BlankNode::new_from_unique_id(0x42);
         assert_eq!(b.as_str(), "42");
+    }
+
+    #[test]
+    fn casting() {
+        let bnode: Option<BlankNode> = Term::BlankNode(BlankNode::new_from_unique_id(0x42)).into();
+        assert_eq!(bnode, Some(BlankNode::new_from_unique_id(0x42)));
+
+        let literal: Option<BlankNode> = Term::Literal(Literal::new_simple_literal("Hello World!")).into();
+        assert_eq!(literal, None);
+
+        let named_node: Option<BlankNode> = Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).into();
+        assert_eq!(named_node, None);
     }
 
     #[test]

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -241,7 +241,10 @@ impl TryFrom<Term> for BlankNode {
         if let Term::BlankNode(node) = term {
             Ok(node)
         } else {
-            Err(TryFromTermError { term, target: "BlankNode" })
+            Err(TryFromTermError {
+                term,
+                target: "BlankNode",
+            })
         }
     }
 }
@@ -386,15 +389,27 @@ mod tests {
             Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         assert_eq!(literal.is_err(), true);
         let err = literal.unwrap_err();
-        assert_eq!(err.to_string(), "\"Hello World!\" can not be converted to a BlankNode");
-        assert_eq!(Term::from(err), Term::Literal(Literal::new_simple_literal("Hello World!")));
+        assert_eq!(
+            err.to_string(),
+            "\"Hello World!\" can not be converted to a BlankNode"
+        );
+        assert_eq!(
+            Term::from(err),
+            Term::Literal(Literal::new_simple_literal("Hello World!"))
+        );
 
         let named_node: Result<BlankNode, TryFromTermError> =
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         assert_eq!(named_node.is_err(), true);
         let named_node_error = named_node.unwrap_err();
-        assert_eq!(named_node_error.to_string(), "<http://example.org/test> can not be converted to a BlankNode");
-        assert_eq!(Term::from(named_node_error), Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(
+            named_node_error.to_string(),
+            "<http://example.org/test> can not be converted to a BlankNode"
+        );
+        assert_eq!(
+            Term::from(named_node_error),
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
     }
 
     #[test]

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -1,9 +1,7 @@
 use rand::random;
 use std::io::Write;
 use std::{fmt, str};
-
-use crate::cast_error::{TermCastError, TermCastErrorKind};
-use crate::Term;
+use crate::{TermCastError, TermCastErrorKind, Term};
 
 /// An owned RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 ///

--- a/lib/oxrdf/src/cast_error.rs
+++ b/lib/oxrdf/src/cast_error.rs
@@ -1,6 +1,5 @@
 use std::{fmt, str};
 
-
 use crate::{NamedNode, Subject, Term};
 
 // An error return if trying to cast a term as something it cannot be converted to.
@@ -8,7 +7,7 @@ use crate::{NamedNode, Subject, Term};
 #[error("{term} can not be converted to a {target}")]
 pub struct TryFromTermError {
     pub(crate) term: Term,
-    pub(crate) target: &'static str
+    pub(crate) target: &'static str,
 }
 
 impl From<TryFromTermError> for Term {
@@ -32,7 +31,7 @@ impl fmt::Display for TripleConstructionError {
             (Some(e), Some(e2)) => write!(f, "subject: [{}], predicate: [{}]", e, e2),
             (Some(e), _) => write!(f, "subject: [{}]", e),
             (_, Some(e)) => write!(f, "predicate: [{}]", e),
-            _ => write!(f, "object: {}", self.object)
+            _ => write!(f, "object: {}", self.object),
         }
     }
 }

--- a/lib/oxrdf/src/cast_error.rs
+++ b/lib/oxrdf/src/cast_error.rs
@@ -1,15 +1,38 @@
-use std::error::Error;
+use std::{fmt, str};
 
-/// An error return if trying to cast a term as something it cannot be converted to.
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct TermCastError(#[from] pub TermCastErrorKind);
 
-/// An error return if trying to cast a term as something it cannot be converted to.
+use crate::{NamedNode, Subject, Term};
+
+// An error return if trying to cast a term as something it cannot be converted to.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{term} can not be converted to a {target}")]
+pub struct TryFromTermError {
+    pub(crate) term: Term,
+    pub(crate) target: &'static str
+}
+
+impl From<TryFromTermError> for Term {
+    #[inline]
+    fn from(error: TryFromTermError) -> Self {
+        error.term
+    }
+}
+
+// An error return if trying to construct an invalid triple.
 #[derive(Debug, thiserror::Error)]
-pub enum TermCastErrorKind {
-    #[error("{0}")]
-    Msg(String),
-    #[error("{0}")]
-    Other(#[source] Box<dyn Error + Send + Sync + 'static>),
+pub struct TripleConstructionError {
+    pub(crate) subject: Result<Subject, TryFromTermError>,
+    pub(crate) predicate: Result<NamedNode, TryFromTermError>,
+    pub(crate) object: Term,
+}
+
+impl fmt::Display for TripleConstructionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.subject.clone().err(), self.predicate.clone().err()) {
+            (Some(e), Some(e2)) => write!(f, "subject: [{}], predicate: [{}]", e, e2),
+            (Some(e), _) => write!(f, "subject: [{}]", e),
+            (_, Some(e)) => write!(f, "predicate: [{}]", e),
+            _ => write!(f, "object: {}", self.object)
+        }
+    }
 }

--- a/lib/oxrdf/src/cast_error.rs
+++ b/lib/oxrdf/src/cast_error.rs
@@ -1,0 +1,15 @@
+use std::error::Error;
+
+/// An error return if some content in the database is corrupted.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct TermCastError(#[from] pub TermCastErrorKind);
+
+/// An error return if some content in the database is corrupted.
+#[derive(Debug, thiserror::Error)]
+pub enum TermCastErrorKind {
+    #[error("{0}")]
+    Msg(String),
+    #[error("{0}")]
+    Other(#[source] Box<dyn Error + Send + Sync + 'static>),
+}

--- a/lib/oxrdf/src/cast_error.rs
+++ b/lib/oxrdf/src/cast_error.rs
@@ -1,11 +1,11 @@
 use std::error::Error;
 
-/// An error return if some content in the database is corrupted.
+/// An error return if trying to cast a term as something it cannot be converted to.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct TermCastError(#[from] pub TermCastErrorKind);
 
-/// An error return if some content in the database is corrupted.
+/// An error return if trying to cast a term as something it cannot be converted to.
 #[derive(Debug, thiserror::Error)]
 pub enum TermCastErrorKind {
     #[error("{0}")]

--- a/lib/oxrdf/src/cast_error.rs
+++ b/lib/oxrdf/src/cast_error.rs
@@ -22,6 +22,7 @@ impl From<TryFromTermError> for Term {
 pub struct TripleConstructionError {
     pub(crate) subject: Result<Subject, TryFromTermError>,
     pub(crate) predicate: Result<NamedNode, TryFromTermError>,
+    #[allow(dead_code)]
     pub(crate) object: Term,
 }
 
@@ -31,7 +32,7 @@ impl fmt::Display for TripleConstructionError {
             (Some(e), Some(e2)) => write!(f, "subject: [{}], predicate: [{}]", e, e2),
             (Some(e), _) => write!(f, "subject: [{}]", e),
             (_, Some(e)) => write!(f, "predicate: [{}]", e),
-            _ => write!(f, "object: {}", self.object),
+            _ => write!(f, "No Errors"),
         }
     }
 }

--- a/lib/oxrdf/src/lib.rs
+++ b/lib/oxrdf/src/lib.rs
@@ -17,7 +17,7 @@ mod variable;
 pub mod vocab;
 
 pub use crate::blank_node::{BlankNode, BlankNodeIdParseError, BlankNodeRef};
-pub use crate::cast_error::{TryFromTermError, TripleConstructionError};
+pub use crate::cast_error::{TripleConstructionError, TryFromTermError};
 pub use crate::dataset::Dataset;
 pub use crate::graph::Graph;
 pub use crate::literal::{Literal, LiteralRef};

--- a/lib/oxrdf/src/lib.rs
+++ b/lib/oxrdf/src/lib.rs
@@ -5,6 +5,7 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/oxigraph/oxigraph/main/logo.svg")]
 
 mod blank_node;
+mod cast_error;
 pub mod dataset;
 pub mod graph;
 mod interning;
@@ -13,10 +14,10 @@ mod named_node;
 mod parser;
 mod triple;
 mod variable;
-mod cast_error;
 pub mod vocab;
 
 pub use crate::blank_node::{BlankNode, BlankNodeIdParseError, BlankNodeRef};
+pub use crate::cast_error::{TermCastError, TermCastErrorKind};
 pub use crate::dataset::Dataset;
 pub use crate::graph::Graph;
 pub use crate::literal::{Literal, LiteralRef};
@@ -27,6 +28,5 @@ pub use crate::triple::{
     SubjectRef, Term, TermRef, Triple, TripleRef,
 };
 pub use crate::variable::{Variable, VariableNameParseError, VariableRef};
-pub use crate::cast_error::{TermCastError, TermCastErrorKind};
 pub use oxilangtag::LanguageTagParseError;
 pub use oxiri::IriParseError;

--- a/lib/oxrdf/src/lib.rs
+++ b/lib/oxrdf/src/lib.rs
@@ -17,7 +17,7 @@ mod variable;
 pub mod vocab;
 
 pub use crate::blank_node::{BlankNode, BlankNodeIdParseError, BlankNodeRef};
-pub use crate::cast_error::{TermCastError, TermCastErrorKind};
+pub use crate::cast_error::TryFromTermError;
 pub use crate::dataset::Dataset;
 pub use crate::graph::Graph;
 pub use crate::literal::{Literal, LiteralRef};

--- a/lib/oxrdf/src/lib.rs
+++ b/lib/oxrdf/src/lib.rs
@@ -13,6 +13,7 @@ mod named_node;
 mod parser;
 mod triple;
 mod variable;
+mod cast_error;
 pub mod vocab;
 
 pub use crate::blank_node::{BlankNode, BlankNodeIdParseError, BlankNodeRef};
@@ -26,5 +27,6 @@ pub use crate::triple::{
     SubjectRef, Term, TermRef, Triple, TripleRef,
 };
 pub use crate::variable::{Variable, VariableNameParseError, VariableRef};
+pub use crate::cast_error::{TermCastError, TermCastErrorKind};
 pub use oxilangtag::LanguageTagParseError;
 pub use oxiri::IriParseError;

--- a/lib/oxrdf/src/lib.rs
+++ b/lib/oxrdf/src/lib.rs
@@ -17,7 +17,7 @@ mod variable;
 pub mod vocab;
 
 pub use crate::blank_node::{BlankNode, BlankNodeIdParseError, BlankNodeRef};
-pub use crate::cast_error::TryFromTermError;
+pub use crate::cast_error::{TryFromTermError, TripleConstructionError};
 pub use crate::dataset::Dataset;
 pub use crate::graph::Graph;
 pub use crate::literal::{Literal, LiteralRef};

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -169,11 +169,10 @@ impl TryFrom<Term> for Literal {
         if let Term::Literal(node) = term {
             Ok(node)
         } else {
-            Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert term to a literal: {}",
-                term
-            ))
-            .into())
+            Err(
+                TermCastErrorKind::Msg(format!("Cannot convert term to a literal: {}", term))
+                    .into(),
+            )
         }
     }
 }
@@ -677,16 +676,21 @@ mod tests {
         );
     }
 
-
     #[test]
     fn casting() {
-        let literal: Result<Literal, TermCastError> = Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
-        assert_eq!(literal.unwrap(), Literal::new_simple_literal("Hello World!"));
+        let literal: Result<Literal, TermCastError> =
+            Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
+        assert_eq!(
+            literal.unwrap(),
+            Literal::new_simple_literal("Hello World!")
+        );
 
-        let bnode: Result<Literal, TermCastError> = Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
+        let bnode: Result<Literal, TermCastError> =
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         assert_eq!(bnode.is_err(), true);
 
-        let named_node: Result<Literal, TermCastError> = Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
+        let named_node: Result<Literal, TermCastError> =
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         assert_eq!(named_node.is_err(), true);
     }
 

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -161,22 +161,6 @@ impl fmt::Display for Literal {
     }
 }
 
-impl TryFrom<Term> for Literal {
-    type Error = TermCastError;
-
-    #[inline]
-    fn try_from(term: Term) -> Result<Self, Self::Error> {
-        if let Term::Literal(node) = term {
-            Ok(node)
-        } else {
-            Err(
-                TermCastErrorKind::Msg(format!("Cannot convert term to a literal: {}", term))
-                    .into(),
-            )
-        }
-    }
-}
-
 impl<'a> From<&'a str> for Literal {
     #[inline]
     fn from(value: &'a str) -> Self {
@@ -435,6 +419,22 @@ impl From<DayTimeDuration> for Literal {
     #[inline]
     fn from(value: DayTimeDuration) -> Self {
         Self::new_typed_literal(value.to_string(), xsd::DAY_TIME_DURATION)
+    }
+}
+
+impl TryFrom<Term> for Literal {
+    type Error = TermCastError;
+
+    #[inline]
+    fn try_from(term: Term) -> Result<Self, Self::Error> {
+        if let Term::Literal(node) = term {
+            Ok(node)
+        } else {
+            Err(
+                TermCastErrorKind::Msg(format!("Cannot convert term to a literal: {}", term))
+                    .into(),
+            )
+        }
     }
 }
 

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -1,7 +1,6 @@
 use crate::named_node::NamedNode;
-use crate::cast_error::{TermCastError, TermCastErrorKind};
 use crate::vocab::{rdf, xsd};
-use crate::{NamedNodeRef, Term};
+use crate::{NamedNodeRef, Term, TermCastError, TermCastErrorKind};
 use oxilangtag::{LanguageTag, LanguageTagParseError};
 #[cfg(feature = "oxsdatatypes")]
 use oxsdatatypes::*;
@@ -655,9 +654,8 @@ pub fn print_quoted_str(string: &str, f: &mut impl Write) -> fmt::Result {
 mod tests {
     #![allow(clippy::panic_in_result_fn)]
 
-    use crate::BlankNode;
-
     use super::*;
+    use crate::BlankNode;
 
     #[test]
     fn test_simple_literal_equality() {

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -430,7 +430,10 @@ impl TryFrom<Term> for Literal {
         if let Term::Literal(node) = term {
             Ok(node)
         } else {
-            Err(TryFromTermError { term, target: "Literal" })
+            Err(TryFromTermError {
+                term,
+                target: "Literal",
+            })
         }
     }
 }
@@ -685,18 +688,36 @@ mod tests {
         let bnode: Result<Literal, TryFromTermError> =
             Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         let bnode_err = bnode.unwrap_err();
-        assert_eq!(bnode_err.term, Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(
+            bnode_err.term,
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
         assert_eq!(bnode_err.target, "Literal");
-        assert_eq!(bnode_err.to_string(), "_:42 can not be converted to a Literal");
-        assert_eq!(Term::from(bnode_err), Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(
+            bnode_err.to_string(),
+            "_:42 can not be converted to a Literal"
+        );
+        assert_eq!(
+            Term::from(bnode_err),
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
 
         let named_node: Result<Literal, TryFromTermError> =
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         let named_node_err = named_node.unwrap_err();
-        assert_eq!(named_node_err.term, Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(
+            named_node_err.term,
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
         assert_eq!(named_node_err.target, "Literal");
-        assert_eq!(named_node_err.to_string(), "<http://example.org/test> can not be converted to a Literal");
-        assert_eq!(Term::from(named_node_err), Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(
+            named_node_err.to_string(),
+            "<http://example.org/test> can not be converted to a Literal"
+        );
+        assert_eq!(
+            Term::from(named_node_err),
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
     }
 
     #[test]

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -1,7 +1,7 @@
+use crate::{Term, TermCastError, TermCastErrorKind};
 use oxiri::{Iri, IriParseError};
 use std::cmp::Ordering;
 use std::fmt;
-use crate::{TermCastErrorKind, Term, TermCastError};
 
 /// An owned RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).
 ///
@@ -226,11 +226,10 @@ impl TryFrom<Term> for NamedNode {
         if let Term::NamedNode(node) = term {
             Ok(node)
         } else {
-            Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert term to a named node: {}",
-                term
-            ))
-            .into())
+            Err(
+                TermCastErrorKind::Msg(format!("Cannot convert term to a named node: {}", term))
+                    .into(),
+            )
         }
     }
 }
@@ -257,19 +256,25 @@ impl<'a> From<Iri<&'a str>> for NamedNodeRef<'a> {
 mod tests {
     #![allow(clippy::panic_in_result_fn)]
 
-    use crate::{Literal, BlankNode};
+    use crate::{BlankNode, Literal};
 
     use super::*;
 
     #[test]
     fn casting() {
-        let named_node: Result<NamedNode, TermCastError> = Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
-        assert_eq!(named_node.unwrap(), NamedNode::new("http://example.org/test").unwrap());
-        
-        let literal: Result<NamedNode, TermCastError> = Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
+        let named_node: Result<NamedNode, TermCastError> =
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
+        assert_eq!(
+            named_node.unwrap(),
+            NamedNode::new("http://example.org/test").unwrap()
+        );
+
+        let literal: Result<NamedNode, TermCastError> =
+            Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         assert_eq!(literal.is_err(), true);
 
-        let bnode: Result<NamedNode, TermCastError> = Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
+        let bnode: Result<NamedNode, TermCastError> =
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         assert_eq!(bnode.is_err(), true);
     }
 }

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -244,7 +244,10 @@ impl TryFrom<Term> for NamedNode {
         if let Term::NamedNode(node) = term {
             Ok(node)
         } else {
-            Err(TryFromTermError { term, target: "NamedNode" })
+            Err(TryFromTermError {
+                term,
+                target: "NamedNode",
+            })
         }
     }
 }
@@ -269,17 +272,35 @@ mod tests {
         let literal: Result<NamedNode, TryFromTermError> =
             Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         let literal_err = literal.unwrap_err();
-        assert_eq!(literal_err.term, Term::Literal(Literal::new_simple_literal("Hello World!")));
+        assert_eq!(
+            literal_err.term,
+            Term::Literal(Literal::new_simple_literal("Hello World!"))
+        );
         assert_eq!(literal_err.target, "NamedNode");
-        assert_eq!(literal_err.to_string(), "\"Hello World!\" can not be converted to a NamedNode");
-        assert_eq!(Term::from(literal_err), Term::Literal(Literal::new_simple_literal("Hello World!")));
+        assert_eq!(
+            literal_err.to_string(),
+            "\"Hello World!\" can not be converted to a NamedNode"
+        );
+        assert_eq!(
+            Term::from(literal_err),
+            Term::Literal(Literal::new_simple_literal("Hello World!"))
+        );
 
         let bnode: Result<NamedNode, TryFromTermError> =
             Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         let bnode_err = bnode.unwrap_err();
-        assert_eq!(bnode_err.term, Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(
+            bnode_err.term,
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
         assert_eq!(bnode_err.target, "NamedNode");
-        assert_eq!(bnode_err.to_string(), "_:42 can not be converted to a NamedNode");
-        assert_eq!(Term::from(bnode_err), Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(
+            bnode_err.to_string(),
+            "_:42 can not be converted to a NamedNode"
+        );
+        assert_eq!(
+            Term::from(bnode_err),
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
     }
 }

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -218,22 +218,6 @@ impl PartialOrd<NamedNodeRef<'_>> for NamedNode {
     }
 }
 
-impl TryFrom<Term> for NamedNode {
-    type Error = TermCastError;
-
-    #[inline]
-    fn try_from(term: Term) -> Result<Self, Self::Error> {
-        if let Term::NamedNode(node) = term {
-            Ok(node)
-        } else {
-            Err(
-                TermCastErrorKind::Msg(format!("Cannot convert term to a named node: {}", term))
-                    .into(),
-            )
-        }
-    }
-}
-
 impl From<Iri<String>> for NamedNode {
     #[inline]
     fn from(iri: Iri<String>) -> Self {
@@ -248,6 +232,22 @@ impl<'a> From<Iri<&'a str>> for NamedNodeRef<'a> {
     fn from(iri: Iri<&'a str>) -> Self {
         Self {
             iri: iri.into_inner(),
+        }
+    }
+}
+
+impl TryFrom<Term> for NamedNode {
+    type Error = TermCastError;
+
+    #[inline]
+    fn try_from(term: Term) -> Result<Self, Self::Error> {
+        if let Term::NamedNode(node) = term {
+            Ok(node)
+        } else {
+            Err(
+                TermCastErrorKind::Msg(format!("Cannot convert term to a named node: {}", term))
+                    .into(),
+            )
         }
     }
 }

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -1,8 +1,7 @@
 use oxiri::{Iri, IriParseError};
 use std::cmp::Ordering;
 use std::fmt;
-
-use crate::{cast_error::TermCastErrorKind, Term, TermCastError};
+use crate::{TermCastErrorKind, Term, TermCastError};
 
 /// An owned RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).
 ///

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -754,11 +754,14 @@ impl Triple {
     /// Builds an RDF [triple](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple).
     #[inline]
     pub fn new_maybe(
-        subject: impl Into<Option<Subject>>,
-        predicate: impl Into<Option<NamedNode>>,
-        object: impl Into<Option<Term>>,
+        subject: impl Into<Term>,
+        predicate: impl Into<Term>,
+        object: impl Into<Term>,
     ) -> Option<Self> {
-        match (subject.into(), predicate.into(), object.into()) {
+        match (
+            Into::<Option<Subject>>::into(Into::<Term>::into(subject)),
+            Into::<Option<NamedNode>>::into(Into::<Term>::into(predicate)), 
+            Into::<Option<Term>>::into(Into::<Term>::into(object))) {
             (Some(subject), Some(predicate), Some(object)) => Some(Self {
                 subject,
                 predicate,
@@ -1298,10 +1301,18 @@ mod tests {
 
     #[test]
     fn constructing_triple() {
+        use super::*;
+
         let optional_triple = Triple::new_maybe(
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()), 
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
+
+        let optional_triple_2 = Triple::new_maybe(
+            NamedNode::new("http://example.org/test").unwrap(), 
+            NamedNode::new("http://example.org/test").unwrap(),
+            NamedNode::new("http://example.org/test").unwrap()
         );
 
         let bad_triple = Triple::new_maybe(
@@ -1310,14 +1321,29 @@ mod tests {
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
         );
 
+        let bad_triple_2 = Triple::new_maybe(
+            BlankNode::new("abc123").unwrap(), 
+            NamedNode::new("http://example.org/test").unwrap(),
+            NamedNode::new("http://example.org/test").unwrap()
+        );
+
         let triple: Triple = Triple::new(
             Subject::NamedNode(NamedNode::new("http://example.org/test").unwrap()), 
             NamedNode::new("http://example.org/test").unwrap(),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
         );
 
+        let triple_2: Triple = Triple::new(
+            NamedNode::new("http://example.org/test").unwrap(), 
+            NamedNode::new("http://example.org/test").unwrap(),
+            NamedNode::new("http://example.org/test").unwrap()
+        );
+
         assert_eq!(optional_triple, Some(triple));
+        assert_eq!(optional_triple, Some(triple_2.clone()));
+        assert_eq!(optional_triple_2, Some(triple_2));
         assert_eq!(bad_triple, None);
+        assert_eq!(bad_triple_2, None);
     }
 
     #[test]

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -1,8 +1,8 @@
 use crate::blank_node::BlankNode;
-use crate::cast_error::TermCastErrorKind;
+use crate::cast_error::TripleConstructionError;
 use crate::literal::Literal;
 use crate::named_node::NamedNode;
-use crate::{BlankNodeRef, LiteralRef, NamedNodeRef, TermCastError};
+use crate::{BlankNodeRef, LiteralRef, NamedNodeRef, TryFromTermError};
 use std::fmt;
 
 /// The owned union of [IRIs](https://www.w3.org/TR/rdf11-concepts/#dfn-iri) and [blank nodes](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
@@ -225,7 +225,7 @@ impl From<BlankNodeRef<'_>> for Subject {
 }
 
 impl TryFrom<Term> for Subject {
-    type Error = TermCastError;
+    type Error = TryFromTermError;
 
     #[inline]
     fn try_from(term: Term) -> Result<Self, Self::Error> {
@@ -234,11 +234,7 @@ impl TryFrom<Term> for Subject {
             Term::BlankNode(node) => Ok(Subject::BlankNode(node)),
             #[cfg(feature = "rdf-star")]
             Term::Triple(triple) => Ok(Subject::Triple(triple)),
-            Term::Literal(literal) => Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert a literal to a subject: {}",
-                literal
-            ))
-            .into()),
+            Term::Literal(_) => Err(TryFromTermError { term, target: "Subject" }),
         }
     }
 }
@@ -764,12 +760,14 @@ impl Triple {
         subject: impl Into<Term>,
         predicate: impl Into<Term>,
         object: impl Into<Term>,
-    ) -> Result<Self, TermCastError> {
-        Ok(Self {
-            subject: TryInto::<Subject>::try_into(subject.into())?,
-            predicate: TryInto::<NamedNode>::try_into(predicate.into())?,
-            object: object.into(),
-        })
+    ) -> Result<Self, TripleConstructionError> {
+        let subject: Result<Subject, TryFromTermError> = TryInto::<Subject>::try_into(subject.into());
+        let predicate: Result<NamedNode, TryFromTermError> = TryInto::<NamedNode>::try_into(predicate.into());
+        if let (Ok (subject), Ok (predicate)) = (subject.clone(), predicate.clone()) {
+            Ok(Self { subject, predicate, object: object.into() })
+        } else {
+            Err(TripleConstructionError { subject, predicate, object: object.into() })
+        }
     }
 
     /// Encodes that this triple is in an [RDF dataset](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset).
@@ -802,14 +800,14 @@ impl fmt::Display for Triple {
 
 #[cfg(feature = "rdf-star")]
 impl TryFrom<Term> for Box<Triple> {
-    type Error = TermCastError;
+    type Error = TryFromTermError;
 
     #[inline]
     fn try_from(term: Term) -> Result<Self, Self::Error> {
         if let Term::Triple(node) = term {
             Ok(node)
         } else {
-            Err(TermCastErrorKind::Msg(format!("Cannot convert term to a triple: {}", term)).into())
+            Err(TryFromTermError { term, target: "Box<Triple>" })
         }
     }
 }
@@ -1289,20 +1287,32 @@ mod tests {
         };
         let triple_box = Box::new(triple);
 
-        let t: Result<Box<Triple>, TermCastError> = Term::Triple(triple_box.clone()).try_into();
+        let t: Result<Box<Triple>, TryFromTermError> = Term::Triple(triple_box.clone()).try_into();
         assert_eq!(t.unwrap(), triple_box.clone());
 
-        let literal: Result<Box<Triple>, TermCastError> =
+        let literal: Result<Box<Triple>, TryFromTermError> =
             Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
-        assert_eq!(literal.is_err(), true);
-
-        let bnode: Result<Box<Triple>, TermCastError> =
+        let literal_err = literal.unwrap_err();
+        assert_eq!(literal_err.term, Term::Literal(Literal::new_simple_literal("Hello World!")));
+        assert_eq!(literal_err.target, "Box<Triple>");
+        assert_eq!(literal_err.to_string(), "\"Hello World!\" can not be converted to a Box<Triple>");
+        assert_eq!(Term::from(literal_err), Term::Literal(Literal::new_simple_literal("Hello World!")));
+ 
+        let bnode: Result<Box<Triple>, TryFromTermError> =
             Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
-        assert_eq!(bnode.is_err(), true);
+        let bnode_err = bnode.unwrap_err();
+        assert_eq!(bnode_err.term, Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(bnode_err.target, "Box<Triple>");
+        assert_eq!(bnode_err.to_string(), "_:42 can not be converted to a Box<Triple>");
+        assert_eq!(Term::from(bnode_err), Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
 
-        let named_node: Result<Box<Triple>, TermCastError> =
+        let named_node: Result<Box<Triple>, TryFromTermError> =
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
-        assert_eq!(named_node.is_err(), true);
+        let named_node_err = named_node.unwrap_err();
+        assert_eq!(named_node_err.term, Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(named_node_err.target, "Box<Triple>");
+        assert_eq!(named_node_err.to_string(), "<http://example.org/test> can not be converted to a Box<Triple>");
+        assert_eq!(Term::from(named_node_err), Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
     }
 
     #[test]
@@ -1321,7 +1331,7 @@ mod tests {
             NamedNode::new("http://example.org/test").unwrap(),
         );
 
-        let bad_triple: Result<Triple, TermCastError> = Triple::new_from_terms(
+        let bad_triple: Result<Triple, TripleConstructionError> = Triple::new_from_terms(
             Term::Literal(Literal::new_simple_literal("abc123")),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
@@ -1330,6 +1340,12 @@ mod tests {
         let bad_triple_2 = Triple::new_from_terms(
             Term::Literal(Literal::new_simple_literal("abc123")),
             NamedNode::new("http://example.org/test").unwrap(),
+            NamedNode::new("http://example.org/test").unwrap(),
+        );
+
+        let bad_triple_3 = Triple::new_from_terms(
+            Term::Literal(Literal::new_simple_literal("abc123")),
+            BlankNode::new_from_unique_id(0x42),
             NamedNode::new("http://example.org/test").unwrap(),
         );
 
@@ -1350,8 +1366,30 @@ mod tests {
         assert_eq!(unwrapped, triple);
         assert_eq!(unwrapped, triple_2.clone());
         assert_eq!(optional_triple_2.unwrap(), triple_2);
-        assert_eq!(bad_triple.is_err(), true);
+        let bad_triple_err = bad_triple.unwrap_err();
+        assert_eq!(bad_triple_err.to_string(), "subject: [\"abc123\" can not be converted to a Subject]");
+        assert_eq!(bad_triple_err.subject.clone().unwrap_err().clone().term, Term::Literal(Literal::new_simple_literal("abc123")));
+        assert_eq!(bad_triple_err.subject.clone().unwrap_err().clone().target, "Subject");
+        assert_eq!(bad_triple_err.subject.unwrap_err().clone().to_string(), "\"abc123\" can not be converted to a Subject");
+
         assert_eq!(bad_triple_2.is_err(), true);
+        let bad_triple_2_err = bad_triple_2.unwrap_err();
+        assert_eq!(bad_triple_2_err.to_string(), "subject: [\"abc123\" can not be converted to a Subject]");
+        assert_eq!(bad_triple_2_err.subject.clone().unwrap_err().clone().term, Term::Literal(Literal::new_simple_literal("abc123")));
+        assert_eq!(bad_triple_2_err.subject.clone().unwrap_err().clone().target, "Subject");
+        assert_eq!(bad_triple_2_err.subject.unwrap_err().clone().to_string(), "\"abc123\" can not be converted to a Subject");
+        assert_eq!(bad_triple_2_err.predicate.unwrap(), NamedNode::new("http://example.org/test").unwrap());
+        assert_eq!(bad_triple_2_err.object, Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+
+        assert_eq!(bad_triple_3.is_err(), true);
+        let bad_triple_3_err = bad_triple_3.unwrap_err();
+        assert_eq!(bad_triple_3_err.to_string(), "subject: [\"abc123\" can not be converted to a Subject], predicate: [_:42 can not be converted to a NamedNode]");
+        assert_eq!(bad_triple_3_err.subject.clone().unwrap_err().clone().term, Term::Literal(Literal::new_simple_literal("abc123")));
+        assert_eq!(bad_triple_3_err.subject.clone().unwrap_err().clone().target, "Subject");
+        assert_eq!(bad_triple_3_err.subject.unwrap_err().clone().to_string(), "\"abc123\" can not be converted to a Subject");
+        assert_eq!(bad_triple_3_err.predicate.clone().unwrap_err().clone().term, Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(bad_triple_3_err.predicate.clone().unwrap_err().clone().target, "NamedNode");
+        assert_eq!(bad_triple_3_err.predicate.unwrap_err().clone().to_string(), "_:42 can not be converted to a NamedNode");
     }
 
     #[test]
@@ -1363,21 +1401,22 @@ mod tests {
         };
         let triple_box = Box::new(triple);
 
-        let t: Result<Subject, TermCastError> = Term::Triple(triple_box.clone()).try_into();
+        let t: Result<Subject, TryFromTermError> = Term::Triple(triple_box.clone()).try_into();
         assert_eq!(t.unwrap(), Subject::Triple(triple_box.clone()));
 
-        let literal: Result<Subject, TermCastError> =
+        let literal: Result<Subject, TryFromTermError> =
             Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         assert_eq!(literal.is_err(), true);
+        assert_eq!(literal.is_err(), true);
 
-        let bnode: Result<Subject, TermCastError> =
+        let bnode: Result<Subject, TryFromTermError> =
             Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         assert_eq!(
             bnode.unwrap(),
             Subject::BlankNode(BlankNode::new_from_unique_id(0x42))
         );
 
-        let named_node: Result<Subject, TermCastError> =
+        let named_node: Result<Subject, TryFromTermError> =
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         assert_eq!(
             named_node.unwrap(),

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -764,10 +764,8 @@ impl Triple {
         predicate: impl Into<Term>,
         object: impl Into<Term>,
     ) -> Result<Self, TripleConstructionError> {
-        let subject: Result<Subject, TryFromTermError> =
-            TryInto::<Subject>::try_into(subject.into());
-        let predicate: Result<NamedNode, TryFromTermError> =
-            TryInto::<NamedNode>::try_into(predicate.into());
+        let subject: Result<Subject, TryFromTermError> = subject.into().try_into();
+        let predicate: Result<NamedNode, TryFromTermError> = predicate.into().try_into();
         if let (Ok(subject), Ok(predicate)) = (subject.clone(), predicate.clone()) {
             Ok(Self {
                 subject,

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -196,25 +196,6 @@ impl fmt::Display for Subject {
     }
 }
 
-impl TryFrom<Term> for Subject {
-    type Error = TermCastError;
-
-    #[inline]
-    fn try_from(term: Term) -> Result<Self, Self::Error> {
-        match term {
-            Term::NamedNode(node) => Ok(Subject::NamedNode(node)),
-            Term::BlankNode(node) => Ok(Subject::BlankNode(node)),
-            #[cfg(feature = "rdf-star")]
-            Term::Triple(triple) => Ok(Subject::Triple(triple)),
-            Term::Literal(literal) => Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert a literal to a subject: {}",
-                literal
-            ))
-            .into()),
-        }
-    }
-}
-
 impl From<NamedNode> for Subject {
     #[inline]
     fn from(node: NamedNode) -> Self {
@@ -240,6 +221,25 @@ impl From<BlankNodeRef<'_>> for Subject {
     #[inline]
     fn from(node: BlankNodeRef<'_>) -> Self {
         node.into_owned().into()
+    }
+}
+
+impl TryFrom<Term> for Subject {
+    type Error = TermCastError;
+
+    #[inline]
+    fn try_from(term: Term) -> Result<Self, Self::Error> {
+        match term {
+            Term::NamedNode(node) => Ok(Subject::NamedNode(node)),
+            Term::BlankNode(node) => Ok(Subject::BlankNode(node)),
+            #[cfg(feature = "rdf-star")]
+            Term::Triple(triple) => Ok(Subject::Triple(triple)),
+            Term::Literal(literal) => Err(TermCastErrorKind::Msg(format!(
+                "Cannot convert a literal to a subject: {}",
+                literal
+            ))
+            .into()),
+        }
     }
 }
 

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -1321,14 +1321,14 @@ mod tests {
             NamedNode::new("http://example.org/test").unwrap(),
         );
 
-        let bad_triple = Triple::new_from_terms(
-            Term::BlankNode(BlankNode::new("abc123").unwrap()),
+        let bad_triple: Result<Triple, TermCastError> = Triple::new_from_terms(
+            Term::Literal(Literal::new_simple_literal("abc123")),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
         );
 
         let bad_triple_2 = Triple::new_from_terms(
-            BlankNode::new("abc123").unwrap(),
+            Term::Literal(Literal::new_simple_literal("abc123")),
             NamedNode::new("http://example.org/test").unwrap(),
             NamedNode::new("http://example.org/test").unwrap(),
         );

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -234,7 +234,10 @@ impl TryFrom<Term> for Subject {
             Term::BlankNode(node) => Ok(Subject::BlankNode(node)),
             #[cfg(feature = "rdf-star")]
             Term::Triple(triple) => Ok(Subject::Triple(triple)),
-            Term::Literal(_) => Err(TryFromTermError { term, target: "Subject" }),
+            Term::Literal(_) => Err(TryFromTermError {
+                term,
+                target: "Subject",
+            }),
         }
     }
 }
@@ -761,12 +764,22 @@ impl Triple {
         predicate: impl Into<Term>,
         object: impl Into<Term>,
     ) -> Result<Self, TripleConstructionError> {
-        let subject: Result<Subject, TryFromTermError> = TryInto::<Subject>::try_into(subject.into());
-        let predicate: Result<NamedNode, TryFromTermError> = TryInto::<NamedNode>::try_into(predicate.into());
-        if let (Ok (subject), Ok (predicate)) = (subject.clone(), predicate.clone()) {
-            Ok(Self { subject, predicate, object: object.into() })
+        let subject: Result<Subject, TryFromTermError> =
+            TryInto::<Subject>::try_into(subject.into());
+        let predicate: Result<NamedNode, TryFromTermError> =
+            TryInto::<NamedNode>::try_into(predicate.into());
+        if let (Ok(subject), Ok(predicate)) = (subject.clone(), predicate.clone()) {
+            Ok(Self {
+                subject,
+                predicate,
+                object: object.into(),
+            })
         } else {
-            Err(TripleConstructionError { subject, predicate, object: object.into() })
+            Err(TripleConstructionError {
+                subject,
+                predicate,
+                object: object.into(),
+            })
         }
     }
 
@@ -807,7 +820,10 @@ impl TryFrom<Term> for Box<Triple> {
         if let Term::Triple(node) = term {
             Ok(node)
         } else {
-            Err(TryFromTermError { term, target: "Box<Triple>" })
+            Err(TryFromTermError {
+                term,
+                target: "Box<Triple>",
+            })
         }
     }
 }
@@ -1293,26 +1309,53 @@ mod tests {
         let literal: Result<Box<Triple>, TryFromTermError> =
             Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         let literal_err = literal.unwrap_err();
-        assert_eq!(literal_err.term, Term::Literal(Literal::new_simple_literal("Hello World!")));
+        assert_eq!(
+            literal_err.term,
+            Term::Literal(Literal::new_simple_literal("Hello World!"))
+        );
         assert_eq!(literal_err.target, "Box<Triple>");
-        assert_eq!(literal_err.to_string(), "\"Hello World!\" can not be converted to a Box<Triple>");
-        assert_eq!(Term::from(literal_err), Term::Literal(Literal::new_simple_literal("Hello World!")));
- 
+        assert_eq!(
+            literal_err.to_string(),
+            "\"Hello World!\" can not be converted to a Box<Triple>"
+        );
+        assert_eq!(
+            Term::from(literal_err),
+            Term::Literal(Literal::new_simple_literal("Hello World!"))
+        );
+
         let bnode: Result<Box<Triple>, TryFromTermError> =
             Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         let bnode_err = bnode.unwrap_err();
-        assert_eq!(bnode_err.term, Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(
+            bnode_err.term,
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
         assert_eq!(bnode_err.target, "Box<Triple>");
-        assert_eq!(bnode_err.to_string(), "_:42 can not be converted to a Box<Triple>");
-        assert_eq!(Term::from(bnode_err), Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        assert_eq!(
+            bnode_err.to_string(),
+            "_:42 can not be converted to a Box<Triple>"
+        );
+        assert_eq!(
+            Term::from(bnode_err),
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
 
         let named_node: Result<Box<Triple>, TryFromTermError> =
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         let named_node_err = named_node.unwrap_err();
-        assert_eq!(named_node_err.term, Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(
+            named_node_err.term,
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
         assert_eq!(named_node_err.target, "Box<Triple>");
-        assert_eq!(named_node_err.to_string(), "<http://example.org/test> can not be converted to a Box<Triple>");
-        assert_eq!(Term::from(named_node_err), Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(
+            named_node_err.to_string(),
+            "<http://example.org/test> can not be converted to a Box<Triple>"
+        );
+        assert_eq!(
+            Term::from(named_node_err),
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
     }
 
     #[test]
@@ -1367,29 +1410,82 @@ mod tests {
         assert_eq!(unwrapped, triple_2.clone());
         assert_eq!(optional_triple_2.unwrap(), triple_2);
         let bad_triple_err = bad_triple.unwrap_err();
-        assert_eq!(bad_triple_err.to_string(), "subject: [\"abc123\" can not be converted to a Subject]");
-        assert_eq!(bad_triple_err.subject.clone().unwrap_err().clone().term, Term::Literal(Literal::new_simple_literal("abc123")));
-        assert_eq!(bad_triple_err.subject.clone().unwrap_err().clone().target, "Subject");
-        assert_eq!(bad_triple_err.subject.unwrap_err().clone().to_string(), "\"abc123\" can not be converted to a Subject");
+        assert_eq!(
+            bad_triple_err.to_string(),
+            "subject: [\"abc123\" can not be converted to a Subject]"
+        );
+        assert_eq!(
+            bad_triple_err.subject.clone().unwrap_err().clone().term,
+            Term::Literal(Literal::new_simple_literal("abc123"))
+        );
+        assert_eq!(
+            bad_triple_err.subject.clone().unwrap_err().clone().target,
+            "Subject"
+        );
+        assert_eq!(
+            bad_triple_err.subject.unwrap_err().clone().to_string(),
+            "\"abc123\" can not be converted to a Subject"
+        );
 
         assert_eq!(bad_triple_2.is_err(), true);
         let bad_triple_2_err = bad_triple_2.unwrap_err();
-        assert_eq!(bad_triple_2_err.to_string(), "subject: [\"abc123\" can not be converted to a Subject]");
-        assert_eq!(bad_triple_2_err.subject.clone().unwrap_err().clone().term, Term::Literal(Literal::new_simple_literal("abc123")));
-        assert_eq!(bad_triple_2_err.subject.clone().unwrap_err().clone().target, "Subject");
-        assert_eq!(bad_triple_2_err.subject.unwrap_err().clone().to_string(), "\"abc123\" can not be converted to a Subject");
-        assert_eq!(bad_triple_2_err.predicate.unwrap(), NamedNode::new("http://example.org/test").unwrap());
-        assert_eq!(bad_triple_2_err.object, Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        assert_eq!(
+            bad_triple_2_err.to_string(),
+            "subject: [\"abc123\" can not be converted to a Subject]"
+        );
+        assert_eq!(
+            bad_triple_2_err.subject.clone().unwrap_err().clone().term,
+            Term::Literal(Literal::new_simple_literal("abc123"))
+        );
+        assert_eq!(
+            bad_triple_2_err.subject.clone().unwrap_err().clone().target,
+            "Subject"
+        );
+        assert_eq!(
+            bad_triple_2_err.subject.unwrap_err().clone().to_string(),
+            "\"abc123\" can not be converted to a Subject"
+        );
+        assert_eq!(
+            bad_triple_2_err.predicate.unwrap(),
+            NamedNode::new("http://example.org/test").unwrap()
+        );
+        assert_eq!(
+            bad_triple_2_err.object,
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
 
         assert_eq!(bad_triple_3.is_err(), true);
         let bad_triple_3_err = bad_triple_3.unwrap_err();
         assert_eq!(bad_triple_3_err.to_string(), "subject: [\"abc123\" can not be converted to a Subject], predicate: [_:42 can not be converted to a NamedNode]");
-        assert_eq!(bad_triple_3_err.subject.clone().unwrap_err().clone().term, Term::Literal(Literal::new_simple_literal("abc123")));
-        assert_eq!(bad_triple_3_err.subject.clone().unwrap_err().clone().target, "Subject");
-        assert_eq!(bad_triple_3_err.subject.unwrap_err().clone().to_string(), "\"abc123\" can not be converted to a Subject");
-        assert_eq!(bad_triple_3_err.predicate.clone().unwrap_err().clone().term, Term::BlankNode(BlankNode::new_from_unique_id(0x42)));
-        assert_eq!(bad_triple_3_err.predicate.clone().unwrap_err().clone().target, "NamedNode");
-        assert_eq!(bad_triple_3_err.predicate.unwrap_err().clone().to_string(), "_:42 can not be converted to a NamedNode");
+        assert_eq!(
+            bad_triple_3_err.subject.clone().unwrap_err().clone().term,
+            Term::Literal(Literal::new_simple_literal("abc123"))
+        );
+        assert_eq!(
+            bad_triple_3_err.subject.clone().unwrap_err().clone().target,
+            "Subject"
+        );
+        assert_eq!(
+            bad_triple_3_err.subject.unwrap_err().clone().to_string(),
+            "\"abc123\" can not be converted to a Subject"
+        );
+        assert_eq!(
+            bad_triple_3_err.predicate.clone().unwrap_err().clone().term,
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
+        assert_eq!(
+            bad_triple_3_err
+                .predicate
+                .clone()
+                .unwrap_err()
+                .clone()
+                .target,
+            "NamedNode"
+        );
+        assert_eq!(
+            bad_triple_3_err.predicate.unwrap_err().clone().to_string(),
+            "_:42 can not be converted to a NamedNode"
+        );
     }
 
     #[test]

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -809,11 +809,7 @@ impl TryFrom<Term> for Box<Triple> {
         if let Term::Triple(node) = term {
             Ok(node)
         } else {
-            Err(TermCastErrorKind::Msg(format!(
-                "Cannot convert term to a triple: {}",
-                term
-            ))
-            .into())
+            Err(TermCastErrorKind::Msg(format!("Cannot convert term to a triple: {}", term)).into())
         }
     }
 }
@@ -1296,13 +1292,16 @@ mod tests {
         let t: Result<Box<Triple>, TermCastError> = Term::Triple(triple_box.clone()).try_into();
         assert_eq!(t.unwrap(), triple_box.clone());
 
-        let literal: Result<Box<Triple>, TermCastError> = Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
+        let literal: Result<Box<Triple>, TermCastError> =
+            Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         assert_eq!(literal.is_err(), true);
 
-        let bnode: Result<Box<Triple>, TermCastError> = Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
+        let bnode: Result<Box<Triple>, TermCastError> =
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
         assert_eq!(bnode.is_err(), true);
 
-        let named_node: Result<Box<Triple>, TermCastError> = Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
+        let named_node: Result<Box<Triple>, TermCastError> =
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
         assert_eq!(named_node.is_err(), true);
     }
 
@@ -1311,39 +1310,39 @@ mod tests {
         use super::*;
 
         let optional_triple = Triple::new_from_terms(
-            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()), 
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
-            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
         );
 
         let optional_triple_2 = Triple::new_from_terms(
-            NamedNode::new("http://example.org/test").unwrap(), 
             NamedNode::new("http://example.org/test").unwrap(),
-            NamedNode::new("http://example.org/test").unwrap()
+            NamedNode::new("http://example.org/test").unwrap(),
+            NamedNode::new("http://example.org/test").unwrap(),
         );
 
         let bad_triple = Triple::new_from_terms(
-            Term::BlankNode(BlankNode::new("abc123").unwrap()), 
+            Term::BlankNode(BlankNode::new("abc123").unwrap()),
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
-            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
         );
 
         let bad_triple_2 = Triple::new_from_terms(
-            BlankNode::new("abc123").unwrap(), 
+            BlankNode::new("abc123").unwrap(),
             NamedNode::new("http://example.org/test").unwrap(),
-            NamedNode::new("http://example.org/test").unwrap()
+            NamedNode::new("http://example.org/test").unwrap(),
         );
 
         let triple: Triple = Triple::new(
-            Subject::NamedNode(NamedNode::new("http://example.org/test").unwrap()), 
+            Subject::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
             NamedNode::new("http://example.org/test").unwrap(),
-            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()),
         );
 
         let triple_2: Triple = Triple::new(
-            NamedNode::new("http://example.org/test").unwrap(), 
             NamedNode::new("http://example.org/test").unwrap(),
-            NamedNode::new("http://example.org/test").unwrap()
+            NamedNode::new("http://example.org/test").unwrap(),
+            NamedNode::new("http://example.org/test").unwrap(),
         );
 
         let unwrapped = optional_triple.unwrap();
@@ -1367,13 +1366,22 @@ mod tests {
         let t: Result<Subject, TermCastError> = Term::Triple(triple_box.clone()).try_into();
         assert_eq!(t.unwrap(), Subject::Triple(triple_box.clone()));
 
-        let literal: Result<Subject, TermCastError> = Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
+        let literal: Result<Subject, TermCastError> =
+            Term::Literal(Literal::new_simple_literal("Hello World!")).try_into();
         assert_eq!(literal.is_err(), true);
 
-        let bnode: Result<Subject, TermCastError> = Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
-        assert_eq!(bnode.unwrap(), Subject::BlankNode(BlankNode::new_from_unique_id(0x42)));
+        let bnode: Result<Subject, TermCastError> =
+            Term::BlankNode(BlankNode::new_from_unique_id(0x42)).try_into();
+        assert_eq!(
+            bnode.unwrap(),
+            Subject::BlankNode(BlankNode::new_from_unique_id(0x42))
+        );
 
-        let named_node: Result<Subject, TermCastError> = Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
-        assert_eq!(named_node.unwrap(), Subject::NamedNode(NamedNode::new("http://example.org/test").unwrap()));
+        let named_node: Result<Subject, TermCastError> =
+            Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()).try_into();
+        assert_eq!(
+            named_node.unwrap(),
+            Subject::NamedNode(NamedNode::new("http://example.org/test").unwrap())
+        );
     }
 }

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -1267,16 +1267,14 @@ impl<'a> From<QuadRef<'a>> for Quad {
     }
 }
 
+#[cfg(feature = "rdf-star")]
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic_in_result_fn)]
 
-    use crate::{Literal, BlankNode};
-
     use super::*;
 
     #[test]
-    #[cfg(feature = "rdf-star")]
     fn casting_triple() {
         let triple = Triple {
             subject: NamedNode::new("http://example.org/s").unwrap().into(),
@@ -1299,7 +1297,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rdf-star")]
     fn constructing_triple() {
         let optional_triple = Triple::new_maybe(
             Term::NamedNode(NamedNode::new("http://example.org/test").unwrap()), 
@@ -1324,7 +1321,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rdf-star")]
     fn casting_subject() {
         let triple = Triple {
             subject: NamedNode::new("http://example.org/s").unwrap().into(),


### PR DESCRIPTION
This is a proposal to cast `Term`s back to particular types of terms.

I was mainly after the feature of being able to cast `Term`s as `Optional<Subject>`s; and being able to construct an `Optional<Triple>` from arbitrary `Term`s.

If you're on board with this feature I can add documentation and then mark this as ready for review.