### PR TITLE
JS: Drop older NodeJS and WebBrowsers support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -268,7 +268,7 @@ jobs:
         with: { tool: wasm-pack }
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
           cache-dependency-path: "js/package.json"
       - run: npm install

--- a/js/README.md
+++ b/js/README.md
@@ -13,7 +13,7 @@ Oxigraph for JavaScript is a work in progress and currently offers a simple in-m
 
 The store is also able to load RDF serialized in [Turtle](https://www.w3.org/TR/turtle/), [TriG](https://www.w3.org/TR/trig/), [N-Triples](https://www.w3.org/TR/n-triples/), [N-Quads](https://www.w3.org/TR/n-quads/) and [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/).
 
-It is distributed using a [a NPM package](https://www.npmjs.com/package/oxigraph) that should work with Node.JS 12+ and modern web browsers compatible with WebAssembly.
+It is distributed using a [a NPM package](https://www.npmjs.com/package/oxigraph) that should work with Node.JS 18+ and [modern web browsers compatible with WebAssembly reference types and JavaScript `WeakRef`](https://caniuse.com/wasm-reference-types,mdn-javascript_builtins_weakref).
 
 To install:
 ```bash

--- a/js/package.json
+++ b/js/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "fmt": "biome format . --write && biome check . --apply-unsafe && biome format . --write",
-    "test": "biome ci . && wasm-pack build --debug --target nodejs && mocha",
-    "build": "wasm-pack build --release --target web --out-name web && wasm-pack build --release --target nodejs --out-name node && node build_package.js",
+    "test": "biome ci . && wasm-pack build --debug --target nodejs --weak-refs --reference-types && mocha",
+    "build": "wasm-pack build --release --target web --out-name web --weak-refs --reference-types && wasm-pack build --release --target nodejs --out-name node --weak-refs --reference-types && node build_package.js",
     "release": "npm run build && npm publish ./pkg",
     "pack": "npm run build && npm pack ./pkg"
   },

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -14,7 +14,7 @@ use pyo3::prelude::*;
 /// if you insert and remove a lot of different terms, memory will grow without any reduction.
 ///
 /// :param quads: some quads to initialize the dataset with.
-/// :type quads: collections.abc.Iterable[Quad]
+/// :type quads: collections.abc.Iterable[Quad] or None, optional
 ///
 /// The :py:class:`str` function provides an N-Quads serialization:
 ///


### PR DESCRIPTION
Requires WASM reference types and JS WeakRef