### PR TITLE
sparopt: Avoid join reordering in SERVICE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "oxigraph"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7-dev"
 dependencies = [
  "codspeed-criterion-compat",
  "digest",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "oxigraph-cli"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "oxigraph-js"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7-dev"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "oxrocksdb-sys"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7-dev"
 dependencies = [
  "bindgen",
  "cc",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "pyoxigraph"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7-dev"
 dependencies = [
  "oxigraph",
  "pyo3",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "sparopt"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5-dev"
 dependencies = [
  "oxrdf",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7-dev"
 authors = ["Tpt <thomas@pellissier-tanon.fr>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -68,16 +68,16 @@ wasm-bindgen = "0.2.83"
 zstd = ">=0.12, <0.14"
 
 # Internal dependencies
-oxigraph = { version = "=0.4.0-alpha.6", path = "lib/oxigraph" }
+oxigraph = { version = "=0.4.0-alpha.7-dev", path = "lib/oxigraph" }
 oxrdf = { version = "=0.2.0-alpha.4", path = "lib/oxrdf" }
 oxrdfio = { version = "=0.1.0-alpha.5", path = "lib/oxrdfio" }
 oxrdfxml = { version = "=0.1.0-alpha.5", path = "lib/oxrdfxml" }
-oxrocksdb-sys = { version = "=0.4.0-alpha.6", path = "./oxrocksdb-sys" }
+oxrocksdb-sys = { version = "=0.4.0-alpha.7-dev", path = "./oxrocksdb-sys" }
 oxsdatatypes = { version = "=0.2.0-alpha.1", path = "lib/oxsdatatypes" }
 oxttl = { version = "=0.1.0-alpha.5", path = "lib/oxttl" }
 sparesults = { version = "=0.2.0-alpha.4", path = "lib/sparesults" }
 spargebra = { version = "=0.3.0-alpha.4", path = "lib/spargebra" }
-sparopt = { version = "=0.1.0-alpha.4", path = "lib/sparopt" }
+sparopt = { version = "=0.1.0-alpha.5-dev", path = "lib/sparopt" }
 
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"

--- a/lib/sparopt/Cargo.toml
+++ b/lib/sparopt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparopt"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5-dev"
 authors.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/lib/sparopt/src/optimizer.rs
+++ b/lib/sparopt/src/optimizer.rs
@@ -712,11 +712,10 @@ impl Optimizer {
             GraphPattern::OrderBy { inner, expression } => {
                 GraphPattern::order_by(Self::reorder_joins(*inner, input_types), expression)
             }
-            GraphPattern::Service {
-                inner,
-                name,
-                silent,
-            } => GraphPattern::service(Self::reorder_joins(*inner, input_types), name, silent),
+            service @ GraphPattern::Service { .. } => {
+                // We don't do join reordering inside of SERVICE calls, we don't know about cardinalities
+                service
+            }
             GraphPattern::Group {
                 inner,
                 variables,


### PR DESCRIPTION
This is done better by the remote endpoint and avoids harmful transformation like LATERAL insertion