### PR TITLE
JS: Rename benchmark to avoid confusion with Rust benches

### DIFF
--- a/js/benches/bench.mjs
+++ b/js/benches/bench.mjs
@@ -29,21 +29,21 @@ const bsbm_1000_operations = (await readData("mix-exploreAndUpdate-1000.tsv.zst"
 
 const bench = withCodSpeed(new Bench());
 bench
-    .add("load BSBM explore 1000", () => {
+    .add("JS: load BSBM explore 1000", () => {
         const store = new Store();
         store.load(explore_1000_nt, "application/n-triples");
     })
-    .add("BSBM explore 1000 query", () => {
+    .add("JS: BSBM explore 1000 query", () => {
         for (const [kind, sparql] of bsbm_1000_operations) {
             if (kind === "query") {
-                explore_1000_store.query(sparql);
+                explore_1000_store.query(sparql, { results_format: "xml" });
             }
         }
     })
-    .add("BSBM explore 1000 query and update", () => {
+    .add("JS: BSBM explore 1000 query and update", () => {
         for (const [kind, sparql] of bsbm_1000_operations) {
             if (kind === "query") {
-                explore_1000_store.query(sparql);
+                explore_1000_store.query(sparql, { results_format: "xml" });
             } else if (kind === "update") {
                 explore_1000_store.update(sparql);
             }

--- a/js/src/store.rs
+++ b/js/src/store.rs
@@ -274,21 +274,27 @@ impl JsStore {
 fn rdf_format(format: &str) -> Result<RdfFormat, JsValue> {
     if format.contains('/') {
         RdfFormat::from_media_type(format)
-            .ok_or_else(|| format_err!("Not supported RDF format media type: {format}"))
+            .ok_or_else(|| format_err!("Not supported RDF format media type: {}", format))
     } else {
         RdfFormat::from_extension(format)
-            .ok_or_else(|| format_err!("Not supported RDF format extension: {format}"))
+            .ok_or_else(|| format_err!("Not supported RDF format extension: {}", format))
     }
 }
 
 fn query_results_format(format: &str) -> Result<QueryResultsFormat, JsValue> {
     if format.contains('/') {
         QueryResultsFormat::from_media_type(format).ok_or_else(|| {
-            format_err!("Not supported SPARQL query results format media type: {format}")
+            format_err!(
+                "Not supported SPARQL query results format media type: {}",
+                format
+            )
         })
     } else {
         QueryResultsFormat::from_extension(format).ok_or_else(|| {
-            format_err!("Not supported SPARQL query results format extension: {format}")
+            format_err!(
+                "Not supported SPARQL query results format extension: {}",
+                format
+            )
         })
     }
 }


### PR DESCRIPTION
Also serializes query results to JSON