### PR TITLE
Abort instead of unwind on release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,6 +280,7 @@ zero_sized_map_values = "warn"
 lto = true
 codegen-units = 1
 strip = "debuginfo"
+panic = "abort"
 
 [profile.release.package.oxigraph-js]
 codegen-units = 1


### PR DESCRIPTION
We are not catching panics and I believe we never got a panic bug report so unwind is likely not worth it