### PR TITLE
UTF-16 Surrogate Pair Support

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1697,6 +1697,9 @@ fn web_load_graph(
     let mut parser = RdfParser::from_format(format)
         .without_named_graphs()
         .with_default_graph(to_graph_name.clone());
+    if url_query_parameter(request, "lenient").is_some() {
+        parser = parser.unchecked();
+    }
     if let Some(base_iri) = base_iri {
         parser = parser.with_base_iri(base_iri).map_err(bad_request)?;
     }
@@ -2992,7 +2995,7 @@ mod tests {
         // POST
         let request = Request::builder(
             Method::POST,
-            "http://localhost/store?graph=http://example.com".parse()?,
+            "http://localhost/store?lenient&graph=http://example.com".parse()?,
         )
         .with_header(HeaderName::CONTENT_TYPE, "text/turtle")?
         .with_body("<http://example.com/s> <http://example.com/p> \"\\uD83D\\uDC68\" .");
@@ -3008,12 +3011,12 @@ mod tests {
         server.test_body(
             request,
             "<http://example.com/s> <http://example.com/p> \"👨\" .\n",
-        );
+        )?;
 
         // PUT
         let request = Request::builder(
             Method::PUT,
-            "http://localhost/store?graph=http://example.com".parse()?,
+            "http://localhost/store?lenient&graph=http://example.com".parse()?,
         )
         .with_header(HeaderName::CONTENT_TYPE, "text/turtle")?
         .with_body("<http://example.com/s> <http://example.com/p> \"\\uD83D\\uDC68\\u200D\\uD83D\\uDC69\\u200D\\uD83D\\uDC67\\u200D\\uD83D\\uDC67\" .");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3010,7 +3010,7 @@ mod tests {
         .build();
         server.test_body(
             request,
-            "<http://example.com/s> <http://example.com/p> \"👨\" .\n",
+            "<http://example.com/s> <http://example.com/p> \"\u{1f468}\" .\n",
         )?;
 
         // PUT
@@ -3031,7 +3031,7 @@ mod tests {
         .build();
         server.test_body(
             request,
-            "<http://example.com/s> <http://example.com/p> \"👨‍👩‍👧‍👧\" .\n",
+            "<http://example.com/s> <http://example.com/p> \"\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f467}\" .\n",
         )
     }
 

--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -860,7 +860,7 @@ impl N3Lexer {
             };
             if d4 != b'\\' || d5 != b'u' {
                 return Err((
-                    position..position + data.len().min(10) + 2,
+                    position..position + 6,
                     format!(
                         "UTF-16 surrogate escape sequence '\\u{val_high}' must be followed by another surrogate escape sequence"),
                 )

--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -882,17 +882,17 @@ impl N3Lexer {
                 )
             })?;
 
-            let mut chars = char::decode_utf16([surrogate_high, surrogate_low]).map(|r| r.map_err(|_| {
-                (
-                    position..position + 12,
-                    format!(
-                        "Escape sequences '\\u{val_high}\\u{val_low}' do not form a valid UTF-16 surrogate pair"
-                    ),
-                )
-            }));
+            let mut chars = char::decode_utf16([surrogate_high, surrogate_low]);
 
             if let Some(c) = chars.next() {
-                let c = c?;
+                let c = c.map_err(|_| {
+                    (
+                        position..position + 12,
+                        format!(
+                            "Escape sequences '\\u{val_high}\\u{val_low}' do not form a valid UTF-16 surrogate pair"
+                        ),
+                    )
+                })?;
 
                 debug_assert_eq!(
                     chars.next(),


### PR DESCRIPTION
Decode UTF-16 surrogate pairs and convert them to `char`s.
Linked issue: #925

#### Example
Store `\uD83D\uDC68`
```
curl -v -X POST "localhost:7878/store?graph=http://g" -H "Content-Type: application/n-triples" -d "<http://a> <http://b> \"\\uD83D\\uDC68\" ."
```

```
HTTP/1.1 204 No Content
server: Oxigraph/0.4.0-alpha.7
```

Retrieve correct unicode
```
curl -v -X POST "localhost:7878/query" -H "Content-Type: application/sparql-query" -d "select ?o where { graph <http://g> { ?s ?p ?o } }"
```

```
HTTP/1.1 200 OK
content-type: application/sparql-results+json
server: Oxigraph/0.4.0-alpha.7

{"head":{"vars":["o"]},"results":{"bindings":[{"o":{"type":"literal","value":"👨"}}]}}
```
