### PR TITLE
SPARQL: Fixes CONSTRUCT parsing when dot follows semicolon

### DIFF
--- a/testsuite/oxigraph-tests/sparql/construct_semicolon_dot.rq
+++ b/testsuite/oxigraph-tests/sparql/construct_semicolon_dot.rq
@@ -1,0 +1,3 @@
+CONSTRUCT WHERE {
+    ?s ?p ?o ; .
+}

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -34,6 +34,7 @@
     :one_or_more_star
     :in_empty_error
     :small_iri_str
+    :construct_semicolon_dot
     ) .
 
 :small_unicode_escape_with_multibytes_char rdf:type mf:NegativeSyntaxTest ;
@@ -165,3 +166,7 @@
     mf:name "Small IRI strings should be properly equal to their value" ;
     mf:action [ qt:query  <small_iri_str.rq> ] ;
     mf:result  <small_iri_str.srx> .
+
+:construct_semicolon_dot a mf:PositiveSyntaxTest ;
+    mf:name "; followed by . in CONSTRUCT" ;
+    mf:action <construct_semicolon_dot.rq> .


### PR DESCRIPTION
Issue #943