### PR TITLE
SPARQL: discard errors on one side of the join if the other is empty

### DIFF
--- a/testsuite/oxigraph-tests/sparql/ask_join_error_left.rq
+++ b/testsuite/oxigraph-tests/sparql/ask_join_error_left.rq
@@ -1,0 +1,1 @@
+ASK { SERVICE ?1 {} VALUES () {} }

--- a/testsuite/oxigraph-tests/sparql/ask_join_error_right.rq
+++ b/testsuite/oxigraph-tests/sparql/ask_join_error_right.rq
@@ -1,0 +1,1 @@
+ASK { VALUES () {} SERVICE ?1 {} }

--- a/testsuite/oxigraph-tests/sparql/ask_union_error_left.rq
+++ b/testsuite/oxigraph-tests/sparql/ask_union_error_left.rq
@@ -1,0 +1,1 @@
+ASK { { SERVICE ?1 {} } UNION {} }

--- a/testsuite/oxigraph-tests/sparql/ask_union_error_right.rq
+++ b/testsuite/oxigraph-tests/sparql/ask_union_error_right.rq
@@ -1,0 +1,1 @@
+ASK { {} UNION { SERVICE ?1 {} } }

--- a/testsuite/oxigraph-tests/sparql/false.srx
+++ b/testsuite/oxigraph-tests/sparql/false.srx
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head />
+    <boolean>false</boolean>
+</sparql>

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -36,6 +36,10 @@
     :small_iri_str
     :construct_semicolon_dot
     :regex_variable
+    :ask_union_error_left
+    :ask_union_error_right
+    :ask_join_error_left
+    :ask_join_error_right
     ) .
 
 :small_unicode_escape_with_multibytes_char rdf:type mf:NegativeSyntaxTest ;
@@ -176,3 +180,23 @@
     mf:name "regex works even if it is not a constant" ;
     mf:action [ qt:query <regex_variable.rq> ] ;
     mf:result  <regex_variable.srx> .
+
+:ask_union_error_left rdf:type mf:QueryEvaluationTest ;
+    mf:name "ASK query with a UNION where left arg is an error and right arg is true" ;
+    mf:action [ qt:query <ask_union_error_left.rq> ] ;
+    mf:result  <true.srx> .
+
+:ask_union_error_right rdf:type mf:QueryEvaluationTest ;
+    mf:name "ASK query with a UNION where left arg is true and right arg is an error" ;
+    mf:action [ qt:query <ask_union_error_right.rq> ] ;
+    mf:result  <true.srx> .
+
+:ask_join_error_left rdf:type mf:QueryEvaluationTest ;
+    mf:name "ASK query with a join where left arg is an error and right arg is empty" ;
+    mf:action [ qt:query <ask_join_error_left.rq> ] ;
+    mf:result  <false.srx> .
+
+:ask_join_error_right rdf:type mf:QueryEvaluationTest ;
+    mf:name "ASK query with a join where left arg is empty and right arg is an error" ;
+    mf:action [ qt:query <ask_join_error_right.rq> ] ;
+    mf:result  <false.srx> .

--- a/testsuite/oxigraph-tests/sparql/true.srx
+++ b/testsuite/oxigraph-tests/sparql/true.srx
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head />
+    <boolean>true</boolean>
+</sparql>


### PR DESCRIPTION
There is no ambiguity in this case, the result is empty, whatever the other side is returning