### PR TITLE
Fuzzer: do not fuzz unbound service

### DIFF
--- a/lib/sparql-smith/Cargo.toml
+++ b/lib/sparql-smith/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 default = []
 limit-offset = []
 service = []
+unbound-service = ["service"]
 sep-0006 = []
 
 [lints]

--- a/lib/sparql-smith/src/lib.rs
+++ b/lib/sparql-smith/src/lib.rs
@@ -1059,7 +1059,10 @@ impl fmt::Display for GraphGraphPattern {
 struct ServiceGraphPattern {
     // [59]  	ServiceGraphPattern	  ::=  	'SERVICE' 'SILENT'? VarOrIri GroupGraphPattern
     silent: bool,
+    #[cfg(feature = "unbound-service")]
     service: VarOrIri,
+    #[cfg(not(feature = "unbound-service"))]
+    service: Iri,
     inner: GroupGraphPattern,
 }
 


### PR DESCRIPTION
Behavior depends on LATERAL optimization,
and it's the only way of making this feature useful