### PR TITLE
Python: remove explicit strip

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Database :: Database Engines/Servers",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -27,9 +29,6 @@ Documentation = "https://pyoxigraph.readthedocs.io/"
 Homepage = "https://pyoxigraph.readthedocs.io/"
 Source = "https://github.com/oxigraph/oxigraph/tree/main/python"
 Tracker = "https://github.com/oxigraph/oxigraph/issues"
-
-[tool.maturin]
-strip = true
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Rustc does it now by default and release builds