### PR TITLE
feat: Add stdin/stdout mode to send queries and receive JSON response

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -30,6 +30,25 @@ pub enum Command {
         #[arg(long)]
         union_default_graph: bool,
     },
+    /// Execute SPARQL operations in single operation or interactive REPL mode
+    Execute {
+        /// Directory in which the data should be persisted
+        ///
+        /// If not present, an in-memory storage will be used.
+        #[arg(short, long, value_hint = ValueHint::DirPath)]
+        location: Option<PathBuf>,
+        /// If the SPARQL queries should look for triples in all the dataset graphs by default (ie. without `GRAPH` operations)
+        ///
+        /// This is equivalent as setting the union-default-graph option in all SPARQL queries
+        #[arg(long)]
+        union_default_graph: bool,
+        /// Run in interactive REPL mode
+        ///
+        /// In this mode, commands are read from stdin and results are written to stdout continuously.
+        /// The format is: QUERY <sparql>, UPDATE <sparql>, or EXIT to quit.
+        #[arg(short, long)]
+        interactive: bool,
+    },
     /// Start Oxigraph HTTP server in read-only mode
     ///
     /// It allows to read the database while other processes are also reading it.


### PR DESCRIPTION
This PR introduces a new execute command for Oxigraph CLI that supports two modes:

1. Interactive REPL mode - Provides a command-line interface for running SPARQL queries and updates interactively.

2. Single operation mode - Runs a single command from stdin and exits.

Features

- Interactive shell with command history

- JSON-formatted responses for easy parsing by external tools

- Support for both in-memory and persistent stores

- Union default graph option for consistent behavior with other commands

- Simple command syntax: QUERY <sparql>, UPDATE <sparql>, and EXIT