### PR TITLE
Feat/serde query

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,6 +172,19 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - run: cargo test
 
+  test_features:
+    strategy:
+      matrix:
+        features: [ "serde" ]
+        os: [ "linux", "windows", "macos" ]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ./.github/actions/setup-rust
+      - run: cargo test --features ${{ matrix.features }}
+
   test_linux_i686:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
   test_features:
     strategy:
       matrix:
-        features: [ "serde" ]
+        features: [ "serde", "rdf-star", "serde rdf-star" ]
         os: [ "linux", "windows", "macos" ]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,8 +176,7 @@ jobs:
     strategy:
       matrix:
         features: [ "serde", "serde-unvalidated" ]
-        os: [ "linux", "windows", "macos" ]
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: linux-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
   test_features:
     strategy:
       matrix:
-        features: [ "serde", "rdf-star", "serde rdf-star" ]
+        features: [ "serde", "serde-unvalidated", "rdf-star", "serde rdf-star" ]
         os: [ "linux", "windows", "macos" ]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
   test_features:
     strategy:
       matrix:
-        features: [ "serde", "serde-unvalidated", "rdf-star", "serde rdf-star" ]
+        features: [ "serde", "serde-unvalidated" ]
         os: [ "linux", "windows", "macos" ]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
   test_features:
     strategy:
       matrix:
-        features: [ "serde", "serde-unvalidated" ]
+        features: [ "serde" ]
     runs-on: linux-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,8 @@ dependencies = [
  "oxrdf",
  "peg",
  "rand",
+ "serde",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-bench"
+version = "0.2.4"
+dependencies = [
+ "criterion",
+ "oxrdf",
+ "serde_json",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,9 @@ dependencies = [
  "oxiri",
  "oxsdatatypes",
  "rand",
- "thiserror 2.0.12",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ members = [
     "lib/sparql-smith",
     "oxrocksdb-sys",
     "python",
-    "testsuite"
+    "testsuite",
+    "bench/criterion"
 ]
 resolver = "2"
 

--- a/bench/criterion/Cargo.toml
+++ b/bench/criterion/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-oxrdf = { workspace = true, features = ["serde", "rdf-star", "serde-unvalidated"] }
+oxrdf = { workspace = true, features = ["serde", "rdf-star"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [dev-dependencies]

--- a/bench/criterion/Cargo.toml
+++ b/bench/criterion/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 
 [dependencies]
 oxrdf = { workspace = true, features = ["serde", "rdf-star", "serde-unvalidated"] }
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [dev-dependencies]
 # Ideally this would be an optional dependency, used only when the `serde` feature is enabled.

--- a/bench/criterion/Cargo.toml
+++ b/bench/criterion/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-oxrdf = { workspace = true, features = ["serde", "rdf-star"] }
+oxrdf = { workspace = true, features = ["serde", "rdf-star", "serde-unvalidated"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [dev-dependencies]

--- a/bench/criterion/Cargo.toml
+++ b/bench/criterion/Cargo.toml
@@ -21,7 +21,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 # Ideally this would be an optional dependency, used only when the `serde` feature is enabled.
 # However, optional dev-dependencies are not currently supported by cargo.
 # See https://github.com/rust-lang/cargo/issues/1596
-serde_json = { version = "1.0.138" }
+serde_json = { version = "1.0.134" }
 
 [lints]
 workspace = true

--- a/bench/criterion/Cargo.toml
+++ b/bench/criterion/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "criterion-bench"
+version = "0.2.4"
+authors.workspace = true
+license.workspace = true
+readme = "README.md"
+keywords = []
+repository = "https://github.com/oxigraph/oxigraph/tree/main/bench/criterion"
+description = """
+A library providing basic data structures related to RDF
+"""
+documentation = "https://docs.rs/oxrdf"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+oxrdf = { workspace = true, features = ["serde", "rdf-star"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[dev-dependencies]
+# Ideally this would be an optional dependency, used only when the `serde` feature is enabled.
+# However, optional dev-dependencies are not currently supported by cargo.
+# See https://github.com/rust-lang/cargo/issues/1596
+serde_json = { version = "1.0.138" }
+
+[lints]
+workspace = true
+
+[[bench]]
+name = "serde_bench"
+harness = false

--- a/bench/criterion/benches/serde_bench.rs
+++ b/bench/criterion/benches/serde_bench.rs
@@ -1,0 +1,90 @@
+use std::hint::black_box;
+use criterion::{criterion_group, criterion_main, Criterion};
+use oxrdf::{NamedNode, BlankNode, Literal, Triple, Term};
+use serde_json;
+
+fn serialize_named_node(c: &mut Criterion) {
+    let named_node = NamedNode::new("http://example.com").unwrap();
+    c.bench_function("serialize_named_node", |b| b.iter(|| serde_json::to_string(&named_node)));
+}
+
+fn deserialize_named_node(c: &mut Criterion) {
+    let named_node = NamedNode::new("http://example.com").unwrap();
+    let named_node_json = serde_json::to_string(&named_node).unwrap();
+    c.bench_function("deserialize_named_node", |b| b.iter(|| serde_json::from_str::<NamedNode>(&named_node_json)));
+}
+
+fn serialize_blank_node(c: &mut Criterion) {
+    let blank_node = BlankNode::new("1").unwrap();
+    c.bench_function("serialize_blank_node", |b| b.iter(|| serde_json::to_string(&blank_node)));
+}
+
+fn deserialize_blank_node(c: &mut Criterion) {
+    let blank_node = BlankNode::new("1").unwrap();
+    let blank_node_json = serde_json::to_string(&blank_node).unwrap();
+    c.bench_function("deserialize_blank_node", |b| b.iter(|| serde_json::from_str::<BlankNode>(&blank_node_json)));
+}
+
+fn serialize_simple_literal(c: &mut Criterion) {
+    let literal = Literal::new_simple_literal("1");
+    c.bench_function("serialize_literal", |b| b.iter(|| serde_json::to_string(&literal)));
+}
+
+fn deserialize_simple_literal(c: &mut Criterion) {
+    let literal = Literal::new_simple_literal("1");
+    let literal_json = serde_json::to_string(&literal).unwrap();
+    c.bench_function("deserialize_literal", |b| b.iter(|| serde_json::from_str::<Literal>(&literal_json)));
+}
+
+fn serialize_typed_literal(c: &mut Criterion) {
+    let named_node = NamedNode::new("http://example.com").unwrap();
+    let literal = Literal::new_typed_literal("1", named_node);
+    c.bench_function("serialize_typed_literal", |b| b.iter(|| serde_json::to_string(&literal)));
+}
+
+fn deserialize_typed_literal(c: &mut Criterion) {
+    let named_node = NamedNode::new("http://example.com").unwrap();
+    let literal = Literal::new_typed_literal("1", named_node);
+    let literal_json = serde_json::to_string(&literal).unwrap();
+    c.bench_function("deserialize_typed_literal", |b| b.iter(|| serde_json::from_str::<Literal>(&literal_json)));
+}
+
+fn serialize_triple(c: &mut Criterion) {
+    let named_node = NamedNode::new("http://example.com").unwrap();
+    let blank_node = BlankNode::new("1").unwrap();
+    let literal = Literal::new_simple_literal("1");
+    let triple = Triple::new(
+        blank_node,
+        named_node,
+        Term::Literal(literal),
+    );
+    c.bench_function("serialize_triple", |b| b.iter(|| serde_json::to_string(&triple)));
+}
+
+fn deserialize_triple(c: &mut Criterion) {
+    let named_node = NamedNode::new("http://example.com").unwrap();
+    let blank_node = BlankNode::new("1").unwrap();
+    let literal = Literal::new_simple_literal("1");
+    let triple = Triple::new(
+        blank_node,
+        named_node,
+        Term::Literal(literal),
+    );
+    let triple_json = serde_json::to_string(&triple).unwrap();
+    c.bench_function("deserialize_triple", |b| b.iter(|| serde_json::from_str::<Triple>(&triple_json)));
+}
+
+criterion_group!(
+    benches,
+    serialize_named_node,
+    deserialize_named_node,
+    serialize_blank_node,
+    deserialize_blank_node,
+    serialize_simple_literal,
+    deserialize_simple_literal,
+    serialize_typed_literal,
+    deserialize_typed_literal,
+    serialize_triple,
+    deserialize_triple
+);
+criterion_main!(benches);

--- a/bench/criterion/benches/serde_bench.rs
+++ b/bench/criterion/benches/serde_bench.rs
@@ -1,77 +1,89 @@
-use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
-use oxrdf::{NamedNode, BlankNode, Literal, Triple, Term};
+use oxrdf::{BlankNode, Literal, NamedNode, Term, Triple};
 use serde_json;
+use std::hint::black_box;
 
 fn serialize_named_node(c: &mut Criterion) {
     let named_node = NamedNode::new("http://example.com").unwrap();
-    c.bench_function("serialize_named_node", |b| b.iter(|| serde_json::to_string(&named_node)));
+    c.bench_function("serialize_named_node", |b| {
+        b.iter(|| serde_json::to_string(&named_node))
+    });
 }
 
 fn deserialize_named_node(c: &mut Criterion) {
     let named_node = NamedNode::new("http://example.com").unwrap();
     let named_node_json = serde_json::to_string(&named_node).unwrap();
-    c.bench_function("deserialize_named_node", |b| b.iter(|| serde_json::from_str::<NamedNode>(&named_node_json)));
+    c.bench_function("deserialize_named_node", |b| {
+        b.iter(|| serde_json::from_str::<NamedNode>(&named_node_json))
+    });
 }
 
 fn serialize_blank_node(c: &mut Criterion) {
     let blank_node = BlankNode::new("1").unwrap();
-    c.bench_function("serialize_blank_node", |b| b.iter(|| serde_json::to_string(&blank_node)));
+    c.bench_function("serialize_blank_node", |b| {
+        b.iter(|| serde_json::to_string(&blank_node))
+    });
 }
 
 fn deserialize_blank_node(c: &mut Criterion) {
     let blank_node = BlankNode::new("1").unwrap();
     let blank_node_json = serde_json::to_string(&blank_node).unwrap();
-    c.bench_function("deserialize_blank_node", |b| b.iter(|| serde_json::from_str::<BlankNode>(&blank_node_json)));
+    c.bench_function("deserialize_blank_node", |b| {
+        b.iter(|| serde_json::from_str::<BlankNode>(&blank_node_json))
+    });
 }
 
 fn serialize_simple_literal(c: &mut Criterion) {
     let literal = Literal::new_simple_literal("1");
-    c.bench_function("serialize_literal", |b| b.iter(|| serde_json::to_string(&literal)));
+    c.bench_function("serialize_literal", |b| {
+        b.iter(|| serde_json::to_string(&literal))
+    });
 }
 
 fn deserialize_simple_literal(c: &mut Criterion) {
     let literal = Literal::new_simple_literal("1");
     let literal_json = serde_json::to_string(&literal).unwrap();
-    c.bench_function("deserialize_literal", |b| b.iter(|| serde_json::from_str::<Literal>(&literal_json)));
+    c.bench_function("deserialize_literal", |b| {
+        b.iter(|| serde_json::from_str::<Literal>(&literal_json))
+    });
 }
 
 fn serialize_typed_literal(c: &mut Criterion) {
     let named_node = NamedNode::new("http://example.com").unwrap();
     let literal = Literal::new_typed_literal("1", named_node);
-    c.bench_function("serialize_typed_literal", |b| b.iter(|| serde_json::to_string(&literal)));
+    c.bench_function("serialize_typed_literal", |b| {
+        b.iter(|| serde_json::to_string(&literal))
+    });
 }
 
 fn deserialize_typed_literal(c: &mut Criterion) {
     let named_node = NamedNode::new("http://example.com").unwrap();
     let literal = Literal::new_typed_literal("1", named_node);
     let literal_json = serde_json::to_string(&literal).unwrap();
-    c.bench_function("deserialize_typed_literal", |b| b.iter(|| serde_json::from_str::<Literal>(&literal_json)));
+    c.bench_function("deserialize_typed_literal", |b| {
+        b.iter(|| serde_json::from_str::<Literal>(&literal_json))
+    });
 }
 
 fn serialize_triple(c: &mut Criterion) {
     let named_node = NamedNode::new("http://example.com").unwrap();
     let blank_node = BlankNode::new("1").unwrap();
     let literal = Literal::new_simple_literal("1");
-    let triple = Triple::new(
-        blank_node,
-        named_node,
-        Term::Literal(literal),
-    );
-    c.bench_function("serialize_triple", |b| b.iter(|| serde_json::to_string(&triple)));
+    let triple = Triple::new(blank_node, named_node, Term::Literal(literal));
+    c.bench_function("serialize_triple", |b| {
+        b.iter(|| serde_json::to_string(&triple))
+    });
 }
 
 fn deserialize_triple(c: &mut Criterion) {
     let named_node = NamedNode::new("http://example.com").unwrap();
     let blank_node = BlankNode::new("1").unwrap();
     let literal = Literal::new_simple_literal("1");
-    let triple = Triple::new(
-        blank_node,
-        named_node,
-        Term::Literal(literal),
-    );
+    let triple = Triple::new(blank_node, named_node, Term::Literal(literal));
     let triple_json = serde_json::to_string(&triple).unwrap();
-    c.bench_function("deserialize_triple", |b| b.iter(|| serde_json::from_str::<Triple>(&triple_json)));
+    c.bench_function("deserialize_triple", |b| {
+        b.iter(|| serde_json::from_str::<Triple>(&triple_json))
+    });
 }
 
 criterion_group!(

--- a/lib/oxrdf/Cargo.toml
+++ b/lib/oxrdf/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 default = []
 rdf-star = []
 serde = ["dep:serde"]
+serde-unvalidated = ["serde"]
 
 [dependencies]
 oxilangtag.workspace = true

--- a/lib/oxrdf/Cargo.toml
+++ b/lib/oxrdf/Cargo.toml
@@ -17,7 +17,6 @@ rust-version.workspace = true
 default = []
 rdf-star = []
 serde = ["dep:serde"]
-serde-unvalidated = ["serde"]
 
 [dependencies]
 oxilangtag.workspace = true

--- a/lib/oxrdf/Cargo.toml
+++ b/lib/oxrdf/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 [features]
 default = []
 rdf-star = []
-serde = []
+serde = ["dep:serde"]
 
 [dependencies]
 oxilangtag.workspace = true
@@ -24,7 +24,7 @@ oxiri.workspace = true
 oxsdatatypes = { workspace = true, optional = true }
 rand.workspace = true
 thiserror.workspace = true
-serde = { version = "1.0.217", features = ["derive"] }
+serde = { version = "1.0.217", features = ["derive"], optional = true}
 
 [dev-dependencies]
 # Ideally this would be an optional dependency, used only when the `serde` feature is enabled.

--- a/lib/oxrdf/Cargo.toml
+++ b/lib/oxrdf/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.217", features = ["derive"], optional = true}
 # Ideally this would be an optional dependency, used only when the `serde` feature is enabled.
 # However, optional dev-dependencies are not currently supported by cargo.
 # See https://github.com/rust-lang/cargo/issues/1596
-serde_json = { version = "1.0.138" }
+serde_json = { version = "1.0.134" }
 
 [lints]
 workspace = true

--- a/lib/oxrdf/Cargo.toml
+++ b/lib/oxrdf/Cargo.toml
@@ -16,6 +16,7 @@ rust-version.workspace = true
 [features]
 default = []
 rdf-star = []
+serde = []
 
 [dependencies]
 oxilangtag.workspace = true
@@ -23,6 +24,13 @@ oxiri.workspace = true
 oxsdatatypes = { workspace = true, optional = true }
 rand.workspace = true
 thiserror.workspace = true
+serde = { version = "1.0.217", features = ["derive"] }
+
+[dev-dependencies]
+# Ideally this would be an optional dependency, used only when the `serde` feature is enabled.
+# However, optional dev-dependencies are not currently supported by cargo.
+# See https://github.com/rust-lang/cargo/issues/1596
+serde_json = { version = "1.0.138" }
 
 [lints]
 workspace = true

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -405,9 +405,9 @@ pub struct BlankNodeIdParseError;
 mod tests {
     use super::*;
     #[cfg(feature = "serde")]
-    use serde_json;
-    #[cfg(feature = "serde")]
     use serde::de::DeserializeOwned;
+    #[cfg(feature = "serde")]
+    use serde_json;
     #[cfg(not(target_family = "wasm"))]
     use std::mem::{align_of, size_of};
 
@@ -513,10 +513,7 @@ mod tests {
         }
 
         assert!(deserialized.is_ok());
-        assert_eq!(
-            deserialized.unwrap(),
-            BlankNode::new("abc").unwrap()
-        );
+        assert_eq!(deserialized.unwrap(), BlankNode::new("abc").unwrap());
     }
 
     // This helper function will only compile if T implements DeserializeOwned.

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::host_endian_bytes)] // We use it to go around 16 bytes alignment of u128
 use rand::random;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, de, de::Visitor, de::MapAccess, Serialize, Serializer, ser::SerializeStruct};
+use serde::{
+    de, de::MapAccess, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize,
+    Serializer,
+};
 use std::io::Write;
 use std::{fmt, str};
 
@@ -401,10 +404,10 @@ pub struct BlankNodeIdParseError;
 #[allow(clippy::panic_in_result_fn)]
 mod tests {
     use super::*;
-    #[cfg(not(target_family = "wasm"))]
-    use std::mem::{align_of, size_of};
     #[cfg(feature = "serde")]
     use serde_json;
+    #[cfg(not(target_family = "wasm"))]
+    use std::mem::{align_of, size_of};
 
     #[test]
     fn as_str_partial() {
@@ -485,10 +488,12 @@ mod tests {
         let b2: BlankNode = serde_json::from_str(&json).unwrap();
         assert_eq!(b2, b);
 
-        let b3: Result<BlankNode, serde_json::Error> = serde_json::from_str::<BlankNode>(&"{\"art\":\"r\", \"value\":\"a\", \"noise\":\"t\"}");
+        let b3: Result<BlankNode, serde_json::Error> =
+            serde_json::from_str::<BlankNode>(&"{\"art\":\"r\", \"value\":\"a\", \"noise\":\"t\"}");
         assert!(b3.is_err());
 
-        let b4: Result<BlankNode, serde_json::Error> = serde_json::from_str::<BlankNode>(&"{\"art\":\"r\"}");
+        let b4: Result<BlankNode, serde_json::Error> =
+            serde_json::from_str::<BlankNode>(&"{\"art\":\"r\"}");
         assert!(b4.is_err());
     }
 

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -148,15 +148,15 @@ impl<'de> Visitor<'de> for BlankNodeVisitor {
     where
         V: MapAccess<'de>,
     {
-        let key = map.next_key::<&str>()?;
-        if key != Some("value") {
+        let key = map.next_key::<String>()?;
+        if key != Some("value".to_string()) {
             if let Some(val) = key {
-                return Err(de::Error::unknown_field(val, &["value"]));
+                return Err(de::Error::unknown_field(&val, &["value"]));
             }
             return Err(de::Error::missing_field("value"));
         }
         if cfg!(not(feature = "serde-unvalidated")) {
-            Ok(BlankNode::new(map.next_value::<&str>()?).map_err(de::Error::custom)?)
+            Ok(BlankNode::new(map.next_value::<String>()?).map_err(de::Error::custom)?)
         } else {
             Ok(BlankNode::new_unchecked(map.next_value::<String>()?))
         }
@@ -410,6 +410,8 @@ mod tests {
     use super::*;
     #[cfg(feature = "serde")]
     use serde_json;
+    #[cfg(feature = "serde")]
+    use serde::de::DeserializeOwned;
     #[cfg(not(target_family = "wasm"))]
     use std::mem::{align_of, size_of};
 
@@ -499,5 +501,36 @@ mod tests {
         let b4: Result<BlankNode, serde_json::Error> =
             serde_json::from_str::<BlankNode>(&"{\"art\":\"r\"}");
         assert!(b4.is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn as_str_partial_reader() {
+        let j = serde_json::to_string(&BlankNode::new("abc").unwrap()).unwrap();
+        let reader = std::io::Cursor::new(j.into_bytes());
+
+        let mut de = serde_json::Deserializer::from_reader(reader);
+        let deserialized = BlankNode::deserialize(&mut de);
+
+        if let Err(e) = deserialized {
+            panic!("{}", e);
+        }
+
+        assert!(deserialized.is_ok());
+        assert_eq!(
+            deserialized.unwrap(),
+            BlankNode::new("abc").unwrap()
+        );
+    }
+
+    // This helper function will only compile if T implements DeserializeOwned.
+    #[cfg(feature = "serde")]
+    fn assert_deserialize_owned<T: DeserializeOwned>() {}
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_blank_node_deserialize_owned() {
+        // If BlankNode does not implement DeserializeOwned, this call will fail to compile.
+        assert_deserialize_owned::<BlankNode>();
     }
 }

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -155,7 +155,7 @@ impl<'de> Visitor<'de> for BlankNodeVisitor {
             }
             return Err(de::Error::missing_field("value"));
         }
-        Ok(BlankNode::new_unchecked(map.next_value::<String>()?))
+        Ok(BlankNode::new(map.next_value::<String>()?).map_err(de::Error::custom)?)
     }
 }
 

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -134,6 +134,7 @@ impl Serialize for BlankNode {
         state.end()
     }
 }
+
 #[cfg(feature = "serde")]
 struct BlankNodeVisitor;
 
@@ -141,7 +142,7 @@ struct BlankNodeVisitor;
 impl<'de> Visitor<'de> for BlankNodeVisitor {
     type Value = BlankNode;
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("struct Value")
+        formatter.write_str("struct BlankNode")
     }
     fn visit_map<V>(self, mut map: V) -> Result<BlankNode, V::Error>
     where
@@ -154,7 +155,11 @@ impl<'de> Visitor<'de> for BlankNodeVisitor {
             }
             return Err(de::Error::missing_field("value"));
         }
-        Ok(BlankNode::new(map.next_value::<&str>()?).map_err(de::Error::custom)?)
+        if cfg!(not(feature = "serde-unvalidated")) {
+            Ok(BlankNode::new(map.next_value::<&str>()?).map_err(de::Error::custom)?)
+        } else {
+            Ok(BlankNode::new_unchecked(map.next_value::<String>()?))
+        }
     }
 }
 

--- a/lib/oxrdf/src/blank_node.rs
+++ b/lib/oxrdf/src/blank_node.rs
@@ -155,11 +155,7 @@ impl<'de> Visitor<'de> for BlankNodeVisitor {
             }
             return Err(de::Error::missing_field("value"));
         }
-        if cfg!(not(feature = "serde-unvalidated")) {
-            Ok(BlankNode::new(map.next_value::<String>()?).map_err(de::Error::custom)?)
-        } else {
-            Ok(BlankNode::new_unchecked(map.next_value::<String>()?))
-        }
+        Ok(BlankNode::new_unchecked(map.next_value::<String>()?))
     }
 }
 

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -208,20 +208,10 @@ impl<'de> Deserialize<'de> for Literal {
         match (datatype, language) {
             (Some(datatype), None) => Ok(Literal::new_typed_literal(
                 value,
-                if cfg!(feature = "serde-unvalidated") {
-                    NamedNode::new_unchecked(datatype)
-                } else {
-                    NamedNode::new(datatype).map_err(de::Error::custom)?
-                },
+                NamedNode::new(datatype).map_err(de::Error::custom)?,
             )),
             (None, Some(language)) => {
-                if cfg!(feature = "serde-unvalidated") {
-                    Ok(Literal::new_language_tagged_literal_unchecked(
-                        value, language,
-                    ))
-                } else {
-                    Literal::new_language_tagged_literal(value, language).map_err(de::Error::custom)
-                }
+                Literal::new_language_tagged_literal(value, language).map_err(de::Error::custom)
             }
             _ => Ok(Literal::new_simple_literal(value)),
         }
@@ -809,21 +799,13 @@ mod tests {
         let mut de = serde_json::Deserializer::from_str(j);
         let deserialized = Literal::deserialize(&mut de);
 
-        if cfg!(feature = "serde-unvalidated") {
-            assert!(deserialized.is_ok());
-        } else {
-            assert!(deserialized.is_err());
-        }
+        assert!(deserialized.is_err());
 
         let j = r#"{"value":"true","language":"bo2"}"#;
         let mut de = serde_json::Deserializer::from_str(j);
         let deserialized = Literal::deserialize(&mut de);
 
-        if cfg!(feature = "serde-unvalidated") {
-            assert!(deserialized.is_ok());
-        } else {
-            assert!(deserialized.is_err());
-        }
+        assert!(deserialized.is_err());
     }
 
     // This helper function will only compile if T implements DeserializeOwned.

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -190,11 +190,11 @@ impl Serialize for Literal {
 }
 
 #[cfg(feature = "serde")]
-#[derive(Deserialize)]  
-struct LiteralValue {  
-    value: String,  
-    language: Option<String>,  
-    datatype: Option<String>  
+#[derive(Deserialize)]
+struct LiteralValue {
+    value: String,
+    language: Option<String>,
+    datatype: Option<String>,
 }
 
 #[cfg(feature = "serde")]
@@ -203,7 +203,11 @@ impl<'de> Deserialize<'de> for Literal {
     where
         D: Deserializer<'de>,
     {
-        let LiteralValue { value, language, datatype } = LiteralValue::deserialize(deserializer)?;
+        let LiteralValue {
+            value,
+            language,
+            datatype,
+        } = LiteralValue::deserialize(deserializer)?;
         match (datatype, language) {
             (Some(datatype), None) => Ok(Literal::new_typed_literal(
                 value,

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -756,7 +756,10 @@ mod tests {
         assert_eq!("{\"value\":\"foo\",\"language\":\"en\"}", j);
         let mut de = serde_json::Deserializer::from_str(&j);
         let node: Literal = Deserialize::deserialize(&mut de).unwrap();
-        assert_eq!(node, Literal::new_language_tagged_literal("foo", "en").unwrap());
+        assert_eq!(
+            node,
+            Literal::new_language_tagged_literal("foo", "en").unwrap()
+        );
     }
 
     #[test]
@@ -788,7 +791,10 @@ mod tests {
         assert_eq!("{\"value\":\"foo\",\"language\":\"en\"}", j);
         let mut de = serde_json::Deserializer::from_reader(j.as_bytes());
         let node: Literal = Deserialize::deserialize(&mut de).unwrap();
-        assert_eq!(node, Literal::new_language_tagged_literal("foo", "en").unwrap());
+        assert_eq!(
+            node,
+            Literal::new_language_tagged_literal("foo", "en").unwrap()
+        );
     }
 
     // Test for serde validation errors

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -5,7 +5,7 @@ use oxilangtag::{LanguageTag, LanguageTagParseError};
 use oxsdatatypes::*;
 #[cfg(feature = "serde")]
 use serde::{
-    de, de::MapAccess, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize,
+    de, ser::SerializeStruct, Deserialize, Deserializer, Serialize,
     Serializer,
 };
 use std::borrow::Cow;

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -4,10 +4,7 @@ use oxilangtag::{LanguageTag, LanguageTagParseError};
 #[cfg(feature = "oxsdatatypes")]
 use oxsdatatypes::*;
 #[cfg(feature = "serde")]
-use serde::{
-    de, ser::SerializeStruct, Deserialize, Deserializer, Serialize,
-    Serializer,
-};
+use serde::{de, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Write;

--- a/lib/oxrdf/src/literal.rs
+++ b/lib/oxrdf/src/literal.rs
@@ -762,7 +762,7 @@ mod tests {
 
     // Test for serde validation errors
     #[test]
-    #[cfg(all(feature = "serde"))]
+    #[cfg(feature = "serde")]
     fn test_serde_validation() {
         let j = r#"{"value":"true","datatype":"boo"}"#;
         let mut de = serde_json::Deserializer::from_str(j);

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -45,7 +45,7 @@ impl<'de> Visitor<'de> for NamedNodeVisitor {
             }
             return Err(de::Error::missing_field("value"));
         }
-        Ok(NamedNode::new_unchecked(map.next_value::<String>()?))
+        Ok(NamedNode::new(map.next_value::<String>()?).map_err(de::Error::custom)?)
     }
 }
 
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for NamedNode {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_struct("BlankNode", &["value"], NamedNodeVisitor)
+        deserializer.deserialize_struct("NamedNode", &["value"], NamedNodeVisitor)
     }
 }
 

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -1,5 +1,5 @@
 use oxiri::{Iri, IriParseError};
-#[cfg(all(feature = "serde"))]
+#[cfg(feature = "serde")]
 use serde::{de, de::MapAccess, de::Visitor, Deserializer};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -25,10 +25,10 @@ pub struct NamedNode {
     iri: String,
 }
 
-#[cfg(all(feature = "serde"))]
+#[cfg(feature = "serde")]
 struct NamedNodeVisitor;
 
-#[cfg(all(feature = "serde"))]
+#[cfg(feature = "serde")]
 impl<'de> Visitor<'de> for NamedNodeVisitor {
     type Value = NamedNode;
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -49,7 +49,7 @@ impl<'de> Visitor<'de> for NamedNodeVisitor {
     }
 }
 
-#[cfg(all(feature = "serde"))]
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for NamedNode {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/lib/oxrdf/src/named_node.rs
+++ b/lib/oxrdf/src/named_node.rs
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "serde"))]
+    #[cfg(feature = "serde")]
     fn invalid_iri() {
         let j = r#"{"value":"boo"}"#;
         let mut de = serde_json::Deserializer::from_str(j);

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -1258,12 +1258,7 @@ pub struct Quad {
     pub object: Term,
 
     /// The name of the RDF [graph](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph) in which the triple is.
-    #[cfg_attr(
-        feature = "serde",
-        serde(
-            rename = "graph",
-        )
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "graph",))]
     pub graph_name: GraphName,
 }
 
@@ -1435,9 +1430,9 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "serde")]
-    use serde_json::json;
-    #[cfg(feature = "serde")]
     use serde::de::DeserializeOwned;
+    #[cfg(feature = "serde")]
+    use serde_json::json;
 
     #[test]
     fn triple_from_terms() -> Result<(), TryFromTermError> {

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -865,7 +865,7 @@ where
                     }
                 }
             }
-            iri.map(|iri| NamedNode::new_unchecked(iri))
+            iri.map(NamedNode::new_unchecked)
                 .ok_or_else(|| de::Error::missing_field("value"))
         }
     }

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -1586,7 +1586,7 @@ mod tests {
         let b: Term = BlankNode::new("foo").unwrap().into();
         let json = serde_json::to_string(&b).unwrap();
         assert_eq!(json, "{\"type\":\"bnode\",\"value\":\"foo\"}");
-        let b2: BlankNode = serde_json::from_str(&json).unwrap();
-        assert_eq!(b2, BlankNode::new("foo").unwrap());
+        let b2: Term = serde_json::from_str(&json).unwrap();
+        assert_eq!(b2, Term::BlankNode(BlankNode::new("foo").unwrap()));
     }
 }

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -848,7 +848,10 @@ where
                     "type" => {
                         let value = map.next_value::<&str>()?;
                         if value != "uri" {
-                            return Err(de::Error::invalid_value(de::Unexpected::Str(value), &"uri"));
+                            return Err(de::Error::invalid_value(
+                                de::Unexpected::Str(value),
+                                &"uri",
+                            ));
                         }
                     }
                     "value" => {
@@ -862,8 +865,7 @@ where
                     }
                 }
             }
-            iri
-                .map(|iri| NamedNode::new_unchecked(iri))
+            iri.map(|iri| NamedNode::new_unchecked(iri))
                 .ok_or_else(|| de::Error::missing_field("value"))
         }
     }
@@ -954,7 +956,6 @@ pub struct TripleRef<'a> {
     pub subject: SubjectRef<'a>,
 
     /// The [predicate](https://www.w3.org/TR/rdf11-concepts/#dfn-predicate) of this triple.
-    
     pub predicate: NamedNodeRef<'a>,
 
     /// The [object](https://www.w3.org/TR/rdf11-concepts/#dfn-object) of this triple.

--- a/lib/oxrdf/src/triple.rs
+++ b/lib/oxrdf/src/triple.rs
@@ -843,13 +843,13 @@ where
             V: MapAccess<'de>,
         {
             let mut iri = None;
-            while let Some(key) = map.next_key::<&str>()? {
-                match key {
+            while let Some(key) = map.next_key::<String>()? {
+                match key.as_str() {
                     "type" => {
-                        let value = map.next_value::<&str>()?;
-                        if value != "uri" {
+                        let value = map.next_value::<String>()?;
+                        if value.as_str() != "uri" {
                             return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(value),
+                                de::Unexpected::Str(value.as_str()),
                                 &"uri",
                             ));
                         }
@@ -861,7 +861,7 @@ where
                         iri = Some(map.next_value::<String>()?);
                     }
                     _ => {
-                        return Err(de::Error::unknown_field(key, &["type", "value"]));
+                        return Err(de::Error::unknown_field(&key, &["type", "value"]));
                     }
                 }
             }
@@ -1023,10 +1023,15 @@ impl<'a> From<TripleRef<'a>> for Triple {
 ///
 /// It is the union of [IRIs](https://www.w3.org/TR/rdf11-concepts/#dfn-iri), [blank nodes](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node), and the [default graph name](https://www.w3.org/TR/rdf11-concepts/#dfn-default-graph).
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "lowercase"))]
 pub enum GraphName {
+    #[cfg_attr(feature = "serde", serde(rename = "uri"))]
     NamedNode(NamedNode),
+    #[cfg_attr(feature = "serde", serde(rename = "bnode"))]
     BlankNode(BlankNode),
     #[default]
+    #[cfg_attr(feature = "serde", serde(rename = "default"))]
     DefaultGraph,
 }
 
@@ -1233,17 +1238,32 @@ impl<'a> From<GraphNameRef<'a>> for GraphName {
 /// # Result::<_,oxrdf::IriParseError>::Ok(())
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Quad {
     /// The [subject](https://www.w3.org/TR/rdf11-concepts/#dfn-subject) of this triple.
     pub subject: Subject,
 
     /// The [predicate](https://www.w3.org/TR/rdf11-concepts/#dfn-predicate) of this triple.
+    ///     #[cfg_attr(
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "serialize_predicate",
+            deserialize_with = "deserialize_predicate"
+        )
+    )]
     pub predicate: NamedNode,
 
     /// The [object](https://www.w3.org/TR/rdf11-concepts/#dfn-object) of this triple.
     pub object: Term,
 
     /// The name of the RDF [graph](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph) in which the triple is.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            rename = "graph",
+        )
+    )]
     pub graph_name: GraphName,
 }
 
@@ -1416,6 +1436,8 @@ mod tests {
 
     #[cfg(feature = "serde")]
     use serde_json::json;
+    #[cfg(feature = "serde")]
+    use serde::de::DeserializeOwned;
 
     #[test]
     fn triple_from_terms() -> Result<(), TryFromTermError> {
@@ -1557,6 +1579,44 @@ mod tests {
 
     #[test]
     #[cfg(feature = "serde")]
+    fn serde_from_reader() -> Result<(), serde_json::Error> {
+        let triple = Triple::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+        );
+        let jsn = serde_json::to_string(&triple)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Triple = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, triple);
+
+        // Test triples with all possible combinations of terms
+        let triple = Triple::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            Literal::new_simple_literal("foo"),
+        );
+        let jsn = serde_json::to_string(&triple)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Triple = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, triple);
+
+        let triple = Triple::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            BlankNode::new("foo").unwrap(),
+        );
+
+        let jsn = serde_json::to_string(&triple).unwrap();
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Triple = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, triple);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
     #[cfg(feature = "rdf-star")]
     fn serde_star() -> Result<(), serde_json::Error> {
         let triple = Triple::new(
@@ -1582,11 +1642,250 @@ mod tests {
 
     #[test]
     #[cfg(feature = "serde")]
+    #[cfg(feature = "rdf-star")]
+    fn serde_star_from_reader() -> Result<(), serde_json::Error> {
+        let triple = Triple::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            Term::Triple(Box::new(Triple::new(
+                NamedNode::new_unchecked("http://example.com/s"),
+                NamedNode::new_unchecked("http://example.com/p"),
+                NamedNode::new_unchecked("http://example.com/o"),
+            ))),
+        );
+
+        let jsn = serde_json::to_string(&triple)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Triple = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, triple);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_quad() -> Result<(), serde_json::Error> {
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        assert_eq!(
+            jsn,
+            r#"{"subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"uri","value":"http://example.com/o"},"graph":{"type":"uri","value":"http://example.com/g"}}"#
+        );
+        let deserialized: Quad = serde_json::from_str(&jsn)?;
+        assert_eq!(deserialized, quad);
+
+        // Test quads with all possible combinations of terms
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            Literal::new_simple_literal("foo"),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        assert_eq!(
+            jsn,
+            r#"{"subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"literal","value":"foo"},"graph":{"type":"uri","value":"http://example.com/g"}}"#
+        );
+        let deserialized: Quad = serde_json::from_str(&jsn)?;
+        assert_eq!(deserialized, quad);
+
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            BlankNode::new("foo").unwrap(),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+
+        let jsn = serde_json::to_string(&quad).unwrap();
+        assert_eq!(
+            jsn,
+            r#"{"subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"bnode","value":"foo"},"graph":{"type":"uri","value":"http://example.com/g"}}"#
+        );
+        let deserialized: Quad = serde_json::from_str(&jsn)?;
+        assert_eq!(deserialized, quad);
+
+        // Test quads with blank node graph name
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+            BlankNode::new("foo").unwrap(),
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        assert_eq!(
+            jsn,
+            r#"{"subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"uri","value":"http://example.com/o"},"graph":{"type":"bnode","value":"foo"}}"#
+        );
+        let deserialized: Quad = serde_json::from_str(&jsn)?;
+        assert_eq!(deserialized, quad);
+
+        // Test quads with default graph name
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+            GraphName::DefaultGraph,
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        assert_eq!(
+            jsn,
+            r#"{"subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"uri","value":"http://example.com/o"},"graph":{"type":"default"}}"#
+        );
+        let deserialized: Quad = serde_json::from_str(&jsn)?;
+        assert_eq!(deserialized, quad);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_quad_from_reader() -> Result<(), serde_json::Error> {
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Quad = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, quad);
+
+        // Test quads with all possible combinations of terms
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            Literal::new_simple_literal("foo"),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Quad = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, quad);
+
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            BlankNode::new("foo").unwrap(),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+
+        let jsn = serde_json::to_string(&quad).unwrap();
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Quad = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, quad);
+
+        // Test quads with blank node graph name
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+            BlankNode::new("foo").unwrap(),
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Quad = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, quad);
+
+        // Test quads with default graph name
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            NamedNode::new_unchecked("http://example.com/o"),
+            GraphName::DefaultGraph,
+        );
+        let jsn = serde_json::to_string(&quad)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Quad = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, quad);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    #[cfg(feature = "rdf-star")]
+    fn serde_quad_star() -> Result<(), serde_json::Error> {
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            Term::Triple(Box::new(Triple::new(
+                NamedNode::new_unchecked("http://example.com/s"),
+                NamedNode::new_unchecked("http://example.com/p"),
+                NamedNode::new_unchecked("http://example.com/o"),
+            ))),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+
+        let jsn = serde_json::to_string(&quad)?;
+        assert_eq!(
+            jsn,
+            r#"{"subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"triple","subject":{"type":"uri","value":"http://example.com/s"},"predicate":{"type":"uri","value":"http://example.com/p"},"object":{"type":"uri","value":"http://example.com/o"}},"graph":{"type":"uri","value":"http://example.com/g"}}"#
+        );
+        let deserialized: Quad = serde_json::from_str(&jsn)?;
+        assert_eq!(deserialized, quad);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    #[cfg(feature = "rdf-star")]
+    fn serde_quad_star_from_reader() -> Result<(), serde_json::Error> {
+        let quad = Quad::new(
+            NamedNode::new_unchecked("http://example.com/s"),
+            NamedNode::new_unchecked("http://example.com/p"),
+            Term::Triple(Box::new(Triple::new(
+                NamedNode::new_unchecked("http://example.com/s"),
+                NamedNode::new_unchecked("http://example.com/p"),
+                NamedNode::new_unchecked("http://example.com/o"),
+            ))),
+            NamedNode::new_unchecked("http://example.com/g"),
+        );
+
+        let jsn = serde_json::to_string(&quad)?;
+        let reader = std::io::Cursor::new(jsn.as_bytes());
+        let deserialized: Quad = serde_json::from_reader(reader)?;
+        assert_eq!(deserialized, quad);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
     fn test_serde_term() {
         let b: Term = BlankNode::new("foo").unwrap().into();
         let json = serde_json::to_string(&b).unwrap();
         assert_eq!(json, "{\"type\":\"bnode\",\"value\":\"foo\"}");
         let b2: Term = serde_json::from_str(&json).unwrap();
         assert_eq!(b2, Term::BlankNode(BlankNode::new("foo").unwrap()));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_term_from_reader() {
+        let b: Term = BlankNode::new("foo").unwrap().into();
+        let json = serde_json::to_string(&b).unwrap();
+        let reader = std::io::Cursor::new(json.as_bytes());
+        let b2: Term = serde_json::from_reader(reader).unwrap();
+        assert_eq!(b2, Term::BlankNode(BlankNode::new("foo").unwrap()));
+    }
+
+    // This helper function will only compile if T implements DeserializeOwned.
+    #[cfg(feature = "serde")]
+    fn assert_deserialize_owned<T: DeserializeOwned>() {}
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_term_deserialize_owned() {
+        // If Term does not implement DeserializeOwned, this call will fail to compile.
+        assert_deserialize_owned::<Term>();
+        assert_deserialize_owned::<Triple>();
+        assert_deserialize_owned::<Quad>();
     }
 }

--- a/lib/spargebra/Cargo.toml
+++ b/lib/spargebra/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 rdf-star = ["oxrdf/rdf-star"]
 sep-0002 = []
 sep-0006 = []
+serde = ["dep:serde", "oxrdf/serde"]
 
 [dependencies]
 oxilangtag.workspace = true
@@ -26,6 +27,14 @@ oxrdf.workspace = true
 peg.workspace = true
 rand.workspace = true
 thiserror.workspace = true
+serde = { version = "1.0.217", features = ["derive"], optional = true }
+
+[dev-dependencies]
+# Ideally this would be an optional dependency, used only when the `serde` feature is enabled.
+
+# However, optional dev-dependencies are not currently supported by cargo.
+# See https://github.com/rust-lang/cargo/issues/1596
+serde_json = { version = "1.0.134" }
 
 [lints]
 workspace = true

--- a/lib/spargebra/src/algebra.rs
+++ b/lib/spargebra/src/algebra.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 /// A [property path expression](https://www.w3.org/TR/sparql11-query/#defn_PropertyPathExpr).
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PropertyPathExpression {
     NamedNode(NamedNode),
     Reverse(Box<Self>),
@@ -516,6 +517,7 @@ impl fmt::Display for Function {
 
 /// A SPARQL query [graph pattern](https://www.w3.org/TR/sparql11-query/#sparqlQuery).
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GraphPattern {
     /// A [basic graph pattern](https://www.w3.org/TR/sparql11-query/#defn_BasicGraphPattern).
     Bgp { patterns: Vec<TriplePattern> },
@@ -1313,6 +1315,7 @@ impl fmt::Display for OrderExpression {
 
 /// A SPARQL query [dataset specification](https://www.w3.org/TR/sparql11-query/#specifyingDataset).
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
+
 pub struct QueryDataset {
     pub default: Vec<NamedNode>,
     pub named: Option<Vec<NamedNode>>,

--- a/lib/spargebra/src/term.rs
+++ b/lib/spargebra/src/term.rs
@@ -797,6 +797,7 @@ impl From<NamedNodePattern> for GraphNamePattern {
 }
 
 /// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct TriplePattern {
     pub subject: TermPattern,


### PR DESCRIPTION
Extends #1272 with support for `Serde` on the query object.