### PR TITLE
spargrebra: introduce the SparqlParser struct instead of Query::parse

### DIFF
--- a/fuzz/fuzz_targets/sparql_query.rs
+++ b/fuzz/fuzz_targets/sparql_query.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use spargebra::Query;
+use spargebra::SparqlParser;
 
 fuzz_target!(|data: &str| {
-    let _ = Query::parse(data, None);
+    let _ = SparqlParser::new().parse_query(data);
 });

--- a/fuzz/fuzz_targets/sparql_query_eval.rs
+++ b/fuzz/fuzz_targets/sparql_query_eval.rs
@@ -13,6 +13,7 @@ use oxigraph_fuzz::count_triple_blank_nodes;
 use oxiri::Iri;
 use oxrdf::{GraphNameRef, QuadRef};
 use spareval::{DefaultServiceHandler, QueryEvaluationError, QueryEvaluator};
+use spargebra::SparqlParser;
 use spargebra::algebra::GraphPattern;
 use std::sync::OnceLock;
 
@@ -35,7 +36,7 @@ fuzz_target!(|data: sparql_smith::Query| {
     });
 
     let query_str = data.to_string();
-    if let Ok(query) = spargebra::Query::parse(&query_str, None) {
+    if let Ok(query) = SparqlParser::new().parse_query(&query_str) {
         let options = QueryOptions::default().with_default_service_handler(StoreServiceHandler {
             store: store.clone(),
         });

--- a/fuzz/fuzz_targets/sparql_update.rs
+++ b/fuzz/fuzz_targets/sparql_update.rs
@@ -1,8 +1,8 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use spargebra::Update;
+use spargebra::SparqlParser;
 use std::str;
 
 fuzz_target!(|data: &str| {
-    let _ = Update::parse(data, None);
+    let _ = SparqlParser::new().parse_update(data);
 });

--- a/lib/oxigraph/src/sparql/algebra.rs
+++ b/lib/oxigraph/src/sparql/algebra.rs
@@ -40,6 +40,7 @@ impl Query {
         query: &str,
         base_iri: Option<&str>,
     ) -> Result<Self, spargebra::SparqlSyntaxError> {
+        #[expect(deprecated)]
         let query = Self::from(spargebra::Query::parse(query, base_iri)?);
         Ok(Self {
             dataset: query.dataset,
@@ -126,6 +127,7 @@ impl Update {
         update: &str,
         base_iri: Option<&str>,
     ) -> Result<Self, spargebra::SparqlSyntaxError> {
+        #[expect(deprecated)]
         Ok(spargebra::Update::parse(update, base_iri)?.into())
     }
 

--- a/lib/spareval/README.md
+++ b/lib/spareval/README.md
@@ -17,7 +17,7 @@ to be a building piece for SPARQL implementations like [oxigraph](https://oxigra
 ```rust
 use oxrdf::{Dataset, GraphName, NamedNode, Quad};
 use spareval::{QueryEvaluator, QueryResults};
-use spargebra::Query;
+use spargebra::SparqlParser;
 
 let ex = NamedNode::new("http://example.com").unwrap();
 let dataset = Dataset::from_iter([Quad::new(
@@ -26,7 +26,7 @@ let dataset = Dataset::from_iter([Quad::new(
     ex.clone(),
     GraphName::DefaultGraph,
 )]);
-let query = Query::parse("SELECT * WHERE { ?s ?p ?o }", None).unwrap();
+let query = SparqlParser::new().parse_query("SELECT * WHERE { ?s ?p ?o }").unwrap();
 let results = QueryEvaluator::new().execute(dataset, &query);
 if let QueryResults::Solutions(solutions) = results.unwrap() {
     let solutions = solutions.collect::<Result<Vec<_>, _>>().unwrap();

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -38,7 +38,7 @@ use std::{fmt, io};
 /// ```
 /// use oxrdf::{Dataset, GraphName, NamedNode, Quad};
 /// use spareval::{QueryEvaluator, QueryResults};
-/// use spargebra::Query;
+/// use spargebra::SparqlParser;
 ///
 /// let ex = NamedNode::new("http://example.com")?;
 /// let dataset = Dataset::from_iter([Quad::new(
@@ -47,7 +47,7 @@ use std::{fmt, io};
 ///     ex.clone(),
 ///     GraphName::DefaultGraph,
 /// )]);
-/// let query = Query::parse("SELECT * WHERE { ?s ?p ?o }", None)?;
+/// let query = SparqlParser::new().parse_query("SELECT * WHERE { ?s ?p ?o }")?;
 /// let results = QueryEvaluator::new().execute(dataset, &query);
 /// if let QueryResults::Solutions(solutions) = results? {
 ///     let solutions = solutions.collect::<Result<Vec<_>, _>>()?;
@@ -86,7 +86,7 @@ impl QueryEvaluator {
     /// ```
     /// use oxrdf::{Dataset, GraphName, NamedNode, Quad, Variable};
     /// use spareval::{QueryEvaluator, QueryResults};
-    /// use spargebra::Query;
+    /// use spargebra::SparqlParser;
     ///
     /// let ex = NamedNode::new("http://example.com")?;
     /// let dataset = Dataset::from_iter([Quad::new(
@@ -95,7 +95,7 @@ impl QueryEvaluator {
     ///     ex.clone(),
     ///     GraphName::DefaultGraph,
     /// )]);
-    /// let query = Query::parse("SELECT * WHERE { ?s ?p ?o }", None)?;
+    /// let query = SparqlParser::new().parse_query("SELECT * WHERE { ?s ?p ?o }")?;
     /// let results = QueryEvaluator::new().execute_with_substituted_variables(
     ///     dataset,
     ///     &query,
@@ -275,16 +275,14 @@ impl QueryEvaluator {
     /// ```
     /// use oxrdf::{Dataset, Literal, NamedNode};
     /// use spareval::{QueryEvaluator, QueryResults};
-    /// use spargebra::Query;
+    /// use spargebra::SparqlParser;
     ///
     /// let evaluator = QueryEvaluator::new().with_custom_function(
     ///     NamedNode::new("http://www.w3.org/ns/formats/N-Triples")?,
     ///     |args| args.get(0).map(|t| Literal::from(t.to_string()).into()),
     /// );
-    /// let query = Query::parse(
-    ///     "SELECT (<http://www.w3.org/ns/formats/N-Triples>(1) AS ?nt) WHERE {}",
-    ///     None,
-    /// )?;
+    /// let query = SparqlParser::new()
+    ///     .parse_query("SELECT (<http://www.w3.org/ns/formats/N-Triples>(1) AS ?nt) WHERE {}")?;
     /// if let QueryResults::Solutions(mut solutions) = evaluator.execute(Dataset::new(), &query)? {
     ///     assert_eq!(
     ///         solutions.next().unwrap()?.get("nt"),

--- a/lib/spareval/src/model.rs
+++ b/lib/spareval/src/model.rs
@@ -25,9 +25,9 @@ impl From<QuerySolutionIter> for QueryResults {
 /// ```
 /// use oxrdf::Dataset;
 /// use spareval::{QueryEvaluator, QueryResults};
-/// use spargebra::Query;
+/// use spargebra::SparqlParser;
 ///
-/// let query = Query::parse("SELECT ?s ?o WHERE { ?s ?p ?o }", None)?;
+/// let query = SparqlParser::new().parse_query("SELECT ?s ?o WHERE { ?s ?p ?o }")?;
 /// if let QueryResults::Solutions(solutions) =
 ///     QueryEvaluator::new().execute(Dataset::new(), &query)?
 /// {
@@ -60,9 +60,9 @@ impl QuerySolutionIter {
     /// ```
     /// use oxrdf::{Dataset, Variable};
     /// use spareval::{QueryEvaluator, QueryResults};
-    /// use spargebra::Query;
+    /// use spargebra::SparqlParser;
     ///
-    /// let query = Query::parse("SELECT ?s ?o WHERE { ?s ?p ?o }", None)?;
+    /// let query = SparqlParser::new().parse_query("SELECT ?s ?o WHERE { ?s ?p ?o }")?;
     /// if let QueryResults::Solutions(solutions) =
     ///     QueryEvaluator::new().execute(Dataset::new(), &query)?
     /// {
@@ -98,9 +98,9 @@ impl Iterator for QuerySolutionIter {
 /// ```
 /// use oxrdf::Dataset;
 /// use spareval::{QueryEvaluator, QueryResults};
-/// use spargebra::Query;
+/// use spargebra::SparqlParser;
 ///
-/// let query = Query::parse("CONSTRUCT WHERE { ?s ?p ?o }", None)?;
+/// let query = SparqlParser::new().parse_query("CONSTRUCT WHERE { ?s ?p ?o }")?;
 /// if let QueryResults::Graph(triples) = QueryEvaluator::new().execute(Dataset::new(), &query)? {
 ///     for triple in triples {
 ///         println!("{}", triple?);

--- a/lib/spareval/src/service.rs
+++ b/lib/spareval/src/service.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// use oxrdf::{Dataset, Literal, NamedNode, Variable};
 /// use sparesults::QuerySolution;
 /// use spareval::{QueryEvaluator, QueryResults, QuerySolutionIter, ServiceHandler};
-/// use spargebra::Query;
+/// use spargebra::SparqlParser;
 /// use spargebra::algebra::GraphPattern;
 /// use std::convert::Infallible;
 /// use std::iter::once;
@@ -48,10 +48,8 @@ use std::sync::Arc;
 ///     NamedNode::new("http://example.com/service")?,
 ///     TestServiceHandler {},
 /// );
-/// let query = Query::parse(
-///     "SELECT ?foo WHERE { SERVICE <http://example.com/service> {} }",
-///     None,
-/// )?;
+/// let query = SparqlParser::new()
+///     .parse_query("SELECT ?foo WHERE { SERVICE <http://example.com/service> {} }")?;
 /// if let QueryResults::Solutions(mut solutions) = evaluator.execute(Dataset::new(), &query)? {
 ///     assert_eq!(
 ///         solutions.next().unwrap()?.get("foo"),
@@ -83,7 +81,7 @@ pub trait ServiceHandler: Send + Sync {
 /// use oxrdf::{Dataset, NamedNode, Variable};
 /// use sparesults::QuerySolution;
 /// use spareval::{DefaultServiceHandler, QueryEvaluator, QueryResults, QuerySolutionIter};
-/// use spargebra::Query;
+/// use spargebra::SparqlParser;
 /// use spargebra::algebra::GraphPattern;
 /// use std::convert::Infallible;
 /// use std::iter::once;
@@ -113,10 +111,8 @@ pub trait ServiceHandler: Send + Sync {
 /// }
 ///
 /// let evaluator = QueryEvaluator::default().with_default_service_handler(TestServiceHandler {});
-/// let query = Query::parse(
-///     "SELECT ?foo WHERE { SERVICE <http://example.com/service> {} }",
-///     None,
-/// )?;
+/// let query = SparqlParser::new()
+///     .parse_query("SELECT ?foo WHERE { SERVICE <http://example.com/service> {} }")?;
 /// if let QueryResults::Solutions(mut solutions) = evaluator.execute(Dataset::new(), &query)? {
 ///     assert_eq!(
 ///         solutions.next().unwrap()?.get("foo"),

--- a/lib/spargebra/README.md
+++ b/lib/spargebra/README.md
@@ -22,10 +22,10 @@ This crate is intended to be a building piece for SPARQL implementations in Rust
 Usage example:
 
 ```rust
-use spargebra::Query;
+use spargebra::SparqlParser;
 
 let query_str = "SELECT ?s ?p ?o WHERE { ?s ?p ?o . }";
-let query = Query::parse(query_str, None).unwrap();
+let query = SparqlParser::new().parse_query(query_str).unwrap();
 assert_eq!(query.to_string(), query_str);
 ```
 

--- a/lib/spargebra/src/lib.rs
+++ b/lib/spargebra/src/lib.rs
@@ -10,6 +10,6 @@ mod query;
 pub mod term;
 mod update;
 
-pub use parser::SparqlSyntaxError;
+pub use parser::{SparqlParser, SparqlSyntaxError};
 pub use query::*;
 pub use update::*;


### PR DESCRIPTION
Allows to set default prefixes

