### PR TITLE
Introduce `LowLevelTurtleParser::seen_comment(&self) -> bool`

### DIFF
--- a/lib/oxttl/src/toolkit/lexer.rs
+++ b/lib/oxttl/src/toolkit/lexer.rs
@@ -64,6 +64,11 @@ pub struct Lexer<B, R: TokenRecognizer> {
     min_buffer_size: usize,
     max_buffer_size: usize,
     line_comment_start: Option<&'static [u8]>,
+    /// Whether a (syntax) comment has been seen in the input yet.
+    ///
+    /// This concerns syntax comments (e.g. `# foo`),
+    /// not RDF comments (e.g. `<s> rdfs::comment "A random subject"@en .`).
+    seen_comment: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -102,7 +107,16 @@ impl<B, R: TokenRecognizer> Lexer<B, R> {
             min_buffer_size,
             max_buffer_size,
             line_comment_start,
+            seen_comment: false,
         }
+    }
+
+    /// Whether a (syntax) comment has been seen in the input yet.
+    ///
+    /// This concerns syntax comments (e.g. `# foo`),
+    /// not RDF comments (e.g. `<s> rdfs::comment "A random subject"@en .`).
+    pub fn seen_comment(&self) -> bool {
+        self.seen_comment
     }
 }
 
@@ -331,6 +345,7 @@ impl<B: Deref<Target = [u8]>, R: TokenRecognizer> Lexer<B, R> {
         if let Some(line_comment_start) = self.line_comment_start {
             if buf.starts_with(line_comment_start) {
                 // Comment
+                self.seen_comment = true;
                 if let Some(end) = memchr2(b'\r', b'\n', &buf[line_comment_start.len()..]) {
                     let mut end_position = line_comment_start.len() + end;
                     if buf.get(end_position).copied() == Some(b'\r') {

--- a/lib/oxttl/src/toolkit/parser.rs
+++ b/lib/oxttl/src/toolkit/parser.rs
@@ -71,6 +71,14 @@ impl<B: Deref<Target = [u8]>, RR: RuleRecognizer> Parser<B, RR> {
         self.state.is_none() && self.results.is_empty() && self.errors.is_empty()
     }
 
+    /// Whether a (syntax) comment has been seen in the input yet.
+    ///
+    /// This concerns syntax comments (e.g. `# foo`),
+    /// not RDF comments (e.g. `<s> rdfs::comment "A random subject"@en .`).
+    pub fn seen_comment(&self) -> bool {
+        self.lexer.seen_comment()
+    }
+
     pub fn parse_next(&mut self) -> Option<Result<RR::Output, TurtleSyntaxError>> {
         loop {
             if let Some(error) = self.errors.pop() {

--- a/lib/oxttl/src/turtle.rs
+++ b/lib/oxttl/src/turtle.rs
@@ -761,6 +761,14 @@ impl LowLevelTurtleParser {
             .as_ref()
             .map(Iri::as_str)
     }
+
+    /// Whether a (syntax) comment has been seen in the input yet.
+    ///
+    /// This concerns syntax comments (e.g. `# foo`),
+    /// not RDF comments (e.g. `<s> rdfs::comment "A random subject"@en .`).
+    pub fn seen_comment(&self) -> bool {
+        self.parser.seen_comment()
+    }
 }
 
 /// Iterator on the file prefixes.


### PR DESCRIPTION
I am pretty sure you do not want that,
but I need this (or somethign similar),
and it woudl make my life easier if it were with you (upstream).
If you would accept it if it were behind a feature,
or even making comment content available
in a way similar to prefixes and bases (behind a feautre),
I could have a go at that too.

If none of that, I'll just have to maintain a fork for that;
possible too.