### PR TITLE
Introduce SPARQL fluent API SparqlEvaluator

### DIFF
--- a/cli/src/service_description.rs
+++ b/cli/src/service_description.rs
@@ -27,6 +27,11 @@ mod sd {
 
     pub const EMPTY_GRAPHS: NamedNodeRef<'_> =
         NamedNodeRef::new_unchecked("http://www.w3.org/ns/sparql-service-description#EmptyGraphs");
+    #[cfg(any(
+        feature = "native-tls",
+        feature = "rustls-native",
+        feature = "rustls-webpki"
+    ))]
     pub const BASIC_FEDERATED_QUERY: NamedNodeRef<'_> = NamedNodeRef::new_unchecked(
         "http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery",
     );

--- a/lib/oxigraph/src/sparql/algebra.rs
+++ b/lib/oxigraph/src/sparql/algebra.rs
@@ -2,6 +2,8 @@
 //!
 //! The root type for SPARQL queries is [`Query`] and the root type for updates is [`Update`].
 
+#![expect(deprecated)]
+
 use crate::model::*;
 use spargebra::GraphUpdateOperation;
 use std::fmt;
@@ -29,6 +31,10 @@ use std::str::FromStr;
 /// ```
 #[expect(clippy::field_scoped_visibility_modifiers)]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[deprecated(
+    note = "Use SparqlEvaluator instead to parse the query with options or directly the spargebra::Query type",
+    since = "0.5.0"
+)]
 pub struct Query {
     pub(super) inner: spargebra::Query,
     pub(super) dataset: QueryDataset,
@@ -41,11 +47,7 @@ impl Query {
         base_iri: Option<&str>,
     ) -> Result<Self, spargebra::SparqlSyntaxError> {
         #[expect(deprecated)]
-        let query = Self::from(spargebra::Query::parse(query, base_iri)?);
-        Ok(Self {
-            dataset: query.dataset,
-            inner: query.inner,
-        })
+        Ok(spargebra::Query::parse(query, base_iri)?.into())
     }
 
     /// Returns [the query dataset specification](https://www.w3.org/TR/sparql11-query/#specifyingDataset)
@@ -116,6 +118,10 @@ impl From<spargebra::Query> for Query {
 /// ```
 #[expect(clippy::field_scoped_visibility_modifiers)]
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[deprecated(
+    note = "Use SparqlEvaluator instead to parse the update with options or directly the spargebra::Update type",
+    since = "0.5.0"
+)]
 pub struct Update {
     pub(super) inner: spargebra::Update,
     pub(super) using_datasets: Vec<Option<QueryDataset>>,
@@ -206,7 +212,7 @@ impl QueryDataset {
         }
     }
 
-    fn from_algebra(inner: &Option<spargebra::algebra::QueryDataset>) -> Self {
+    pub(crate) fn from_algebra(inner: &Option<spargebra::algebra::QueryDataset>) -> Self {
         if let Some(inner) = inner {
             Self {
                 default: Some(inner.default.iter().map(|g| g.clone().into()).collect()),
@@ -224,7 +230,7 @@ impl QueryDataset {
     }
 
     /// Checks if this dataset specification is the default one
-    /// (i.e. the default graph is the store default graph and all the store named graphs are available)
+    /// (i.e., the default graph is the store default graph and all the store named graphs are available)
     ///
     /// ```
     /// use oxigraph::sparql::Query;
@@ -252,8 +258,8 @@ impl QueryDataset {
             && self.named.is_none()
     }
 
-    /// Returns the list of the store graphs that are available to the query as the default graph or `None` if the union of all graphs is used as the default graph
-    /// This list is by default only the store default graph
+    /// Returns the list of the store graphs that are available to the query as the default graph or `None` if the union of all graphs is used as the default graph.
+    /// This list is by default only the store default graph.
     pub fn default_graph_graphs(&self) -> Option<&[GraphName]> {
         self.default.as_deref()
     }
@@ -265,7 +271,7 @@ impl QueryDataset {
 
     /// Sets the list of graphs the query should consider as being part of the default graph.
     ///
-    /// By default only the store default graph is considered.
+    /// By default, only the store default graph is considered.
     /// ```
     /// use oxigraph::model::NamedNode;
     /// use oxigraph::sparql::Query;

--- a/lib/oxigraph/src/sparql/mod.rs
+++ b/lib/oxigraph/src/sparql/mod.rs
@@ -1,6 +1,6 @@
 //! [SPARQL](https://www.w3.org/TR/sparql11-overview/) implementation.
 //!
-//! Stores execute SPARQL. See [`Store`](crate::store::Store::query()) for an example.
+//! The entry point for SPARQL execution is the [`SparqlEvaluator`] type.
 
 mod algebra;
 mod dataset;
@@ -13,6 +13,7 @@ mod service;
 mod update;
 
 use crate::model::{NamedNode, Term};
+#[expect(deprecated)]
 pub use crate::sparql::algebra::{Query, QueryDataset, Update};
 use crate::sparql::dataset::DatasetView;
 pub use crate::sparql::error::EvaluationError;
@@ -21,71 +22,122 @@ use crate::sparql::http::HttpServiceHandler;
 pub use crate::sparql::model::{QueryResults, QuerySolution, QuerySolutionIter, QueryTripleIter};
 pub use crate::sparql::service::{DefaultServiceHandler, ServiceHandler};
 use crate::sparql::service::{WrappedDefaultServiceHandler, WrappedServiceHandler};
-pub(crate) use crate::sparql::update::{
-    evaluate_update_on_storage, evaluate_update_on_transaction,
-};
+pub use crate::sparql::update::{BoundPreparedSparqlUpdate, PreparedSparqlUpdate};
 use crate::storage::StorageReader;
+use crate::store::{Store, Transaction};
+use oxrdf::IriParseError;
 pub use oxrdf::{Variable, VariableNameParseError};
 use spareval::QueryEvaluator;
 pub use spareval::QueryExplanation;
+use spargebra::SparqlParser;
 pub use spargebra::SparqlSyntaxError;
+use std::collections::HashMap;
+use std::mem::take;
 #[cfg(feature = "http-client")]
 use std::time::Duration;
 
-pub(crate) fn evaluate_query(
-    reader: StorageReader,
-    query: impl TryInto<Query, Error = impl Into<EvaluationError>>,
-    options: QueryOptions,
-    run_stats: bool,
-    substitutions: impl IntoIterator<Item = (Variable, Term)>,
-) -> Result<(Result<QueryResults, EvaluationError>, QueryExplanation), EvaluationError> {
-    let query = query.try_into().map_err(Into::into)?;
-    let dataset = DatasetView::new(reader, &query.dataset);
-    let mut evaluator = options.into_evaluator();
-    if run_stats {
-        evaluator = evaluator.compute_statistics();
-    }
-    let (results, explanation) =
-        evaluator.explain_with_substituted_variables(dataset, &query.inner, substitutions);
-    let results = results.map_err(Into::into).map(Into::into);
-    Ok((results, explanation))
-}
+#[deprecated(note = "Use SparqlEvaluator instead", since = "0.5.0")]
+pub type QueryOptions = SparqlEvaluator;
+#[deprecated(note = "Use SparqlEvaluator instead", since = "0.5.0")]
+pub type UpdateOptions = SparqlEvaluator;
 
-/// Options for SPARQL query evaluation.
+/// SPARQL evaluator.
 ///
+/// It supports [SPARQL 1.1 query](https://www.w3.org/TR/sparql11-query/) and [SPARQL 1.1 update](https://www.w3.org/TR/sparql11-update/).
 ///
 /// If the `"http-client"` optional feature is enabled,
 /// a simple HTTP 1.1 client is used to execute [SPARQL 1.1 Federated Query](https://www.w3.org/TR/sparql11-federated-query/) SERVICE calls.
 ///
 /// Usage example disabling the federated query support:
 /// ```
-/// use oxigraph::sparql::QueryOptions;
+/// use oxigraph::sparql::SparqlEvaluator;
 /// use oxigraph::store::Store;
 ///
-/// let store = Store::new()?;
-/// store.query_opt(
-///     "SELECT * WHERE { SERVICE <https://query.wikidata.org/sparql> {} }",
-///     QueryOptions::default().without_default_http_service_handler(),
-/// )?;
+/// SparqlEvaluator::new()
+///     .without_default_http_service_handler()
+///     .parse_query("SELECT * WHERE { SERVICE <https://query.wikidata.org/sparql> {} }")?
+///     .on_store(&Store::new()?)
+///     .execute()?;
 /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
 /// ```
 #[derive(Clone)]
-pub struct QueryOptions {
+#[must_use]
+pub struct SparqlEvaluator {
     #[cfg(feature = "http-client")]
     http_timeout: Option<Duration>,
     #[cfg(feature = "http-client")]
     http_redirection_limit: usize,
     #[cfg(feature = "http-client")]
     with_http_default_service_handler: bool,
+    parser: SparqlParser,
     inner: QueryEvaluator,
 }
 
-impl QueryOptions {
+impl SparqlEvaluator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Provides an IRI that could be used to resolve the operation relative IRIs.
+    ///
+    /// ```
+    /// use oxigraph::model::*;
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    ///
+    /// if let QueryResults::Solutions(mut solutions) = SparqlEvaluator::new()
+    ///     .with_base_iri("http://example.com/")?
+    ///     .parse_query("SELECT (<> AS ?r) WHERE {}")?
+    ///     .on_store(&Store::new()?)
+    ///     .execute()?
+    /// {
+    ///     assert_eq!(
+    ///         solutions.next().unwrap()?.get("r"),
+    ///         Some(&NamedNode::new("http://example.com/")?.into())
+    ///     );
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
+    #[inline]
+    pub fn with_base_iri(mut self, base_iri: impl Into<String>) -> Result<Self, IriParseError> {
+        self.parser = self.parser.with_base_iri(base_iri)?;
+        Ok(self)
+    }
+
+    /// Set a default IRI prefix used during parsing.
+    ///
+    /// ```
+    /// use oxigraph::model::*;
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    ///
+    /// if let QueryResults::Solutions(mut solutions) = SparqlEvaluator::new()
+    ///     .with_prefix("ex", "http://example.com/")?
+    ///     .parse_query("SELECT (ex: AS ?r) WHERE {}")?
+    ///     .on_store(&Store::new()?)
+    ///     .execute()?
+    /// {
+    ///     assert_eq!(
+    ///         solutions.next().unwrap()?.get("r"),
+    ///         Some(&NamedNode::new("http://example.com/")?.into())
+    ///     );
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
+    #[inline]
+    pub fn with_prefix(
+        mut self,
+        prefix_name: impl Into<String>,
+        prefix_iri: impl Into<String>,
+    ) -> Result<Self, IriParseError> {
+        self.parser = self.parser.with_prefix(prefix_name, prefix_iri)?;
+        Ok(self)
+    }
+
     /// Use a given [`ServiceHandler`] to execute [SPARQL 1.1 Federated Query](https://www.w3.org/TR/sparql11-federated-query/) SERVICE calls.
     ///
     /// See [`ServiceHandler`] for an example.
     #[inline]
-    #[must_use]
     pub fn with_service_handler(
         mut self,
         service_name: impl Into<NamedNode>,
@@ -103,7 +155,6 @@ impl QueryOptions {
     ///
     /// See [`DefaultServiceHandler`] for an example.
     #[inline]
-    #[must_use]
     pub fn with_default_service_handler(
         mut self,
         handler: impl DefaultServiceHandler + 'static,
@@ -121,7 +172,6 @@ impl QueryOptions {
     /// Disables the default `SERVICE` call implementation that does HTTP requests to remote endpoints.
     #[cfg(feature = "http-client")]
     #[inline]
-    #[must_use]
     pub fn without_default_http_service_handler(mut self) -> Self {
         self.with_http_default_service_handler = false;
         self
@@ -130,7 +180,6 @@ impl QueryOptions {
     /// Disables the `SERVICE` calls
     #[cfg(feature = "http-client")]
     #[inline]
-    #[must_use]
     #[deprecated(
         note = "Use `without_default_http_service_handler` instead",
         since = "0.5.0"
@@ -142,7 +191,6 @@ impl QueryOptions {
     /// Sets a timeout for HTTP requests done during SPARQL evaluation.
     #[cfg(feature = "http-client")]
     #[inline]
-    #[must_use]
     pub fn with_http_timeout(mut self, timeout: Duration) -> Self {
         self.http_timeout = Some(timeout);
         self
@@ -153,9 +201,49 @@ impl QueryOptions {
     /// By default, this value is `0`.
     #[cfg(feature = "http-client")]
     #[inline]
-    #[must_use]
     pub fn with_http_redirection_limit(mut self, redirection_limit: usize) -> Self {
         self.http_redirection_limit = redirection_limit;
+        self
+    }
+
+    /// Adds a custom SPARQL evaluation function.
+    ///
+    /// Example with a function serializing terms to N-Triples:
+    /// ```
+    /// use oxigraph::model::*;
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    ///
+    /// if let QueryResults::Solutions(mut solutions) = SparqlEvaluator::new()
+    ///     .with_custom_function(
+    ///         NamedNode::new("http://www.w3.org/ns/formats/N-Triples")?,
+    ///         |args| args.get(0).map(|t| Literal::from(t.to_string()).into()),
+    ///     )
+    ///     .parse_query("SELECT (<http://www.w3.org/ns/formats/N-Triples>(1) AS ?nt) WHERE {}")?
+    ///     .on_store(&Store::new()?)
+    ///     .execute()?
+    /// {
+    ///     assert_eq!(
+    ///         solutions.next().unwrap()?.get("nt"),
+    ///         Some(&Literal::from("\"1\"^^<http://www.w3.org/2001/XMLSchema#integer>").into())
+    ///     );
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
+    #[inline]
+    pub fn with_custom_function(
+        mut self,
+        name: NamedNode,
+        evaluator: impl Fn(&[Term]) -> Option<Term> + Send + Sync + 'static,
+    ) -> Self {
+        self.inner = self.inner.with_custom_function(name, evaluator);
+        self
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn without_optimizations(mut self) -> Self {
+        self.inner = self.inner.without_optimizations();
         self
     }
 
@@ -173,51 +261,130 @@ impl QueryOptions {
         self.inner
     }
 
-    /// Adds a custom SPARQL evaluation function.
+    /// Parse a query and returns a [`PreparedSparqlQuery`] for the current evaluator.
     ///
-    /// Example with a function serializing terms to N-Triples:
+    /// Usage example:
     /// ```
     /// use oxigraph::model::*;
-    /// use oxigraph::sparql::{QueryOptions, QueryResults};
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
     /// use oxigraph::store::Store;
     ///
     /// let store = Store::new()?;
+    /// let ex = NamedNodeRef::new("http://example.com")?;
+    /// store.insert(QuadRef::new(ex, ex, ex, GraphNameRef::DefaultGraph))?;
     ///
-    /// if let QueryResults::Solutions(mut solutions) = store.query_opt(
-    ///     "SELECT (<http://www.w3.org/ns/formats/N-Triples>(1) AS ?nt) WHERE {}",
-    ///     QueryOptions::default().with_custom_function(
-    ///         NamedNode::new("http://www.w3.org/ns/formats/N-Triples")?,
-    ///         |args| args.get(0).map(|t| Literal::from(t.to_string()).into()),
-    ///     ),
-    /// )? {
+    /// let prepared_query = SparqlEvaluator::new().parse_query("SELECT ?s WHERE { ?s ?p ?o }")?;
+    ///
+    /// if let QueryResults::Solutions(mut solutions) = prepared_query.on_store(&store).execute()? {
     ///     assert_eq!(
-    ///         solutions.next().unwrap()?.get("nt"),
-    ///         Some(&Literal::from("\"1\"^^<http://www.w3.org/2001/XMLSchema#integer>").into())
+    ///         solutions.next().unwrap()?.get("s"),
+    ///         Some(&ex.into_owned().into())
     ///     );
     /// }
     /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
     /// ```
-    #[inline]
-    #[must_use]
-    pub fn with_custom_function(
+    pub fn parse_query(
         mut self,
-        name: NamedNode,
-        evaluator: impl Fn(&[Term]) -> Option<Term> + Send + Sync + 'static,
-    ) -> Self {
-        self.inner = self.inner.with_custom_function(name, evaluator);
-        self
+        query: &(impl AsRef<str> + ?Sized),
+    ) -> Result<PreparedSparqlQuery, SparqlSyntaxError> {
+        let query = take(&mut self.parser).parse_query(query.as_ref())?;
+        Ok(self.for_query(query))
     }
 
-    #[doc(hidden)]
-    #[inline]
-    #[must_use]
-    pub fn without_optimizations(mut self) -> Self {
-        self.inner = self.inner.without_optimizations();
-        self
+    /// Returns a [`PreparedSparqlQuery`] for the current evaluator and SPARQL query.
+    ///
+    /// Usage example:
+    /// ```
+    /// use oxigraph::model::*;
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    /// use spargebra::SparqlParser;
+    ///
+    /// let store = Store::new()?;
+    /// let ex = NamedNodeRef::new("http://example.com")?;
+    /// store.insert(QuadRef::new(ex, ex, ex, GraphNameRef::DefaultGraph))?;
+    ///
+    /// let query = SparqlParser::new().parse_query("SELECT ?s WHERE { ?s ?p ?o }")?;
+    ///
+    /// let prepared_query = SparqlEvaluator::new().for_query(query);
+    ///
+    /// if let QueryResults::Solutions(mut solutions) = prepared_query.on_store(&store).execute()? {
+    ///     assert_eq!(
+    ///         solutions.next().unwrap()?.get("s"),
+    ///         Some(&ex.into_owned().into())
+    ///     );
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
+    #[expect(deprecated)]
+    pub fn for_query(self, query: impl Into<Query>) -> PreparedSparqlQuery {
+        let query = query.into();
+        PreparedSparqlQuery {
+            dataset: query.dataset,
+            query: query.inner,
+            evaluator: self.into_evaluator(),
+            substitutions: HashMap::new(),
+        }
+    }
+
+    /// Parse an update and returns a [`PreparedSparqlUpdate`] for the current evaluator.
+    ///
+    /// Usage example:
+    /// ```
+    /// use oxigraph::sparql::SparqlEvaluator;
+    /// use oxigraph::store::Store;
+    ///
+    /// SparqlEvaluator::new()
+    ///     .parse_update(
+    ///         "INSERT DATA { <http://example.com> <http://example.com> <http://example.com> }",
+    ///     )?
+    ///     .on_store(&Store::new()?)
+    ///     .execute()?;
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn parse_update(
+        mut self,
+        query: &(impl AsRef<str> + ?Sized),
+    ) -> Result<PreparedSparqlUpdate, SparqlSyntaxError> {
+        let update = take(&mut self.parser).parse_update(query.as_ref())?;
+        Ok(self.for_update(update))
+    }
+
+    /// Returns a [`PreparedSparqlUpdate`] for the current evaluator and SPARQL update.
+    ///
+    /// Usage example:
+    /// ```
+    /// use oxigraph::sparql::SparqlEvaluator;
+    /// use oxigraph::store::Store;
+    /// use spargebra::SparqlParser;
+    ///
+    /// let update = SparqlParser::new().parse_update(
+    ///     "INSERT DATA { <http://example.com> <http://example.com> <http://example.com> }",
+    /// )?;
+    /// SparqlEvaluator::new()
+    ///     .for_update(update)
+    ///     .on_store(&Store::new()?)
+    ///     .execute()?;
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// ```
+    #[expect(deprecated)]
+    pub fn for_update(self, update: impl Into<Update>) -> PreparedSparqlUpdate {
+        #[cfg(feature = "http-client")]
+        let http_timeout = self.http_timeout;
+        #[cfg(feature = "http-client")]
+        let http_redirection_limit = self.http_redirection_limit;
+        PreparedSparqlUpdate::new(
+            self.into_evaluator(),
+            update.into(),
+            #[cfg(feature = "http-client")]
+            http_timeout,
+            #[cfg(feature = "http-client")]
+            http_redirection_limit,
+        )
     }
 }
 
-impl Default for QueryOptions {
+impl Default for SparqlEvaluator {
     fn default() -> Self {
         Self {
             #[cfg(feature = "http-client")]
@@ -226,20 +393,221 @@ impl Default for QueryOptions {
             http_redirection_limit: 0,
             #[cfg(feature = "http-client")]
             with_http_default_service_handler: true,
+            parser: SparqlParser::new(),
             inner: QueryEvaluator::new(),
         }
     }
 }
 
-/// Options for SPARQL update evaluation.
-#[derive(Clone, Default)]
-pub struct UpdateOptions {
-    query_options: QueryOptions,
+/// A prepared SPARQL query.
+///
+/// Allows customizing things like the evaluation dataset and substituting variables.
+///
+/// Usage example:
+/// ```
+/// use oxigraph::model::{Literal, Variable};
+/// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+/// use oxigraph::store::Store;
+///
+/// let prepared_query = SparqlEvaluator::new()
+///     .parse_query("SELECT ?v WHERE {}")?
+///     .substitute_variable(Variable::new("v")?, Literal::from(1));
+///
+/// if let QueryResults::Solutions(mut solutions) =
+///     prepared_query.on_store(&Store::new()?).execute()?
+/// {
+///     assert_eq!(
+///         solutions.next().unwrap()?.get("v"),
+///         Some(&Literal::from(1).into())
+///     );
+/// }
+/// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+/// ```
+#[derive(Clone)]
+#[must_use]
+pub struct PreparedSparqlQuery {
+    evaluator: QueryEvaluator,
+    query: spargebra::Query,
+    dataset: QueryDataset,
+    substitutions: HashMap<Variable, Term>,
 }
 
-impl From<QueryOptions> for UpdateOptions {
+impl PreparedSparqlQuery {
+    /// Substitute a variable with a given RDF term in the SPARQL query.
+    ///
+    /// Usage example:
+    /// ```
+    /// use oxigraph::model::{Literal, Variable};
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    ///
+    /// let prepared_query = SparqlEvaluator::new()
+    ///     .parse_query("SELECT ?v WHERE {}")?
+    ///     .substitute_variable(Variable::new("v")?, Literal::from(1));
+    ///
+    /// if let QueryResults::Solutions(mut solutions) =
+    ///     prepared_query.on_store(&Store::new()?).execute()?
+    /// {
+    ///     assert_eq!(
+    ///         solutions.next().unwrap()?.get("v"),
+    ///         Some(&Literal::from(1).into())
+    ///     );
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
     #[inline]
-    fn from(query_options: QueryOptions) -> Self {
-        Self { query_options }
+    pub fn substitute_variable(
+        mut self,
+        variable: impl Into<Variable>,
+        term: impl Into<Term>,
+    ) -> Self {
+        self.substitutions.insert(variable.into(), term.into());
+        self
+    }
+
+    /// Returns [the query dataset specification](https://www.w3.org/TR/sparql11-query/#specifyingDataset) of this prepared query.
+    #[inline]
+    pub fn dataset(&self) -> &QueryDataset {
+        &self.dataset
+    }
+
+    /// Returns [the query dataset specification](https://www.w3.org/TR/sparql11-query/#specifyingDataset) of this prepared query.
+    #[inline]
+    pub fn dataset_mut(&mut self) -> &mut QueryDataset {
+        &mut self.dataset
+    }
+
+    /// Bind the prepared query to the [`Store`] it should be evaluated on.
+    pub fn on_store(self, store: &Store) -> BoundPreparedSparqlQuery {
+        BoundPreparedSparqlQuery {
+            evaluator: self.evaluator,
+            query: self.query,
+            dataset: self.dataset,
+            substitutions: self.substitutions,
+            reader: store.storage().snapshot(),
+        }
+    }
+
+    /// Bind the prepared query to the [`Transaction`] it should be evaluated on.
+    pub fn on_transaction(self, transaction: &Transaction<'_>) -> BoundPreparedSparqlQuery {
+        BoundPreparedSparqlQuery {
+            evaluator: self.evaluator,
+            query: self.query,
+            dataset: self.dataset,
+            substitutions: self.substitutions,
+            reader: transaction.inner().reader(),
+        }
+    }
+}
+
+/// A prepared SPARQL query bound to a storage, ready to be executed.
+///
+/// Usage example:
+/// ```
+/// use oxigraph::model::{Literal, Variable};
+/// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+/// use oxigraph::store::Store;
+///
+/// let prepared_query = SparqlEvaluator::new()
+///     .parse_query("SELECT ?v WHERE {}")?
+///     .substitute_variable(Variable::new("v")?, Literal::from(1));
+///
+/// if let QueryResults::Solutions(mut solutions) =
+///     prepared_query.on_store(&Store::new()?).execute()?
+/// {
+///     assert_eq!(
+///         solutions.next().unwrap()?.get("v"),
+///         Some(&Literal::from(1).into())
+///     );
+/// }
+/// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+/// ```
+#[must_use]
+pub struct BoundPreparedSparqlQuery {
+    evaluator: QueryEvaluator,
+    query: spargebra::Query,
+    dataset: QueryDataset,
+    substitutions: HashMap<Variable, Term>,
+    reader: StorageReader,
+}
+
+impl BoundPreparedSparqlQuery {
+    /// Substitute a variable with a given RDF term in the SPARQL query.
+    ///
+    /// Usage example:
+    /// ```
+    /// use oxigraph::model::{Literal, Variable};
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    ///
+    /// let prepared_query = SparqlEvaluator::new()
+    ///     .parse_query("SELECT ?v WHERE {}")?
+    ///     .on_store(&Store::new()?)
+    ///     .substitute_variable(Variable::new("v")?, Literal::from(1));
+    ///
+    /// if let QueryResults::Solutions(mut solutions) = prepared_query.execute()? {
+    ///     assert_eq!(
+    ///         solutions.next().unwrap()?.get("v"),
+    ///         Some(&Literal::from(1).into())
+    ///     );
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
+    #[inline]
+    pub fn substitute_variable(
+        mut self,
+        variable: impl Into<Variable>,
+        term: impl Into<Term>,
+    ) -> Self {
+        self.substitutions.insert(variable.into(), term.into());
+        self
+    }
+
+    /// Evaluate the query against the given store.
+    pub fn execute(self) -> Result<QueryResults, EvaluationError> {
+        let dataset = DatasetView::new(self.reader, &self.dataset);
+        Ok(self
+            .evaluator
+            .execute_with_substituted_variables(dataset, &self.query, self.substitutions)?
+            .into())
+    }
+
+    /// Compute statistics during evaluation and fills them in the explanation tree.
+    pub fn compute_statistics(mut self) -> Self {
+        self.evaluator = self.evaluator.compute_statistics();
+        self
+    }
+
+    /// Executes a [SPARQL 1.1 query](https://www.w3.org/TR/sparql11-query/) with some options and
+    /// returns a query explanation with some statistics (if enabled with the [`compute_statistics`](Self::compute_statistics) option).
+    ///
+    /// <div class="warning">If you want to compute statistics, you need to exhaust the results iterator before having a look at them.</div>
+    ///
+    /// Usage example serializing the explanation with statistics in JSON:
+    /// ```
+    /// use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+    /// use oxigraph::store::Store;
+    ///
+    /// if let (Ok(QueryResults::Solutions(solutions)), explanation) = SparqlEvaluator::new()
+    ///     .parse_query("SELECT ?s WHERE { VALUES ?s { 1 2 3 } }")?
+    ///     .on_store(&Store::new()?)
+    ///     .explain()
+    /// {
+    ///     // We make sure to have read all the solutions
+    ///     for _ in solutions {}
+    ///     let mut buf = Vec::new();
+    ///     explanation.write_in_json(&mut buf)?;
+    /// }
+    /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
+    /// ```
+    pub fn explain(self) -> (Result<QueryResults, EvaluationError>, QueryExplanation) {
+        let dataset = DatasetView::new(self.reader, &self.dataset);
+        let (results, explanation) = self.evaluator.explain_with_substituted_variables(
+            dataset,
+            &self.query,
+            self.substitutions,
+        );
+        let results = results.map_err(Into::into).map(Into::into);
+        (results, explanation)
     }
 }

--- a/lib/oxigraph/src/sparql/model.rs
+++ b/lib/oxigraph/src/sparql/model.rs
@@ -186,7 +186,7 @@ pub struct QuerySolutionIter {
 }
 
 impl QuerySolutionIter {
-    /// Construct a new iterator of solution from an ordered list of solution variables and an iterator of solution tuples
+    /// Construct a new iterator of solutions from an ordered list of solution variables and an iterator of solution tuples
     /// (each tuple using the same ordering as the variable list such that tuple element 0 is the value for the variable 0...)
     pub fn new(
         variables: Arc<[Variable]>,

--- a/lib/spargeo/src/lib.rs
+++ b/lib/spargeo/src/lib.rs
@@ -7,14 +7,14 @@
 use geo::{Geometry, Relate};
 use geojson::GeoJson;
 use oxigraph::model::{Literal, NamedNodeRef, Term};
-use oxigraph::sparql::QueryOptions;
+use oxigraph::sparql::SparqlEvaluator;
 use spareval::QueryEvaluator;
 use std::str::FromStr;
 use wkt::TryFromWkt;
 
-/// Registers GeoSPARQL extension functions in the [`QueryOptions`]
-pub fn register_geosparql_functions(options: QueryOptions) -> QueryOptions {
-    options
+/// Registers GeoSPARQL extension functions in the [`SparqlEvaluator`]
+pub fn register_geosparql_functions(evaluator: SparqlEvaluator) -> SparqlEvaluator {
+    evaluator
         .with_custom_function(geosparql_functions::SF_EQUALS.into(), geof_sf_equals)
         .with_custom_function(geosparql_functions::SF_DISJOINT.into(), geof_sf_disjoint)
         .with_custom_function(


### PR DESCRIPTION
Allows injecting a bunch of options, both for SPARQL parsing and evaluation

Deprecations:
 - Query and Update types
  - (Store|Transaction).(query|update) methods