### PR TITLE
SPARQL: adds a CancellationToken to cancel processing gracefully

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -29,6 +29,13 @@ pub enum Command {
         /// This is equivalent as setting the union-default-graph option in all SPARQL queries
         #[arg(long)]
         union_default_graph: bool,
+        /// Timeout for request processing in seconds
+        ///
+        /// Currently only used for SPARQL queries
+        ///
+        /// Might be used to set up things like HTTP query timeout
+        #[arg(long)]
+        timeout_s: Option<u64>,
     },
     /// Start Oxigraph HTTP server in read-only mode
     ///
@@ -49,6 +56,13 @@ pub enum Command {
         /// This is equivalent as setting the union-default-graph option in all SPARQL queries
         #[arg(long)]
         union_default_graph: bool,
+        /// Timeout for request processing in seconds
+        ///
+        /// Currently only used for SPARQL queries
+        ///
+        /// Might be used to set up things like HTTP query timeout
+        #[arg(long)]
+        timeout_s: Option<u64>,
     },
     /// Create a database backup into a target directory
     ///

--- a/lib/spareval/src/error.rs
+++ b/lib/spareval/src/error.rs
@@ -31,6 +31,8 @@ pub enum QueryEvaluationError {
     #[cfg(feature = "sparql-12")]
     #[error("The SPARQL dataset returned a triple term that is not a valid RDF 1.2 term")]
     InvalidStorageTripleTerm,
+    #[error("The SPARQL operation has been cancelled")]
+    Cancelled,
     #[doc(hidden)]
     #[error(transparent)]
     Unexpected(Box<dyn Error + Send + Sync>),


### PR DESCRIPTION
It's a global boolean that allows to cancel a request. It is currently read on all RocksDB operations, it might mean some stalling on e.g. sorts or slow SERVICE calls.

Adds an option to the HTTP server to use the token for timeouts