### PR TITLE
oxttl: Add support for digits in language tag variant

### DIFF
--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -582,8 +582,11 @@ impl N3Lexer {
     ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
         // [39] 	LANG_DIR 	::= 	'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?
         let mut is_last_block_empty = true;
+        let mut are_digits_allowed = false;
         for (i, c) in data[1..].iter().enumerate() {
-            if c.is_ascii_alphabetic() {
+            if (are_digits_allowed && c.is_ascii_alphanumeric())
+                || (!are_digits_allowed && c.is_ascii_alphabetic())
+            {
                 is_last_block_empty = false;
             } else if i == 0 {
                 return Some((
@@ -610,6 +613,7 @@ impl N3Lexer {
                 ));
             } else if *c == b'-' {
                 is_last_block_empty = true;
+                are_digits_allowed = true
             } else {
                 return Some((i + 1, self.parse_lang_tag(&data[1..=i], None, 1..i)));
             }

--- a/testsuite/serd-tests/good/test-lang.nt
+++ b/testsuite/serd-tests/good/test-lang.nt
@@ -1,4 +1,5 @@
 <http://example.org/test-lang#thing> <http://example.org/test-lang#greeting> "Hello"@en .
 <http://example.org/test-lang#thing> <http://example.org/test-lang#greeting> "Howdy"@en-us .
 <http://example.org/test-lang#thing> <http://example.org/test-lang#greeting> "Bonjour"@fr .
+<http://example.org/test-lang#thing> <http://example.org/test-lang#greeting> "Hola"@es-419 .
 <http://example.org/test-lang#thing> <http://example.org/test-lang#greeting> "Guten Tag"@de-latn-de .

--- a/testsuite/serd-tests/good/test-lang.ttl
+++ b/testsuite/serd-tests/good/test-lang.ttl
@@ -3,4 +3,5 @@
 :thing :greeting "Hello"@en ;
        :greeting "Howdy"@en-us ;
        :greeting "Bonjour"@fr ;
+       :greeting "Hola"@es-419 ;
        :greeting "Guten Tag"@de-latn-de .


### PR DESCRIPTION
This is allowed both by RFC5646 (referenced as BCP47 in https://www.w3.org/TR/turtle/) and the comment at the top of recognize_lang_tag()