### PR TITLE
Generalize the Storage interface as an UpdatableDataset trait

### DIFF
--- a/js/src/store.rs
+++ b/js/src/store.rs
@@ -411,7 +411,7 @@ impl JsStore {
             parser = parser.lenient();
         }
         if no_transaction {
-            let mut loader = self.store.bulk_loader();
+            let mut loader = self.store.bulk_loader().map_err(JsError::from)?;
             loader
                 .load_from_slice(parser, data.as_bytes())
                 .map_err(JsError::from)?;

--- a/lib/oxigraph/benches/store.rs
+++ b/lib/oxigraph/benches/store.rs
@@ -137,7 +137,7 @@ fn do_load(store: &Store, data: &[u8]) {
 }
 
 fn do_bulk_load(store: &Store, data: &[u8]) {
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader().unwrap();
     loader
         .load_from_slice(RdfParser::from_format(RdfFormat::NTriples).lenient(), data)
         .unwrap();

--- a/lib/oxigraph/src/sparql/mod.rs
+++ b/lib/oxigraph/src/sparql/mod.rs
@@ -19,6 +19,7 @@ pub use crate::sparql::error::UpdateEvaluationError;
 use crate::sparql::http::HttpServiceHandler;
 pub use crate::sparql::update::{BoundPreparedSparqlUpdate, PreparedSparqlUpdate};
 use crate::storage::StorageReader;
+use crate::storage::updatable_dataset::{ReadWriteTransaction, UpdatableDataset};
 use crate::store::{Store, Transaction};
 use oxrdf::IriParseError;
 pub use oxrdf::{Variable, VariableNameParseError};

--- a/lib/oxigraph/src/sparql/update.rs
+++ b/lib/oxigraph/src/sparql/update.rs
@@ -8,6 +8,9 @@ use crate::sparql::dataset::DatasetView;
 use crate::sparql::error::UpdateEvaluationError;
 #[cfg(feature = "http-client")]
 use crate::sparql::http::Client;
+use crate::storage::updatable_dataset::{
+    ReadWriteTransaction, Reader, UpdatableDataset, WriteOnlyTransaction,
+};
 use crate::storage::{Storage, StorageError, StorageReadableTransaction, StorageTransaction};
 use crate::store::{Store, Transaction};
 use oxiri::Iri;
@@ -619,15 +622,15 @@ impl WriteOnlyUpdateEvaluator<'_, '_> {
                 "Not possible to clear a named graph using a write-only transaction".into(),
             )),
             GraphTarget::DefaultGraph => {
-                self.transaction.clear_default_graph();
+                self.transaction.clear_default_graph()?;
                 Ok(())
             }
             GraphTarget::NamedGraphs => {
-                self.transaction.clear_all_named_graphs();
+                self.transaction.clear_all_named_graphs()?;
                 Ok(())
             }
             GraphTarget::AllGraphs => {
-                self.transaction.clear_all_graphs();
+                self.transaction.clear_all_graphs()?;
                 Ok(())
             }
         }
@@ -643,15 +646,15 @@ impl WriteOnlyUpdateEvaluator<'_, '_> {
                 "Not possible to drop a named graph using a write-only transaction".into(),
             )),
             GraphTarget::DefaultGraph => {
-                self.transaction.clear_default_graph();
+                self.transaction.clear_default_graph()?;
                 Ok(())
             }
             GraphTarget::NamedGraphs => {
-                self.transaction.remove_all_named_graphs();
+                self.transaction.remove_all_named_graphs()?;
                 Ok(())
             }
             GraphTarget::AllGraphs => {
-                self.transaction.clear();
+                self.transaction.clear()?;
                 Ok(())
             }
         }

--- a/lib/oxigraph/src/storage/memory.rs
+++ b/lib/oxigraph/src/storage/memory.rs
@@ -625,7 +625,7 @@ impl WriteOnlyTransaction<'_> for MemoryStorageTransaction<'_> {
         Ok(())
     }
 
-        #[expect(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn clear_all_graphs(&mut self) -> Result<(), StorageError> {
         self.storage.content.quad_set.iter().for_each(|node| {
             if node.range.lock().unwrap().remove(self.transaction_id) {

--- a/lib/oxigraph/src/storage/mod.rs
+++ b/lib/oxigraph/src/storage/mod.rs
@@ -12,7 +12,6 @@ use crate::storage::rocksdb::{
     RocksDbStorageTransaction,
 };
 use oxrdf::Quad;
-#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
 use std::path::Path;
 #[cfg(not(target_family = "wasm"))]
 use std::{io, thread};

--- a/lib/oxigraph/src/storage/rocksdb.rs
+++ b/lib/oxigraph/src/storage/rocksdb.rs
@@ -1089,7 +1089,7 @@ impl WriteOnlyTransaction<'_> for RocksDbStorageTransaction<'_> {
     }
 
     fn clear_graph(&mut self, graph_name: GraphNameRef<'_>) -> Result<(), StorageError> {
-        if graph_name == GraphName::DefaultGraph.as_ref() {
+        if graph_name == GraphNameRef::DefaultGraph {
             self.clear_default_graph()
         } else {
             let prefix = encode_term(&graph_name.into());

--- a/lib/oxigraph/src/storage/updatable_dataset.rs
+++ b/lib/oxigraph/src/storage/updatable_dataset.rs
@@ -23,11 +23,20 @@ pub trait UpdatableDataset<'a> {
     fn snapshot(&self) -> Self::Reader<'static>;
     fn start_transaction(&self) -> Result<Self::WriteOnlyTransaction<'_>, Self::Error>;
     fn start_readable_transaction(&self) -> Result<Self::ReadWriteTransaction<'_>, Self::Error>;
-    #[cfg_attr(any(target_family = "wasm", not(feature = "rocksdb")), expect(dead_code))]
+    #[cfg_attr(
+        any(target_family = "wasm", not(feature = "rocksdb")),
+        expect(dead_code)
+    )]
     fn flush(&self) -> Result<(), Self::Error>;
-    #[cfg_attr(any(target_family = "wasm", not(feature = "rocksdb")), expect(dead_code))]
+    #[cfg_attr(
+        any(target_family = "wasm", not(feature = "rocksdb")),
+        expect(dead_code)
+    )]
     fn compact(&self) -> Result<(), Self::Error>;
-    #[cfg_attr(any(target_family = "wasm", not(feature = "rocksdb")), expect(dead_code))]
+    #[cfg_attr(
+        any(target_family = "wasm", not(feature = "rocksdb")),
+        expect(dead_code)
+    )]
     fn backup(&self, target_directory: &Path) -> Result<(), Self::Error>;
     fn bulk_loader(&self) -> Result<Self::BulkLoader<'_>, Self::Error>;
 }

--- a/lib/oxigraph/src/storage/updatable_dataset.rs
+++ b/lib/oxigraph/src/storage/updatable_dataset.rs
@@ -1,0 +1,91 @@
+use crate::model::{GraphNameRef, NamedOrBlankNodeRef, QuadRef};
+use crate::storage::numeric_encoder::{EncodedQuad, EncodedTerm, StrHash};
+use oxrdf::Quad;
+use std::error::Error;
+use std::path::Path;
+
+pub trait UpdatableDataset<'a> {
+    type Error: Error;
+
+    type Reader<'reader>: Reader<'reader, Error = Self::Error>
+    where
+        Self: 'reader;
+    type WriteOnlyTransaction<'transaction>: WriteOnlyTransaction<'transaction, Error = Self::Error>
+    where
+        Self: 'transaction;
+    type ReadWriteTransaction<'transaction>: ReadWriteTransaction<'transaction, Error = Self::Error>
+    where
+        Self: 'transaction;
+    type BulkLoader<'loader>: BulkLoader<'loader, Error = Self::Error>
+    where
+        Self: 'loader;
+
+    fn snapshot(&self) -> Self::Reader<'static>;
+    fn start_transaction(&self) -> Result<Self::WriteOnlyTransaction<'_>, Self::Error>;
+    fn start_readable_transaction(&self) -> Result<Self::ReadWriteTransaction<'_>, Self::Error>;
+    fn flush(&self) -> Result<(), Self::Error>;
+    fn compact(&self) -> Result<(), Self::Error>;
+    fn backup(&self, target_directory: &Path) -> Result<(), Self::Error>;
+    fn bulk_loader(&self) -> Result<Self::BulkLoader<'_>, Self::Error>;
+}
+
+pub trait Reader<'a> {
+    type Error: Error;
+    type TermIterator<'iter>: Iterator<Item = Result<EncodedTerm, Self::Error>> + 'iter
+    where
+        Self: 'iter;
+    type QuadIterator<'iter>: Iterator<Item = Result<EncodedQuad, Self::Error>> + 'iter
+    where
+        Self: 'iter;
+
+    fn len(&self) -> Result<usize, Self::Error>;
+    fn is_empty(&self) -> Result<bool, Self::Error>;
+    fn contains(&self, quad: &EncodedQuad) -> Result<bool, Self::Error>;
+    fn quads_for_pattern(
+        &self,
+        subject: Option<&EncodedTerm>,
+        predicate: Option<&EncodedTerm>,
+        object: Option<&EncodedTerm>,
+        graph_name: Option<&EncodedTerm>,
+    ) -> Self::QuadIterator<'a>;
+    fn named_graphs(&self) -> Self::TermIterator<'a>;
+    fn contains_named_graph(&self, graph_name: &EncodedTerm) -> Result<bool, Self::Error>;
+    fn contains_str(&self, key: &StrHash) -> Result<bool, Self::Error>;
+    /// Validate that all the storage invariants held in the data
+    fn validate(&self) -> Result<(), Self::Error>;
+}
+
+pub trait WriteOnlyTransaction<'a> {
+    type Error: Error;
+    fn insert(&mut self, quad: QuadRef<'_>);
+    fn insert_named_graph(&mut self, graph_name: NamedOrBlankNodeRef<'_>);
+    fn remove(&mut self, quad: QuadRef<'_>);
+    fn clear_default_graph(&mut self) -> Result<(), Self::Error> {
+        self.clear_graph(GraphNameRef::DefaultGraph)
+    }
+    fn clear_graph(&mut self, graph_name: GraphNameRef<'_>) -> Result<(), Self::Error>;
+    fn clear_all_graphs(&mut self) -> Result<(), Self::Error>;
+    fn clear_all_named_graphs(&mut self) -> Result<(), Self::Error>;
+    fn remove_all_named_graphs(&mut self) -> Result<(), Self::Error>;
+    fn clear(&mut self) -> Result<(), Self::Error>;
+    fn commit(self) -> Result<(), Self::Error>;
+}
+pub trait ReadWriteTransaction<'a>: WriteOnlyTransaction<'a> {
+    type Reader<'reader>: Reader<'reader, Error = Self::Error>
+    where
+        Self: 'reader;
+
+    fn reader(&self) -> Self::Reader<'_>;
+    fn remove_named_graph(
+        &mut self,
+        graph_name: NamedOrBlankNodeRef<'_>,
+    ) -> Result<(), Self::Error>;
+}
+pub trait BulkLoader<'a> {
+    type Error: Error;
+
+    fn on_progress(self, callback: impl Fn(u64) + Send + Sync + 'static) -> Self;
+    fn without_atomicity(self) -> Self;
+    fn load_batch(&mut self, quads: Vec<Quad>, max_num_threads: usize) -> Result<(), Self::Error>;
+    fn commit(self) -> Result<(), Self::Error>;
+}

--- a/lib/oxigraph/src/storage/updatable_dataset.rs
+++ b/lib/oxigraph/src/storage/updatable_dataset.rs
@@ -23,8 +23,11 @@ pub trait UpdatableDataset<'a> {
     fn snapshot(&self) -> Self::Reader<'static>;
     fn start_transaction(&self) -> Result<Self::WriteOnlyTransaction<'_>, Self::Error>;
     fn start_readable_transaction(&self) -> Result<Self::ReadWriteTransaction<'_>, Self::Error>;
+    #[cfg_attr(any(target_family = "wasm", not(feature = "rocksdb")), expect(dead_code))]
     fn flush(&self) -> Result<(), Self::Error>;
+    #[cfg_attr(any(target_family = "wasm", not(feature = "rocksdb")), expect(dead_code))]
     fn compact(&self) -> Result<(), Self::Error>;
+    #[cfg_attr(any(target_family = "wasm", not(feature = "rocksdb")), expect(dead_code))]
     fn backup(&self, target_directory: &Path) -> Result<(), Self::Error>;
     fn bulk_loader(&self) -> Result<Self::BulkLoader<'_>, Self::Error>;
 }

--- a/lib/oxigraph/tests/store.rs
+++ b/lib/oxigraph/tests/store.rs
@@ -152,7 +152,7 @@ fn test_load_graph_on_disk() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_bulk_load_graph() -> Result<(), Box<dyn Error>> {
     let store = Store::new()?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_from_slice(RdfFormat::Turtle, DATA.as_bytes())?;
     loader.commit()?;
     for q in quads(GraphNameRef::DefaultGraph) {
@@ -167,7 +167,7 @@ fn test_bulk_load_graph() -> Result<(), Box<dyn Error>> {
 fn test_bulk_load_graph_on_disk() -> Result<(), Box<dyn Error>> {
     let dir = TempDir::new()?;
     let store = Store::open(&dir)?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_from_slice(RdfFormat::Turtle, DATA.as_bytes())?;
     loader.commit()?;
     for q in quads(GraphNameRef::DefaultGraph) {
@@ -180,7 +180,7 @@ fn test_bulk_load_graph_on_disk() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_bulk_load_graph_lenient() -> Result<(), Box<dyn Error>> {
     let store = Store::new()?;
-    let mut loader = store.bulk_loader().on_parse_error(|_| Ok(()));
+    let mut loader = store.bulk_loader()?.on_parse_error(|_| Ok(()));
     loader.load_from_slice(
         RdfFormat::NTriples,
         b"<http://example.com> <http://example.com> <http://example.com##> .\n<http://example.com> <http://example.com> <http://example.com> .".as_slice(),
@@ -200,7 +200,7 @@ fn test_bulk_load_graph_lenient() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_bulk_load_empty() -> Result<(), Box<dyn Error>> {
     let store = Store::new()?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_quads(empty::<Quad>())?;
     loader.commit()?;
     assert!(store.is_empty()?);
@@ -216,7 +216,7 @@ fn test_bulk_load_rollback() -> Result<(), Box<dyn Error>> {
     let before_files = read_dir(&dir)?
         .map(|e| e.map(|e| e.path()))
         .collect::<Result<Vec<_>, _>>()?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_from_slice(RdfFormat::Turtle, DATA.as_bytes())?;
     drop(loader);
     store.validate()?;
@@ -246,7 +246,7 @@ fn test_load_dataset() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_bulk_load_dataset() -> Result<(), Box<dyn Error>> {
     let store = Store::new()?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_from_slice(RdfFormat::TriG, GRAPH_DATA.as_bytes())?;
     loader.commit()?;
     let graph_name =
@@ -355,7 +355,7 @@ fn test_bulk_load_on_existing_delete_overrides_the_delete() -> Result<(), Box<dy
     );
     let store = Store::new()?;
     store.remove(quad)?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_quads([quad.into_owned()])?;
     loader.commit()?;
     assert_eq!(store.len()?, 1);
@@ -374,7 +374,7 @@ fn test_bulk_load_on_existing_delete_overrides_the_delete_on_disk() -> Result<()
     let dir = TempDir::new()?;
     let store = Store::open(&dir)?;
     store.remove(quad)?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_quads([quad.into_owned()])?;
     loader.commit()?;
     assert_eq!(store.len()?, 1);
@@ -399,7 +399,7 @@ fn test_bad_stt_open() -> Result<(), Box<dyn Error>> {
     let dir = TempDir::new()?;
     let store = Store::open(&dir)?;
     remove_dir_all(&dir)?;
-    let mut loader = store.bulk_loader();
+    let mut loader = store.bulk_loader()?;
     loader.load_quads(once(Quad::new(
         NamedNode::new_unchecked("http://example.com/s"),
         NamedNode::new_unchecked("http://example.com/p"),


### PR DESCRIPTION
This implements the trait for both the Memory and the Rocksdb traits, and Storage simply delegates to either of them.

Future commits will extend the trait so it covers Store as well, which will allow new backends as alternative to the Store (eg. because they do not use EncodedTerm)