### PR TITLE
SPARQL: fail parsing on repeated variables in VALUES

### DIFF
--- a/lib/spargebra/src/parser.rs
+++ b/lib/spargebra/src/parser.rs
@@ -1475,10 +1475,12 @@ parser! {
         rule InlineDataOneVar_value() -> Vec<Option<GroundTerm>> = t:DataBlockValue() _ { vec![t] }
 
         rule InlineDataFull() -> (Vec<Variable>, Vec<Vec<Option<GroundTerm>>>) = "(" _ vars:InlineDataFull_var()* _ ")" _ "{" _ vals:InlineDataFull_values()* "}" {?
-            if vals.iter().all(|vs| vs.len() == vars.len()) {
-                Ok((vars, vals))
-            } else {
+            if vars.iter().enumerate().any(|(i, vl)| vars[i+1..].contains(vl)) {
+                Err("Repeated variables are not allowed in VALUES clauses.")
+            } else if vals.iter().any(|vs| vs.len() != vars.len()) {
                 Err("The VALUES clause rows should have exactly the same number of values as there are variables. To set a value to undefined use UNDEF.")
+            } else {
+                Ok((vars, vals))
             }
         }
         rule InlineDataFull_var() -> Variable = v:Var() _ { v }

--- a/testsuite/oxigraph-tests/sparql/duplicated_values_var.rq
+++ b/testsuite/oxigraph-tests/sparql/duplicated_values_var.rq
@@ -1,0 +1,1 @@
+SELECT * WHERE { VALUES (?a ?a) { (1 1) } }

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -39,6 +39,7 @@
     :ask_union_error_right
     :ask_join_error_left
     :ask_join_error_right
+    :duplicated_values_var
     ) .
 
 :small_unicode_escape_with_multibytes_char rdf:type mf:NegativeSyntaxTest ;
@@ -191,3 +192,7 @@
     mf:name "ASK query with a join where left arg is empty and right arg is an error" ;
     mf:action [ qt:query <ask_join_error_right.rq> ] ;
     mf:result  <false.srx> .
+
+:duplicated_values_var rdf:type mf:NegativeSyntaxTest ;
+    mf:name "Duplicated variable in a VALUES clause" ;
+    mf:action <duplicated_values_var.rq> .


### PR DESCRIPTION
Example `VALUES (?a ?a) { (1 1) }`

See https://github.com/w3c/sparql-query/issues/293