### PR TITLE
SPARQL ORDER BY: compute ordering exception once per row

### DIFF
--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -40,6 +40,7 @@
     :ask_join_error_left
     :ask_join_error_right
     :duplicated_values_var
+    :order_by_rand
     ) .
 
 :small_unicode_escape_with_multibytes_char rdf:type mf:NegativeSyntaxTest ;
@@ -196,3 +197,8 @@
 :duplicated_values_var rdf:type mf:NegativeSyntaxTest ;
     mf:name "Duplicated variable in a VALUES clause" ;
     mf:action <duplicated_values_var.rq> .
+
+:order_by_rand rdf:type mf:QueryEvaluationTest ;
+    mf:name "ORDER BY RAND() do not panic" ;
+    mf:action [ qt:query <order_by_rand.rq> ] ;
+    mf:result  <order_by_rand.srx> .

--- a/testsuite/oxigraph-tests/sparql/order_by_rand.rq
+++ b/testsuite/oxigraph-tests/sparql/order_by_rand.rq
@@ -1,0 +1,1 @@
+SELECT ?v WHERE { VALUES ?v { 1 1 1 1 1 1 } } ORDER BY RAND()

--- a/testsuite/oxigraph-tests/sparql/order_by_rand.srx
+++ b/testsuite/oxigraph-tests/sparql/order_by_rand.srx
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="v"/>
+  </head>
+  <results>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+  </results>
+</sparql>


### PR DESCRIPTION
Allows to have e.g. stable RAND() values and might provide a performance speed on complex ordering expression

Issue #1542