### PR TITLE
Python: do not publish version-specific builds for musl and cpython 3.8, 3.9 and 3.13t

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -105,12 +105,28 @@ jobs:
         with:
           python-version: "3.13"
       - uses: ./.github/actions/setup-rust
-      - run: sed 's/%arch%/${{ matrix.arch }}/g' .github/workflows/musllinux_build.sh | sed 's/%for_each_version%/${{ github.event_name == 'release' || ''}}/g' > .github/workflows/musllinux_build_script.sh
+      - run: sed 's/%arch%/${{ matrix.arch }}/g' .github/workflows/musllinux_build.sh > .github/workflows/musllinux_build_script.sh
       - run: docker run -v "$(pwd)":/workdir --platform linux/${{ matrix.arch }} quay.io/pypa/musllinux_1_2_${{ matrix.arch }} /bin/bash /workdir/.github/workflows/musllinux_build_script.sh
       - uses: actions/upload-artifact@v6
         with:
           name: pyoxigraph_${{ matrix.arch }}_linux_musl
           path: target/wheels/pyoxigraph-*.whl
+      - uses: actions/upload-artifact@v6
+        with:
+          name: oxigraph_pypi_${{ matrix.arch }}_linux_musl
+          path: target/wheels/oxigraph-*.whl
+      - run: unzip target/wheels/oxigraph-*.whl
+      - uses: actions/upload-artifact@v6
+        with:
+          name: oxigraph_${{ matrix.arch }}_linux_musl
+          path: oxigraph-*.data/scripts/oxigraph
+      - run: mv oxigraph-*.data/scripts/oxigraph oxigraph_${{ github.event.release.tag_name }}_${{ matrix.arch }}_linux_musl
+        if: github.event_name == 'release'
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            oxigraph_${{ github.event.release.tag_name }}_${{ matrix.arch }}_linux_musl
+        if: github.event_name == 'release'
       - run: uvx twine check target/wheels/*
 
   wheel_mac:

--- a/.github/workflows/manylinux_build.sh
+++ b/.github/workflows/manylinux_build.sh
@@ -10,7 +10,7 @@ uv run --locked --only-dev python generate_stubs.py pyoxigraph pyoxigraph.pyi --
 rm -rf ../target/wheels
 uv run --locked --only-dev maturin build --release --features abi3 --compatibility manylinux_2_28
 if [ %for_each_version% ]; then
-  for VERSION in 8 9 10 11 12 13 13t 14 14t; do
+  for VERSION in 10 11 12 13 14 14t; do
     uv run --locked --only-dev maturin build --release --interpreter "python3.$VERSION" --compatibility manylinux_2_28
   done
   uv run --locked --only-dev maturin build --release --interpreter "pypy3.11" --compatibility manylinux_2_28

--- a/.github/workflows/musllinux_build.sh
+++ b/.github/workflows/musllinux_build.sh
@@ -9,8 +9,5 @@ uv run --locked --only-dev maturin develop --release --features abi3
 uv run --locked --only-dev python generate_stubs.py pyoxigraph pyoxigraph.pyi --ruff
 rm -rf ../target/wheels
 uv run --locked --only-dev maturin build --release --features abi3 --compatibility musllinux_1_2
-if [ %for_each_version% ]; then
-  for VERSION in 8 9 10 11 12 13 13t 14 14t; do
-    uv run --locked --only-dev maturin build --release --interpreter "python3.$VERSION" --compatibility musllinux_1_2
-  done
-fi
+cd ../cli
+uvx maturin build --release --no-default-features --features rustls-native,geosparql,rdf-12 --compatibility musllinux_1_2


### PR DESCRIPTION
Not really used or supported targets (all of them but 13t are already covered by the abi3 builds)

Release also cli builds for musl