### PR TITLE
RocksDB: introduce oxrocksdb_writebatch_wi_get_into_buffer_cf

### DIFF
--- a/lib/oxigraph/src/storage/rocksdb_wrapper.rs
+++ b/lib/oxigraph/src/storage/rocksdb_wrapper.rs
@@ -477,29 +477,24 @@ impl Db {
         column_family: &ColumnFamily,
         key: &[u8],
     ) -> Result<Option<PinnableSlice>, StorageError> {
-        unsafe {
-            let slice = match &self.inner {
-                DbKind::ReadOnly(db) => ffi_result!(oxrocksdb_get_pinned_cf_v2(
-                    db.db,
-                    db.read_options,
-                    column_family.0,
-                    key.as_ptr().cast(),
-                    key.len(),
-                )),
-                DbKind::ReadWrite(db) => ffi_result!(oxrocksdb_get_pinned_cf_v2(
-                    db.db,
-                    db.read_options,
-                    column_family.0,
-                    key.as_ptr().cast(),
-                    key.len()
-                )),
-            }?;
-            Ok(if slice.is_null() {
-                None
-            } else {
-                Some(PinnableSlice(slice))
-            })
-        }
+        let (db, read_options) = match &self.inner {
+            DbKind::ReadOnly(db) => (db.db, db.read_options),
+            DbKind::ReadWrite(db) => (db.db, db.read_options),
+        };
+        let slice = unsafe {
+            ffi_result!(oxrocksdb_get_pinned_cf_v2(
+                db,
+                read_options,
+                column_family.0,
+                key.as_ptr().cast(),
+                key.len(),
+            ))
+        }?;
+        Ok(if slice.is_null() {
+            None
+        } else {
+            Some(PinnableSlice(slice))
+        })
     }
 
     pub fn contains_key(
@@ -507,40 +502,26 @@ impl Db {
         column_family: &ColumnFamily,
         key: &[u8],
     ) -> Result<bool, StorageError> {
+        let (db, read_options) = match &self.inner {
+            DbKind::ReadOnly(db) => (db.db, db.read_options),
+            DbKind::ReadWrite(db) => (db.db, db.read_options),
+        };
+        let mut value_len = 0;
+        let mut found = 0;
         unsafe {
-            let mut buffer = 0_u8;
-            let mut value_len = 0;
-            let mut found = 0;
-            match &self.inner {
-                DbKind::ReadOnly(db) => {
-                    ffi_result!(oxrocksdb_get_into_buffer_cf(
-                        db.db,
-                        db.read_options,
-                        column_family.0,
-                        key.as_ptr().cast(),
-                        key.len(),
-                        (&raw mut buffer).cast(),
-                        0,
-                        &raw mut value_len,
-                        &raw mut found
-                    ))?;
-                }
-                DbKind::ReadWrite(db) => {
-                    ffi_result!(oxrocksdb_get_into_buffer_cf(
-                        db.db,
-                        db.read_options,
-                        column_family.0,
-                        key.as_ptr().cast(),
-                        key.len(),
-                        (&raw mut buffer).cast(),
-                        0,
-                        &raw mut value_len,
-                        &raw mut found
-                    ))?;
-                }
-            }
-            Ok(found != 0)
-        }
+            ffi_result!(oxrocksdb_get_into_buffer_cf(
+                db,
+                read_options,
+                column_family.0,
+                key.as_ptr().cast(),
+                key.len(),
+                ptr::null_mut(),
+                0,
+                &raw mut value_len,
+                &raw mut found
+            ))
+        }?;
+        Ok(found != 0)
     }
 
     pub fn insert(
@@ -593,7 +574,7 @@ impl Db {
         };
         unsafe {
             rocksdb_compact_range_cf_opt(
-                db.db.cast(),
+                db.db,
                 column_family.0,
                 db.compaction_options,
                 ptr::null(),
@@ -749,55 +730,14 @@ impl Drop for Reader<'_> {
 }
 
 impl<'a> Reader<'a> {
-    pub fn get(
-        &self,
-        column_family: &ColumnFamily,
-        key: &[u8],
-    ) -> Result<Option<PinnableSlice>, StorageError> {
-        unsafe {
-            let slice = match &self.inner {
-                InnerReader::ReadOnly(inner) => ffi_result!(oxrocksdb_get_pinned_cf_v2(
-                    inner.db,
-                    self.options,
-                    column_family.0,
-                    key.as_ptr().cast(),
-                    key.len()
-                )),
-                InnerReader::ReadWrite(inner) => ffi_result!(oxrocksdb_get_pinned_cf_v2(
-                    inner.db.db,
-                    self.options,
-                    column_family.0,
-                    key.as_ptr().cast(),
-                    key.len()
-                )),
-                InnerReader::Transaction(inner) => {
-                    ffi_result!(oxrocksdb_writebatch_wi_get_pinned_from_batch_and_db_cf(
-                        inner.batch,
-                        inner.db.db,
-                        self.options,
-                        column_family.0,
-                        key.as_ptr().cast(),
-                        key.len()
-                    ))
-                }
-            }?;
-            Ok(if slice.is_null() {
-                None
-            } else {
-                Some(PinnableSlice(slice))
-            })
-        }
-    }
-
     pub fn contains_key(
         &self,
         column_family: &ColumnFamily,
         key: &[u8],
     ) -> Result<bool, StorageError> {
+        let mut value_len = 0;
+        let mut found = 0;
         unsafe {
-            let mut buffer = 0_u8;
-            let mut value_len = 0;
-            let mut found = 0;
             match &self.inner {
                 InnerReader::ReadOnly(inner) => {
                     ffi_result!(oxrocksdb_get_into_buffer_cf(
@@ -806,12 +746,11 @@ impl<'a> Reader<'a> {
                         column_family.0,
                         key.as_ptr().cast(),
                         key.len(),
-                        (&raw mut buffer).cast(),
+                        ptr::null_mut(),
                         0,
                         &raw mut value_len,
                         &raw mut found
-                    ))?;
-                    Ok(found != 0)
+                    ))
                 }
                 InnerReader::ReadWrite(inner) => {
                     ffi_result!(oxrocksdb_get_into_buffer_cf(
@@ -820,16 +759,29 @@ impl<'a> Reader<'a> {
                         column_family.0,
                         key.as_ptr().cast(),
                         key.len(),
-                        (&raw mut buffer).cast(),
+                        ptr::null_mut(),
                         0,
                         &raw mut value_len,
                         &raw mut found
-                    ))?;
-                    Ok(found != 0)
+                    ))
                 }
-                InnerReader::Transaction(_) => Ok(self.get(column_family, key)?.is_some()),
+                InnerReader::Transaction(inner) => {
+                    ffi_result!(oxrocksdb_writebatch_wi_get_into_buffer_cf(
+                        inner.batch,
+                        inner.db.db,
+                        self.options,
+                        column_family.0,
+                        key.as_ptr().cast(),
+                        key.len(),
+                        ptr::null_mut(),
+                        0,
+                        &raw mut value_len,
+                        &raw mut found
+                    ))
+                }
             }
-        }
+        }?;
+        Ok(found != 0)
     }
 
     #[expect(clippy::iter_not_returning_iterator)]

--- a/oxrocksdb-sys/api/c.cc
+++ b/oxrocksdb-sys/api/c.cc
@@ -151,24 +151,34 @@ oxrocksdb_slice_t oxrocksdb_iter_key_slice(const rocksdb_iterator_t* iter) {
   return oxrocksdb_slice_t{key.data(), key.size()};
 }
 
-oxrocksdb_pinnable_handle_t*
-oxrocksdb_writebatch_wi_get_pinned_from_batch_and_db_cf(
+unsigned char oxrocksdb_writebatch_wi_get_into_buffer_cf(
     rocksdb_writebatch_wi_t* wbwi, rocksdb_t* db,
     const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
-    size_t keylen, char** errptr) {
-  oxrocksdb_pinnable_handle_t* v = new (oxrocksdb_pinnable_handle_t);
-  Status s = wbwi->rep->GetFromBatchAndDB(
-      db->rep, options->rep, column_family->rep, Slice(key, keylen), &v->rep);
-  if (!s.ok()) {
-    delete (v);
+    size_t keylen, char* buffer, size_t buffer_size, size_t* vallen,
+    unsigned char* found, char** errptr) {
+  PinnableSlice pinnable_val;
+  Status s =
+      wbwi->rep->GetFromBatchAndDB(db->rep, options->rep, column_family->rep,
+                                   Slice(key, keylen), &pinnable_val);
+  if (s.ok()) {
+    *found = 1;
+    *vallen = pinnable_val.size();
+    if (buffer_size >= pinnable_val.size()) {
+      memcpy(buffer, pinnable_val.data(), pinnable_val.size());
+      return 1;
+    }
+    return 0;
+  } else {
+    *found = 0;
+    *vallen = 0;
     if (!s.IsNotFound()) {
       SaveError(errptr, s);
     }
-    return nullptr;
+    return 0;
   }
-  return v;
 }
+
 rocksdb_readoptions_t* oxrocksdb_readoptions_create_copy(
     rocksdb_readoptions_t* options) {
   return new rocksdb_readoptions_t(*options);

--- a/oxrocksdb-sys/api/c.h
+++ b/oxrocksdb-sys/api/c.h
@@ -37,8 +37,8 @@ oxrocksdb_get_pinned_cf_v2(rocksdb_t* db, const rocksdb_readoptions_t* options,
 extern ROCKSDB_LIBRARY_API const char* oxrocksdb_pinnable_handle_get_value(
     const oxrocksdb_pinnable_handle_t* handle, size_t* vallen);
 
-extern ROCKSDB_LIBRARY_API void
-oxrocksdb_pinnable_handle_destroy(oxrocksdb_pinnable_handle_t* handle);
+extern ROCKSDB_LIBRARY_API void oxrocksdb_pinnable_handle_destroy(
+    oxrocksdb_pinnable_handle_t* handle);
 
 extern ROCKSDB_LIBRARY_API unsigned char oxrocksdb_get_into_buffer_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
@@ -49,12 +49,13 @@ extern ROCKSDB_LIBRARY_API unsigned char oxrocksdb_get_into_buffer_cf(
 extern ROCKSDB_LIBRARY_API oxrocksdb_slice_t
 oxrocksdb_iter_key_slice(const rocksdb_iterator_t* iter);
 
-extern ROCKSDB_LIBRARY_API oxrocksdb_pinnable_handle_t*
-oxrocksdb_writebatch_wi_get_pinned_from_batch_and_db_cf(
+extern ROCKSDB_LIBRARY_API unsigned char
+oxrocksdb_writebatch_wi_get_into_buffer_cf(
     rocksdb_writebatch_wi_t* wbwi, rocksdb_t* db,
     const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
-    size_t keylen, char** errptr);
+    size_t keylen, char* buffer, size_t buffer_size, size_t* vallen,
+    unsigned char* found, char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_readoptions_t*
 oxrocksdb_readoptions_create_copy(rocksdb_readoptions_t*);

--- a/oxrocksdb-sys/build.rs
+++ b/oxrocksdb-sys/build.rs
@@ -236,7 +236,7 @@ fn main() {
 #[cfg(feature = "pkg-config")]
 fn main() {
     let library = pkg_config::Config::new()
-        .atleast_version("8.0.0")
+        .atleast_version("9.10.0")
         .probe("rocksdb")
         .unwrap();
     build_rocksdb_api(&library.include_paths);


### PR DESCRIPTION
Enables to simplify the code and avoid an allocation