### PR TITLE
Wire GeoSPARQL functions natively into spareval (PR 2/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,7 +1699,6 @@ dependencies = [
  "js-sys",
  "oxigraph",
  "oxrdfio",
- "spargeo",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1721,7 +1720,6 @@ dependencies = [
  "oxttl",
  "spareval",
  "spargebra",
- "spargeo",
  "sparopt",
  "time",
 ]
@@ -2059,7 +2057,6 @@ version = "0.5.7"
 dependencies = [
  "oxigraph",
  "pyo3",
- "spargeo",
 ]
 
 [[package]]
@@ -2591,6 +2588,7 @@ dependencies = [
  "sha2",
  "sparesults",
  "spargebra",
+ "spargeo",
  "sparopt",
  "thiserror 2.0.18",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ rdf-12 = ["oxigraph/rdf-12"]
 rocksdb-pkg-config = ["oxigraph/rocksdb-pkg-config"]
 rustls-native = ["oxigraph/http-client-rustls-native"]
 rustls-webpki = ["oxigraph/http-client-rustls-webpki"]
-geosparql = ["dep:spargeo"]
+geosparql = ["dep:spargeo", "oxigraph/geosparql"]
 
 [dependencies]
 anyhow.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -299,7 +299,7 @@ pub fn main() -> anyhow::Result<()> {
                 io::read_to_string(stdin().lock())?
             };
             let store = Store::open_read_only(location)?;
-            let mut evaluator = default_sparql_evaluator();
+            let mut evaluator = SparqlEvaluator::new();
             if let Some(base) = query_base {
                 evaluator = evaluator.with_base_iri(&base)?;
             }
@@ -451,7 +451,7 @@ pub fn main() -> anyhow::Result<()> {
                 io::read_to_string(stdin().lock())?
             };
             let store = Store::open(location)?;
-            let mut evaluator = default_sparql_evaluator();
+            let mut evaluator = SparqlEvaluator::new();
             if let Some(base) = update_base {
                 evaluator = evaluator.with_base_iri(&base)?;
             }
@@ -746,7 +746,7 @@ fn serve(
     union_default_graph: bool,
     timeout_s: Option<u64>,
 ) -> anyhow::Result<()> {
-    let sparql_evaluator = default_sparql_evaluator();
+    let sparql_evaluator = SparqlEvaluator::new();
     let timeout = timeout_s.map(Duration::from_secs);
     let mut server = if cors {
         Server::new(cors_middleware(move |request| {
@@ -1478,9 +1478,6 @@ fn evaluate_sparql_query(
     }
 }
 
-fn default_sparql_evaluator() -> SparqlEvaluator {
-    SparqlEvaluator::new()
-}
 
 fn configure_and_evaluate_sparql_update(
     store: &Store,
@@ -1528,7 +1525,7 @@ fn evaluate_sparql_update(
     named_graph_uris: Vec<String>,
     request: &Request<Body>,
 ) -> Result<Response<Body>, HttpError> {
-    let mut prepared = default_sparql_evaluator()
+    let mut prepared = SparqlEvaluator::new()
         .with_base_iri(base_url(request).as_str())
         .map_err(bad_request)?
         .parse_update(update)
@@ -3374,7 +3371,7 @@ mod tests {
             handle_request(
                 &mut request.map(Into::into),
                 self.store.clone(),
-                default_sparql_evaluator(),
+                SparqlEvaluator::new(),
                 false,
                 false,
                 None,
@@ -3386,7 +3383,7 @@ mod tests {
             handle_request(
                 &mut request.map(Into::into),
                 self.store.clone(),
-                default_sparql_evaluator(),
+                SparqlEvaluator::new(),
                 true,
                 false,
                 None,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,8 +22,6 @@ use oxigraph::store::{BulkLoader, LoaderError, Store};
 use oxiri::Iri;
 use rand::random;
 use rayon_core::ThreadPoolBuilder;
-#[cfg(feature = "geosparql")]
-use spargeo::GEOSPARQL_EXTENSION_FUNCTIONS;
 use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::HashMap;
@@ -1481,13 +1479,7 @@ fn evaluate_sparql_query(
 }
 
 fn default_sparql_evaluator() -> SparqlEvaluator {
-    #[cfg_attr(not(feature = "geosparql"), expect(unused_mut))]
-    let mut evaluator = SparqlEvaluator::new();
-    #[cfg(feature = "geosparql")]
-    for (name, implementation) in GEOSPARQL_EXTENSION_FUNCTIONS {
-        evaluator = evaluator.with_custom_function(name.into(), implementation)
-    }
-    evaluator
+    SparqlEvaluator::new()
 }
 
 fn configure_and_evaluate_sparql_update(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1478,7 +1478,6 @@ fn evaluate_sparql_query(
     }
 }
 
-
 fn configure_and_evaluate_sparql_update(
     store: &Store,
     args: HashMap<String, String>,

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -18,7 +18,7 @@ doc = false
 
 [features]
 default = ["geosparql", "rdf-12"]
-geosparql = ["dep:spargeo"]
+geosparql = ["oxigraph/geosparql"]
 rdf-12 = ["oxigraph/rdf-12"]
 
 [dependencies]
@@ -26,7 +26,6 @@ console_error_panic_hook.workspace = true
 js-sys.workspace = true
 oxigraph = { workspace = true, features = ["js"] }
 oxrdfio = { workspace = true, features = ["async-tokio"] }
-spargeo = { workspace = true, optional = true }
 tokio.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true

--- a/js/src/store.rs
+++ b/js/src/store.rs
@@ -7,8 +7,6 @@ use oxigraph::model::*;
 use oxigraph::sparql::results::{QueryResultsFormat, QueryResultsSerializer};
 use oxigraph::sparql::{QueryResults, SparqlEvaluator};
 use oxigraph::store::Store;
-#[cfg(feature = "geosparql")]
-use spargeo::GEOSPARQL_EXTENSION_FUNCTIONS;
 use wasm_bindgen::prelude::*;
 
 // We skip_typescript on specific wasm_bindgen macros and provide custom TypeScript types for parts of this module in order to have narrower types
@@ -215,10 +213,6 @@ impl JsStore {
         }
 
         let mut evaluator = SparqlEvaluator::new();
-        #[cfg(feature = "geosparql")]
-        for (name, implementation) in GEOSPARQL_EXTENSION_FUNCTIONS {
-            evaluator = evaluator.with_custom_function(name.into(), implementation)
-        }
         if let Some(base_iri) = base_iri {
             evaluator = evaluator.with_base_iri(base_iri).map_err(JsError::from)?;
         }
@@ -329,10 +323,6 @@ impl JsStore {
         }
 
         let mut evaluator = SparqlEvaluator::new();
-        #[cfg(feature = "geosparql")]
-        for (name, implementation) in GEOSPARQL_EXTENSION_FUNCTIONS {
-            evaluator = evaluator.with_custom_function(name.into(), implementation)
-        }
         if let Some(base_iri) = base_iri {
             evaluator = evaluator.with_base_iri(base_iri).map_err(JsError::from)?;
         }

--- a/lib/oxigraph/Cargo.toml
+++ b/lib/oxigraph/Cargo.toml
@@ -24,6 +24,7 @@ http-client-rustls-native = ["http-client", "oxhttp/rustls-ring-native"]
 rocksdb-pkg-config = ["oxrocksdb-sys/pkg-config"]
 rocksdb-debug = []
 rdf-12 = ["oxrdfio/rdf-12", "spareval/sparql-12"]
+geosparql = ["spareval/geosparql"]
 
 [dependencies]
 dashmap.workspace = true

--- a/lib/spareval/Cargo.toml
+++ b/lib/spareval/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 
 [features]
 default = []
+geosparql = ["dep:spargeo"]
 sparql-12 = ["sparopt/sparql-12", "sparesults/sparql-12"]
 sep-0002 = ["sparopt/sep-0002"]
 sep-0006 = ["sparopt/sep-0006"]
@@ -34,6 +35,7 @@ rustc-hash.workspace = true
 sha1.workspace = true
 sha2.workspace = true
 spargebra.workspace = true
+spargeo = { workspace = true, optional = true }
 sparopt.workspace = true
 sparesults.workspace = true
 thiserror.workspace = true

--- a/lib/spareval/README.md
+++ b/lib/spareval/README.md
@@ -41,6 +41,7 @@ if let QueryResults::Solutions(solutions) = results.unwrap() {
 - `sep-0002`: enables the [`SEP-0002`](https://github.com/w3c/sparql-dev/blob/main/SEP/SEP-0002/sep-0002.md) (`ADJUST` function and a lot of arithmetic on `xsd:date`, `xsd:time`, `xsd:yearMonthDuration` and `xsd:dayTimeDuration`).
 - `sep-0006`: enables the [`SEP-0006`](https://github.com/w3c/sparql-dev/blob/main/SEP/SEP-0006/sep-0006.md) (`LATERAL` keyword). 
 - `calendar-ext`: arithmetic on `xsd:gYear`, `xsd:gYearMonth`, `xsd:gMonth`, `xsd:gMonthDay` and `xsd:gDay`.
+- `geosparql`: pre-registers the [GeoSPARQL 1.1](https://docs.ogc.org/is/22-047r1/22-047r1.html) extension functions from the [`spargeo`](https://crates.io/crates/spargeo) crate so `QueryEvaluator::new()` evaluates `geof:` predicates without an explicit `with_custom_function` call per function.
 
 ## License
 

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -65,7 +65,7 @@ use std::{fmt, io};
 /// }
 /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
 /// ```
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct QueryEvaluator {
     service_handler: ServiceHandlerRegistry,
     custom_functions: CustomFunctionRegistry,
@@ -73,6 +73,29 @@ pub struct QueryEvaluator {
     without_optimizations: bool,
     run_stats: bool,
     cancellation_token: Option<CancellationToken>,
+}
+
+impl Default for QueryEvaluator {
+    fn default() -> Self {
+        Self {
+            service_handler: ServiceHandlerRegistry::default(),
+            custom_functions: default_custom_functions(),
+            custom_aggregate_functions: CustomAggregateFunctionRegistry::default(),
+            without_optimizations: false,
+            run_stats: false,
+            cancellation_token: None,
+        }
+    }
+}
+
+fn default_custom_functions() -> CustomFunctionRegistry {
+    #[cfg_attr(not(feature = "geosparql"), expect(unused_mut))]
+    let mut registry = CustomFunctionRegistry::default();
+    #[cfg(feature = "geosparql")]
+    for (name, implementation) in spargeo::GEOSPARQL_EXTENSION_FUNCTIONS {
+        registry.insert(name.into_owned(), Arc::new(implementation));
+    }
+    registry
 }
 
 impl QueryEvaluator {

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -22,14 +22,13 @@ doc = false
 default = ["geosparql", "rdf-12"]
 abi3 = ["pyo3/abi3-py38"]
 rocksdb-pkg-config = ["oxigraph/rocksdb-pkg-config"]
-geosparql = ["dep:spargeo"]
+geosparql = ["oxigraph/geosparql"]
 rdf-12 = ["oxigraph/rdf-12"]
 
 [dependencies]
 pyo3 = { workspace = true, features = [
   "extension-module",
 ] } # TODO: remove the feature in a few months
-spargeo = { workspace = true, optional = true }
 
 [target.'cfg(any(target_family = "windows", target_os = "macos", target_os = "ios"))'.dependencies]
 oxigraph = { workspace = true, default-features = true, features = [

--- a/python/src/sparql.rs
+++ b/python/src/sparql.rs
@@ -17,8 +17,6 @@ use pyo3::exceptions::{PyRuntimeError, PySyntaxError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyTuple;
-#[cfg(feature = "geosparql")]
-use spargeo::GEOSPARQL_EXTENSION_FUNCTIONS;
 use std::collections::HashMap;
 use std::error::Error;
 use std::ffi::OsStr;
@@ -85,10 +83,6 @@ pub fn sparql_evaluator_from_python(
     custom_aggregate_functions: Option<HashMap<PyNamedNode, Py<PyAny>>>,
 ) -> PyResult<SparqlEvaluator> {
     let mut evaluator = SparqlEvaluator::default();
-    #[cfg(feature = "geosparql")]
-    for (name, implementation) in GEOSPARQL_EXTENSION_FUNCTIONS {
-        evaluator = evaluator.with_custom_function(name.into(), implementation)
-    }
 
     if let Some(custom_functions) = custom_functions {
         for (name, function) in custom_functions {

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -23,9 +23,8 @@ oxiri.workspace = true
 oxjsonld.workspace = true
 oxttl.workspace = true
 spargebra = { workspace = true, features = ["standard-unicode-escaping"] }
-spargeo.workspace = true
 sparopt.workspace = true
-spareval.workspace = true
+spareval = { workspace = true, features = ["geosparql"] }
 time = { workspace = true, features = ["formatting"] }
 
 [dev-dependencies]

--- a/testsuite/src/sparql_evaluator.rs
+++ b/testsuite/src/sparql_evaluator.rs
@@ -20,7 +20,6 @@ use oxiri::Iri;
 use spareval::{DefaultServiceHandler, QueryEvaluationError, QueryEvaluator, QuerySolutionIter};
 use spargebra::algebra::GraphPattern;
 use spargebra::{Query, SparqlParser};
-use spargeo::GEOSPARQL_EXTENSION_FUNCTIONS;
 use sparopt::Optimizer;
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -179,11 +178,8 @@ fn evaluate_evaluation_test(test: &Test) -> Result<()> {
         .parse_query(&query.to_string())
         .with_context(|| format!("Failure to deserialize \"{query}\""))?;
 
-    let mut evaluator = QueryEvaluator::new()
+    let evaluator = QueryEvaluator::new()
         .with_default_service_handler(StaticServiceHandler::new(&test.service_data)?);
-    for (name, implementation) in GEOSPARQL_EXTENSION_FUNCTIONS {
-        evaluator = evaluator.with_custom_function(name.into(), implementation)
-    }
 
     // FROM and FROM NAMED support. We make sure the data is in the store
     if let Some(query_dataset) = query.dataset() {


### PR DESCRIPTION
Add a geosparql cargo feature to lib/spareval that pulls spargeo as an optional dependency and pre-populates QueryEvaluator's CustomFunctionRegistry with the 43 GEOSPARQL_EXTENSION_FUNCTIONS at construction time. Propagate the feature through lib/oxigraph so SparqlEvaluator::new() inherits the registered functions.

Drop the manual registration loops from cli/src/main.rs, python/src/sparql.rs, js/src/store.rs, and testsuite/src/sparql_evaluator.rs in favor of just enabling the feature. The oxigraph_geosparql_testsuite continues to exercise the same 43 functions, now via the auto-registered registry rather than the manual loop.

cli/src/service_description.rs keeps its direct dependency on spargeo because it iterates GEOSPARQL_EXTENSION_FUNCTIONS to build the SPARQL service description document, which is a list operation independent of evaluator registration.