### PR TITLE
sparopt: expose join/variable-elimination order via GraphPattern::join_order_variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+### Added
+- `sparopt`: `GraphPattern::join_order_variables`, exposing the join / variable-elimination order chosen by `Optimizer::optimize_graph_pattern` for consumption by external execution engines (e.g. worst-case-optimal join executors).
+
+
 # [0.5.7] - 2026-04-19
 
 ### Changed

--- a/lib/sparopt/src/algebra.rs
+++ b/lib/sparopt/src/algebra.rs
@@ -1112,6 +1112,38 @@ impl GraphPattern {
         }
     }
 
+    /// Returns the variables used by this pattern, in the order they are
+    /// first encountered during a left-to-right, depth-first walk of the
+    /// pattern tree (duplicates removed, keeping the first occurrence).
+    ///
+    /// For [`Join`](Self::Join) nodes specifically, `left` is always visited
+    /// before `right`. This means that after
+    /// [`Optimizer::optimize_graph_pattern`](crate::Optimizer::optimize_graph_pattern)
+    /// has run its greedy join-reordering pass, the nested (left-deep) `Join`
+    /// tree it produces will yield variables here in the same order the
+    /// optimizer chose to introduce them -- i.e. this doubles as a view onto
+    /// sparopt's join / variable-elimination order.
+    ///
+    /// This is intended for execution engines that drive their own join
+    /// algorithm (for example a worst-case-optimal / Leapfrog Triejoin
+    /// executor) and want to consume sparopt's structural join-ordering
+    /// decision as an initial seed or tie-breaker for their own
+    /// variable-elimination order, rather than recomputing it from scratch.
+    ///
+    /// Note this reflects the *structure* of the pattern tree as given; it
+    /// is only meaningful as "the optimizer's chosen order" when called on
+    /// the output of [`Optimizer::optimize_graph_pattern`](crate::Optimizer::optimize_graph_pattern).
+    pub fn join_order_variables(&self) -> Vec<Variable> {
+        let mut seen = HashSet::new();
+        let mut order = Vec::new();
+        self.lookup_used_variables(&mut |v| {
+            if seen.insert(v) {
+                order.push(v.clone());
+            }
+        });
+        order
+    }
+
     fn from_sparql_algebra(
         pattern: &AlGraphPattern,
         graph_name: Option<&NamedNodePattern>,
@@ -1695,5 +1727,81 @@ fn lookup_term_pattern_variables<'a>(
             callback(v);
         }
         lookup_term_pattern_variables(&t.object, callback);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn var(name: &str) -> Variable {
+        Variable::new(name.to_owned()).unwrap()
+    }
+
+    fn quad_pattern(subject: &str, predicate: &str, object: &str) -> GraphPattern {
+        GraphPattern::QuadPattern {
+            subject: GroundTermPattern::Variable(var(subject)),
+            predicate: NamedNodePattern::Variable(var(predicate)),
+            object: GroundTermPattern::Variable(var(object)),
+            graph_name: None,
+        }
+    }
+
+    #[test]
+    fn join_order_variables_matches_left_to_right_join_structure() {
+        // { ?s ?p1 ?o1 . ?s ?p2 ?o2 . ?o1 ?p3 ?o3 }
+        // built as a left-deep join tree, mirroring the shape `reorder_joins`
+        // produces: Join { left: Join { left: A, right: B }, right: C }.
+        let a = quad_pattern("s", "p1", "o1");
+        let b = quad_pattern("s", "p2", "o2");
+        let c = quad_pattern("o1", "p3", "o3");
+        let pattern = GraphPattern::Join {
+            left: Box::new(GraphPattern::Join {
+                left: Box::new(a),
+                right: Box::new(b),
+                algorithm: JoinAlgorithm::default(),
+            }),
+            right: Box::new(c),
+            algorithm: JoinAlgorithm::default(),
+        };
+
+        let order = pattern.join_order_variables();
+        assert_eq!(
+            order,
+            vec![
+                var("s"),
+                var("p1"),
+                var("o1"),
+                var("p2"),
+                var("o2"),
+                var("p3"),
+                var("o3"),
+            ]
+        );
+    }
+
+    #[test]
+    fn join_order_variables_deduplicates_keeping_first_occurrence() {
+        // ?s is shared between both sides of the join and must only appear once,
+        // at the position where it is first encountered (left side).
+        let left = quad_pattern("s", "p1", "o1");
+        let right = quad_pattern("s", "p2", "o2");
+        let pattern = GraphPattern::Join {
+            left: Box::new(left),
+            right: Box::new(right),
+            algorithm: JoinAlgorithm::default(),
+        };
+
+        let order = pattern.join_order_variables();
+        assert_eq!(
+            order,
+            vec![var("s"), var("p1"), var("o1"), var("p2"), var("o2")]
+        );
+    }
+
+    #[test]
+    fn join_order_variables_is_empty_for_variable_free_pattern() {
+        let pattern = GraphPattern::empty_singleton();
+        assert!(pattern.join_order_variables().is_empty());
     }
 }


### PR DESCRIPTION
## What

Adds a new public method, `GraphPattern::join_order_variables()`, to `sparopt::algebra::GraphPattern`. It returns the variables used by a pattern in left-to-right, depth-first order (deduplicated, keeping the first occurrence).

## Why

`Optimizer::optimize_graph_pattern` already performs join reordering (`reorder_joins`) based on structural/statistical heuristics, producing a left-deep nested `Join` tree. However, the resulting join order is only *implicit* in the shape of that tree — there's currently no public way to read it back out as an ordered list of variables.

Execution engines that implement their own join algorithm — for example worst-case-optimal join / Leapfrog Triejoin (LFTJ) executors, which need a variable-elimination order (VEO) — would like to use sparopt's structural join-ordering decision as an initial seed or tie-breaker for their own ordering, rather than ignoring it and recomputing an order from scratch. This method exposes exactly that.

Because `Join { left, right, .. }` nodes are always visited `left` before `right` in the existing `lookup_used_variables` traversal, calling `join_order_variables()` on the *output* of `Optimizer::optimize_graph_pattern` yields variables in the order the optimizer chose to introduce them.

## Implementation notes

- Purely additive: no existing public API, struct, or behavior is changed.
- Reuses the existing `lookup_used_variables` traversal internally (just wraps it with a `HashSet` for dedup while preserving first-occurrence order), so there's no risk of divergent traversal logic or maintenance burden from a second walk implementation.
- Added a `#[cfg(test)] mod tests` block in `algebra.rs` (previously the crate had no test infrastructure) covering:
  - left-to-right join order over a left-deep `Join` tree,
  - deduplication when a variable is shared across both sides of a join,
  - the empty/variable-free pattern case.
- Added a `CHANGELOG.md` entry under a new `[Unreleased]` section.

## Testing

```
cargo test -p sparopt --all-features   # 3 passed
cargo test -p sparopt                  # 3 passed (default features)
cargo clippy -p sparopt --all-features # clean (pre-existing unrelated lint-name warning only)
cargo fmt -p sparopt -- --check        # clean
```