### PR TITLE
Revise README for clarity on Oxigraph features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@
 [![Gitter](https://badges.gitter.im/oxigraph/community.svg)](https://gitter.im/oxigraph/community)
 [![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Foxigraph)](https://twitter.com/oxigraph)
 
-Oxigraph is a graph database implementing the [SPARQL](https://www.w3.org/TR/sparql11-overview/) standard.
+Oxigraph is both a graph database and a [RDF](https://www.w3.org/TR/rdf11-primer/) and [SPARQL](https://www.w3.org/TR/sparql11-overview/) toolkit.
 
 Its goal is to provide a compliant, safe, and fast graph database based on the [RocksDB](https://rocksdb.org/) key-value store.
-It is written in Rust.
-It also provides a set of utility functions for reading, writing, and processing RDF files.
+It also provides a set of utilities for RDF basic manipulation (parsing, serialization, canonicalization) and building SPARQL implementations (SPARQL results parsers/serializers, SPARQL parser...).
 
 Oxigraph is in heavy development and SPARQL query evaluation has not been optimized yet.
-The development roadmap is using [GitHub milestones](https://github.com/oxigraph/oxigraph/milestones?direction=desc&sort=completeness&state=open).
 Oxigraph internal design [is described on the wiki](https://github.com/oxigraph/oxigraph/wiki/Architecture).
 
 Oxigraph implements the following specifications:
@@ -41,7 +39,7 @@ It is split into multiple parts:
   Note that it was previously named [Oxigraph server](https://crates.io/crates/oxigraph-server).
   [![Latest Version](https://img.shields.io/crates/v/oxigraph-cli.svg)](https://crates.io/crates/oxigraph-cli)
 
-Also, some parts of Oxigraph are available as standalone Rust crates:
+Also, some parts of Oxigraph are available as standalone Rust crates to be reused in other Rust projects:
 * [`oxrdf`](./lib/oxrdf), datastructures encoding RDF basic concepts (the [`oxigraph::model`](crate::model) module).
 * [`oxrdfio`](./lib/oxrdfio), a unified parser and serializer API for RDF formats (the [`oxigraph::io`](crate::io) module). It itself relies on:
   * [`oxttl`](./lib/oxttl), N-Triple, N-Quad, Turtle, TriG and N3 parsing and serialization.


### PR DESCRIPTION
Updated the README to clarify Oxigraph's functionality as both a graph database and an RDF/SPARQL toolkit, along with improvements to the description of utility functions.