### PR TITLE
SPARQL: properly propagate storage error during expression evaluation

### DIFF
--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -1270,9 +1270,13 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
                 )?;
                 Rc::new(move |from| {
                     let expression = Rc::clone(&expression);
-                    Box::new(child(from).filter(move |tuple| match tuple {
-                        Ok(tuple) => expression(tuple).unwrap_or(false),
-                        Err(_) => true,
+                    Box::new(child(from).filter_map(move |tuple| match tuple {
+                        Ok(tuple) => match expression(&tuple) {
+                            Ok(Some(true)) => Some(Ok(tuple)),
+                            Ok(Some(false) | None) => None,
+                            Err(error) => Some(Err(error)),
+                        },
+                        Err(error) => Some(Err(error)),
                     }))
                 })
             }
@@ -1315,7 +1319,7 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
                         let expression = Rc::clone(&expression);
                         Box::new(child(from).map(move |tuple| {
                             let mut tuple = tuple?;
-                            if let Some(value) = expression(&tuple) {
+                            if let Some(value) = expression(&tuple)? {
                                 tuple.set(position, value);
                             }
                             Ok(tuple)
@@ -1331,7 +1335,7 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
                     let dataset = dataset.clone();
                     Box::new(child(from).map(move |tuple| {
                         let mut tuple = tuple?;
-                        if let Some(value) = expression(&tuple) {
+                        if let Some(value) = expression(&tuple)? {
                             tuple.set(position, dataset.internalize_expression_term(value)?);
                         }
                         Ok(tuple)
@@ -1521,29 +1525,28 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
                             accumulator_builders.iter().map(|c| c()).collect::<Vec<_>>(),
                         );
                     }
-                    child(from)
-                        .filter_map(|result| match result {
-                            Ok(result) => Some(result),
-                            Err(error) => {
-                                errors.push(error);
-                                None
-                            }
-                        })
-                        .for_each(|tuple| {
-                            // TODO avoid copy for key?
-                            let key = key_variables
-                                .iter()
-                                .map(|v| tuple.get(*v).cloned())
-                                .collect();
+                    for result in child(from) {
+                        match result {
+                            Ok(tuple) => {
+                                // TODO avoid copy for key?
+                                let key = key_variables
+                                    .iter()
+                                    .map(|v| tuple.get(*v).cloned())
+                                    .collect();
 
-                            let key_accumulators =
-                                accumulators_for_group.entry(key).or_insert_with(|| {
-                                    accumulator_builders.iter().map(|c| c()).collect::<Vec<_>>()
-                                });
-                            for accumulator in key_accumulators {
-                                accumulator.accumulate(&tuple);
+                                let key_accumulators =
+                                    accumulators_for_group.entry(key).or_insert_with(|| {
+                                        accumulator_builders.iter().map(|c| c()).collect::<Vec<_>>()
+                                    });
+                                for accumulator in key_accumulators {
+                                    if let Err(error) = accumulator.accumulate(&tuple) {
+                                        errors.push(error);
+                                    }
+                                }
                             }
-                        });
+                            Err(error) => errors.push(error),
+                        }
+                    }
                     let accumulator_variables = accumulator_variables.clone();
                     let dataset = dataset.clone();
                     Box::new(
@@ -1815,14 +1818,20 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
     /// Evaluates an expression and returns an internal term
     ///
     /// Returns None if building such expression implies to convert back to an internal term at the end.
-    #[expect(clippy::type_complexity)]
     fn internal_expression_evaluator(
         &self,
         expression: &Expression,
         encoded_variables: &mut Vec<Variable>,
         stat_children: &mut Vec<Rc<EvalNodeWithStats>>,
     ) -> Result<
-        Option<Rc<dyn Fn(&InternalTuple<D::InternalTerm>) -> Option<D::InternalTerm> + 'a>>,
+        Option<
+            ExpressionEvaluator<
+                'a,
+                InternalTuple<D::InternalTerm>,
+                D::InternalTerm,
+                QueryEvaluationError,
+            >,
+        >,
         QueryEvaluationError,
     > {
         Ok(try_build_internal_expression_evaluator(
@@ -1841,21 +1850,26 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
         expression: &Expression,
         encoded_variables: &mut Vec<Variable>,
         stat_children: &mut Vec<Rc<EvalNodeWithStats>>,
-    ) -> Result<ExpressionEvaluator<'a, InternalTuple<D::InternalTerm>, bool>, QueryEvaluationError>
-    {
+    ) -> Result<
+        ExpressionEvaluator<'a, InternalTuple<D::InternalTerm>, bool, QueryEvaluationError>,
+        QueryEvaluationError,
+    > {
         // TODO: avoid dyn?
         if let Some(eval) =
             self.internal_expression_evaluator(expression, encoded_variables, stat_children)?
         {
             let dataset = self.dataset.clone();
             return Ok(Rc::new(move |tuple| {
-                dataset
-                    .internal_term_effective_boolean_value(eval(tuple)?)
-                    .ok()?
+                let Some(term) = eval(tuple)? else {
+                    return Ok(None);
+                };
+                dataset.internal_term_effective_boolean_value(term)
             }));
         }
         let eval = self.expression_evaluator(expression, encoded_variables, stat_children)?;
-        Ok(Rc::new(move |tuple| eval(tuple)?.effective_boolean_value()))
+        Ok(Rc::new(move |tuple| {
+            Ok(eval(tuple)?.and_then(|term| term.effective_boolean_value()))
+        }))
     }
 
     /// Evaluate an expression and return an explicit ExpressionTerm
@@ -1865,7 +1879,12 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
         encoded_variables: &mut Vec<Variable>,
         stat_children: &mut Vec<Rc<EvalNodeWithStats>>,
     ) -> Result<
-        ExpressionEvaluator<'a, InternalTuple<D::InternalTerm>, ExpressionTerm>,
+        ExpressionEvaluator<
+            'a,
+            InternalTuple<D::InternalTerm>,
+            ExpressionTerm,
+            QueryEvaluationError,
+        >,
         QueryEvaluationError,
     > {
         Ok(build_expression_evaluator(
@@ -1996,21 +2015,21 @@ impl<'a, D: QueryableDataset<'a>> ExpressionEvaluatorContext<'a>
 
     fn build_internalize_expression_term(
         &mut self,
-    ) -> impl Fn(ExpressionTerm) -> Option<Self::Term> + 'a {
+    ) -> impl Fn(ExpressionTerm) -> Result<Self::Term, Self::Error> + 'a {
         let dataset = self.evaluator.dataset.clone();
-        move |t| dataset.internalize_expression_term(t).ok()
+        move |t| dataset.internalize_expression_term(t)
     }
 
     fn build_externalize_expression_term(
         &mut self,
-    ) -> impl Fn(Self::Term) -> Option<ExpressionTerm> + 'a {
+    ) -> impl Fn(Self::Term) -> Result<ExpressionTerm, Self::Error> + 'a {
         let dataset = self.evaluator.dataset.clone();
-        move |t| dataset.externalize_expression_term(t).ok()
+        move |t| dataset.externalize_expression_term(t)
     }
 
-    fn build_externalize_term(&mut self) -> impl Fn(Self::Term) -> Option<Term> + 'a {
+    fn build_externalize_term(&mut self) -> impl Fn(Self::Term) -> Result<Term, Self::Error> + 'a {
         let dataset = self.evaluator.dataset.clone();
-        move |t| dataset.externalize_term(t).ok()
+        move |t| dataset.externalize_term(t)
     }
 
     fn now(&mut self) -> DateTime {
@@ -2111,32 +2130,32 @@ enum AccumulatorWrapper<'a, T> {
         count: u64,
     },
     CountInternal {
-        evaluator: Rc<dyn Fn(&InternalTuple<T>) -> Option<T> + 'a>,
+        evaluator: ExpressionEvaluator<'a, InternalTuple<T>, T, QueryEvaluationError>,
         count: u64,
     },
     CountDistinctInternal {
         seen: FxHashSet<T>,
-        evaluator: Rc<dyn Fn(&InternalTuple<T>) -> Option<T> + 'a>,
+        evaluator: ExpressionEvaluator<'a, InternalTuple<T>, T, QueryEvaluationError>,
         count: u64,
     },
     Sample {
         // TODO: add internal variant
-        evaluator: Rc<dyn Fn(&InternalTuple<T>) -> Option<ExpressionTerm> + 'a>,
+        evaluator: ExpressionEvaluator<'a, InternalTuple<T>, ExpressionTerm, QueryEvaluationError>,
         value: Option<ExpressionTerm>,
     },
     Expression {
-        evaluator: Rc<dyn Fn(&InternalTuple<T>) -> Option<ExpressionTerm> + 'a>,
+        evaluator: ExpressionEvaluator<'a, InternalTuple<T>, ExpressionTerm, QueryEvaluationError>,
         accumulator: Option<Box<dyn Accumulator>>,
     },
     DistinctExpression {
         seen: FxHashSet<ExpressionTerm>,
-        evaluator: Rc<dyn Fn(&InternalTuple<T>) -> Option<ExpressionTerm> + 'a>,
+        evaluator: ExpressionEvaluator<'a, InternalTuple<T>, ExpressionTerm, QueryEvaluationError>,
         accumulator: Option<Box<dyn Accumulator>>,
     },
 }
 
 impl<T: Clone + Eq + Hash> AccumulatorWrapper<'_, T> {
-    fn accumulate(&mut self, tuple: &InternalTuple<T>) {
+    fn accumulate(&mut self, tuple: &InternalTuple<T>) -> Result<(), QueryEvaluationError> {
         match self {
             Self::CountTuple { count } => {
                 *count += 1;
@@ -2147,7 +2166,7 @@ impl<T: Clone + Eq + Hash> AccumulatorWrapper<'_, T> {
                 }
             }
             Self::CountInternal { evaluator, count } => {
-                if evaluator(tuple).is_some() {
+                if evaluator(tuple)?.is_some() {
                     *count += 1;
                 }
             }
@@ -2156,8 +2175,8 @@ impl<T: Clone + Eq + Hash> AccumulatorWrapper<'_, T> {
                 evaluator,
                 count,
             } => {
-                let Some(value) = evaluator(tuple) else {
-                    return;
+                let Some(value) = evaluator(tuple)? else {
+                    return Ok(());
                 };
                 if seen.insert(value) {
                     *count += 1;
@@ -2165,23 +2184,23 @@ impl<T: Clone + Eq + Hash> AccumulatorWrapper<'_, T> {
             }
             Self::Sample { evaluator, value } => {
                 if value.is_some() {
-                    return; // We already got a value
+                    return Ok(()); // We already got a value
                 }
-                *value = evaluator(tuple);
+                *value = evaluator(tuple)?;
             }
             Self::Expression {
                 evaluator,
                 accumulator,
             } => {
                 if accumulator.is_none() {
-                    return; // Already failed
+                    return Ok(()); // Already failed
                 }
-                let Some(value) = evaluator(tuple) else {
+                let Some(value) = evaluator(tuple)? else {
                     *accumulator = None;
-                    return;
+                    return Ok(());
                 };
                 let Some(accumulator) = accumulator else {
-                    return;
+                    return Ok(());
                 };
                 accumulator.accumulate(value);
             }
@@ -2191,20 +2210,21 @@ impl<T: Clone + Eq + Hash> AccumulatorWrapper<'_, T> {
                 accumulator,
             } => {
                 if accumulator.is_none() {
-                    return; // Already failed
+                    return Ok(()); // Already failed
                 }
-                let Some(value) = evaluator(tuple) else {
+                let Some(value) = evaluator(tuple)? else {
                     *accumulator = None;
-                    return;
+                    return Ok(());
                 };
                 let Some(accumulator) = accumulator else {
-                    return;
+                    return Ok(());
                 };
                 if seen.insert(value.clone()) {
                     accumulator.accumulate(value);
                 }
             }
         }
+        Ok(())
     }
 
     fn finish(self) -> Option<ExpressionTerm> {
@@ -3124,7 +3144,7 @@ struct HashLeftJoinIterator<'a, T> {
     left_iter: InternalTuplesIterator<'a, T>,
     right: InternalTupleSet<T>,
     buffered_results: Vec<Result<InternalTuple<T>, QueryEvaluationError>>,
-    expression: Rc<dyn Fn(&InternalTuple<T>) -> Option<bool> + 'a>,
+    expression: Rc<dyn Fn(&InternalTuple<T>) -> Result<Option<bool>, QueryEvaluationError> + 'a>,
 }
 
 impl<T: Clone + Eq + Hash> Iterator for HashLeftJoinIterator<'_, T> {
@@ -3139,14 +3159,18 @@ impl<T: Clone + Eq + Hash> Iterator for HashLeftJoinIterator<'_, T> {
                 Ok(left_tuple) => left_tuple,
                 Err(error) => return Some(Err(error)),
             };
-            self.buffered_results.extend(
-                self.right
-                    .get(&left_tuple)
-                    .iter()
-                    .filter_map(|right_tuple| left_tuple.combine_with(right_tuple))
-                    .filter(|tuple| (self.expression)(tuple).unwrap_or(false))
-                    .map(Ok),
-            );
+            for tuple in self
+                .right
+                .get(&left_tuple)
+                .iter()
+                .filter_map(|right_tuple| left_tuple.combine_with(right_tuple))
+            {
+                match (self.expression)(&tuple) {
+                    Ok(Some(true)) => self.buffered_results.push(Ok(tuple)),
+                    Ok(Some(false) | None) => {}
+                    Err(error) => self.buffered_results.push(Err(error)),
+                }
+            }
             if self.buffered_results.is_empty() {
                 // We have not manage to join with anything
                 return Some(Ok(left_tuple));

--- a/lib/spareval/src/expression.rs
+++ b/lib/spareval/src/expression.rs
@@ -50,17 +50,27 @@ pub trait ExpressionEvaluatorContext<'a> {
     fn internalize_literal(&mut self, term: &Literal) -> Result<Self::Term, Self::Error>;
     fn build_internalize_expression_term(
         &mut self,
-    ) -> impl Fn(ExpressionTerm) -> Option<Self::Term> + 'a; // TODO: return result
+    ) -> impl Fn(ExpressionTerm) -> Result<Self::Term, Self::Error> + 'a;
     fn build_externalize_expression_term(
         &mut self,
-    ) -> impl Fn(Self::Term) -> Option<ExpressionTerm> + 'a; // TODO: return result
-    fn build_externalize_term(&mut self) -> impl Fn(Self::Term) -> Option<Term> + 'a; // TODO: return result
+    ) -> impl Fn(Self::Term) -> Result<ExpressionTerm, Self::Error> + 'a;
+    fn build_externalize_term(&mut self) -> impl Fn(Self::Term) -> Result<Term, Self::Error> + 'a;
     fn now(&mut self) -> DateTime;
     fn base_iri(&mut self) -> Option<Iri<OxString>>;
     fn custom_functions(&mut self) -> &CustomFunctionRegistry;
 }
 
-pub type ExpressionEvaluator<'a, I, O> = Rc<dyn (Fn(&I) -> Option<O>) + 'a>;
+pub type ExpressionEvaluator<'a, I, O, E> = Rc<dyn (Fn(&I) -> Result<Option<O>, E>) + 'a>;
+
+macro_rules! try_or_ok {
+    ($value:expr) => {
+        if let Some(value) = $value {
+            value
+        } else {
+            return Ok(None);
+        }
+    };
+}
 
 #[derive(Debug, Error)]
 pub enum ExpressionEvaluationError<C> {
@@ -82,31 +92,36 @@ pub enum ExpressionEvaluationError<C> {
 pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
     expression: &Expression,
     context: &mut C,
-) -> Result<ExpressionEvaluator<'a, C::Tuple, ExpressionTerm>, ExpressionEvaluationError<C::Error>>
+) -> Result<
+    ExpressionEvaluator<'a, C::Tuple, ExpressionTerm, C::Error>,
+    ExpressionEvaluationError<C::Error>,
+>
+where
+    C::Error: 'a,
 {
     Ok(match expression {
         Expression::NamedNode(t) => {
             let t = ExpressionTerm::from(Term::from(t.clone()));
-            Rc::new(move |_| Some(t.clone()))
+            Rc::new(move |_| Ok(Some(t.clone())))
         }
         Expression::Literal(t) => {
             let t = ExpressionTerm::from(Term::from(t.clone()));
-            Rc::new(move |_| Some(t.clone()))
+            Rc::new(move |_| Ok(Some(t.clone())))
         }
         Expression::Variable(v) => {
             let lookup = context.build_variable_lookup(v);
             let externalize = context.build_externalize_expression_term();
-            Rc::new(move |t| externalize(lookup(t)?))
+            Rc::new(move |t| externalize(try_or_ok!(lookup(t))).map(Some))
         }
         Expression::Bound(v) => {
             let lookup = context.build_is_variable_bound(v);
-            Rc::new(move |tuple| Some(lookup(tuple).into()))
+            Rc::new(move |tuple| Ok(Some(lookup(tuple).into())))
         }
         Expression::Exists(plan) => {
             let exists = context
                 .build_exists(plan)
                 .map_err(ExpressionEvaluationError::Context)?;
-            Rc::new(move |tuple| Some(exists(tuple).into()))
+            Rc::new(move |tuple| Ok(Some(exists(tuple).into())))
         }
         Expression::Or(children) => {
             let children = children
@@ -116,13 +131,13 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
             Rc::new(move |tuple| {
                 let mut error = false;
                 for child in &children {
-                    match child(tuple).and_then(|e| e.effective_boolean_value()) {
-                        Some(true) => return Some(true.into()),
+                    match child(tuple)?.and_then(|e| e.effective_boolean_value()) {
+                        Some(true) => return Ok(Some(true.into())),
                         Some(false) => (),
                         None => error = true,
                     }
                 }
-                if error { None } else { Some(false.into()) }
+                Ok(if error { None } else { Some(false.into()) })
             })
         }
         Expression::And(children) => {
@@ -133,40 +148,58 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
             Rc::new(move |tuple| {
                 let mut error = false;
                 for child in &children {
-                    match child(tuple).and_then(|e| e.effective_boolean_value()) {
+                    match child(tuple)?.and_then(|e| e.effective_boolean_value()) {
                         Some(true) => (),
-                        Some(false) => return Some(false.into()),
+                        Some(false) => return Ok(Some(false.into())),
                         None => error = true,
                     }
                 }
-                if error { None } else { Some(true.into()) }
+                Ok(if error { None } else { Some(true.into()) })
             })
         }
         Expression::Equal(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
-            Rc::new(move |tuple| equals(&a(tuple)?, &b(tuple)?).map(Into::into))
+            Rc::new(move |tuple| {
+                Ok(equals(&try_or_ok!(a(tuple)?), &try_or_ok!(b(tuple)?)).map(Into::into))
+            })
         }
         Expression::SameTerm(a, b) => {
             match (
                 try_build_internal_expression_evaluator(a, context)?,
                 try_build_internal_expression_evaluator(b, context)?,
             ) {
-                (Some(a), Some(b)) => Rc::new(move |tuple| Some((a(tuple)? == b(tuple)?).into())),
+                (Some(a), Some(b)) => Rc::new(move |tuple| {
+                    Ok(Some(
+                        (try_or_ok!(a(tuple)?) == try_or_ok!(b(tuple)?)).into(),
+                    ))
+                }),
                 (Some(a), None) => {
                     let b = build_expression_evaluator(b, context)?;
                     let internalize = context.build_internalize_expression_term();
-                    Rc::new(move |tuple| Some((a(tuple)? == internalize(b(tuple)?)?).into()))
+                    Rc::new(move |tuple| {
+                        Ok(Some(
+                            (try_or_ok!(a(tuple)?) == internalize(try_or_ok!(b(tuple)?))?).into(),
+                        ))
+                    })
                 }
                 (None, Some(b)) => {
                     let a = build_expression_evaluator(a, context)?;
                     let internalize = context.build_internalize_expression_term();
-                    Rc::new(move |tuple| Some((internalize(a(tuple)?)? == b(tuple)?).into()))
+                    Rc::new(move |tuple| {
+                        Ok(Some(
+                            (internalize(try_or_ok!(a(tuple)?))? == try_or_ok!(b(tuple)?)).into(),
+                        ))
+                    })
                 }
                 (None, None) => {
                     let a = build_expression_evaluator(a, context)?;
                     let b = build_expression_evaluator(b, context)?;
-                    Rc::new(move |tuple| Some((a(tuple)? == b(tuple)?).into()))
+                    Rc::new(move |tuple| {
+                        Ok(Some(
+                            (try_or_ok!(a(tuple)?) == try_or_ok!(b(tuple)?)).into(),
+                        ))
+                    })
                 }
             }
         }
@@ -174,218 +207,282 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some((partial_cmp(&a(tuple)?, &b(tuple)?)? == Ordering::Greater).into())
+                Ok(Some(
+                    (try_or_ok!(partial_cmp(&try_or_ok!(a(tuple)?), &try_or_ok!(b(tuple)?)))
+                        == Ordering::Greater)
+                        .into(),
+                ))
             })
         }
         Expression::GreaterOrEqual(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some(
-                    match partial_cmp(&a(tuple)?, &b(tuple)?)? {
+                Ok(Some(
+                    match try_or_ok!(partial_cmp(&try_or_ok!(a(tuple)?), &try_or_ok!(b(tuple)?))) {
                         Ordering::Greater | Ordering::Equal => true,
                         Ordering::Less => false,
                     }
                     .into(),
-                )
+                ))
             })
         }
         Expression::Less(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some((partial_cmp(&a(tuple)?, &b(tuple)?)? == Ordering::Less).into())
+                Ok(Some(
+                    (try_or_ok!(partial_cmp(&try_or_ok!(a(tuple)?), &try_or_ok!(b(tuple)?)))
+                        == Ordering::Less)
+                        .into(),
+                ))
             })
         }
         Expression::LessOrEqual(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some(
-                    match partial_cmp(&a(tuple)?, &b(tuple)?)? {
+                Ok(Some(
+                    match try_or_ok!(partial_cmp(&try_or_ok!(a(tuple)?), &try_or_ok!(b(tuple)?))) {
                         Ordering::Less | Ordering::Equal => true,
                         Ordering::Greater => false,
                     }
                     .into(),
-                )
+                ))
             })
         }
         Expression::Add(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some(match NumericBinaryOperands::new(a(tuple)?, b(tuple)?)? {
-                    NumericBinaryOperands::Float(v1, v2) => ExpressionTerm::FloatLiteral(v1 + v2),
-                    NumericBinaryOperands::Double(v1, v2) => ExpressionTerm::DoubleLiteral(v1 + v2),
-                    NumericBinaryOperands::Integer(v1, v2) => {
-                        ExpressionTerm::IntegerLiteral(v1.checked_add(v2)?)
-                    }
-                    NumericBinaryOperands::Decimal(v1, v2) => {
-                        ExpressionTerm::DecimalLiteral(v1.checked_add(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::Duration(v1, v2) => {
-                        ExpressionTerm::DurationLiteral(v1.checked_add(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::YearMonthDuration(v1, v2) => {
-                        ExpressionTerm::YearMonthDurationLiteral(v1.checked_add(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DayTimeDuration(v1, v2) => {
-                        ExpressionTerm::DayTimeDurationLiteral(v1.checked_add(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTimeDuration(v1, v2) => {
-                        ExpressionTerm::DateTimeLiteral(v1.checked_add_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTimeYearMonthDuration(v1, v2) => {
-                        ExpressionTerm::DateTimeLiteral(v1.checked_add_year_month_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTimeDayTimeDuration(v1, v2) => {
-                        ExpressionTerm::DateTimeLiteral(v1.checked_add_day_time_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateDuration(v1, v2) => {
-                        ExpressionTerm::DateLiteral(v1.checked_add_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateYearMonthDuration(v1, v2) => {
-                        ExpressionTerm::DateLiteral(v1.checked_add_year_month_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateDayTimeDuration(v1, v2) => {
-                        ExpressionTerm::DateLiteral(v1.checked_add_day_time_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::TimeDuration(v1, v2) => {
-                        ExpressionTerm::TimeLiteral(v1.checked_add_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::TimeDayTimeDuration(v1, v2) => {
-                        ExpressionTerm::TimeLiteral(v1.checked_add_day_time_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTime(_, _)
-                    | NumericBinaryOperands::Time(_, _)
-                    | NumericBinaryOperands::Date(_, _) => return None,
-                })
+                Ok(Some(
+                    match try_or_ok!(NumericBinaryOperands::new(
+                        try_or_ok!(a(tuple)?),
+                        try_or_ok!(b(tuple)?),
+                    )) {
+                        NumericBinaryOperands::Float(v1, v2) => {
+                            ExpressionTerm::FloatLiteral(v1 + v2)
+                        }
+                        NumericBinaryOperands::Double(v1, v2) => {
+                            ExpressionTerm::DoubleLiteral(v1 + v2)
+                        }
+                        NumericBinaryOperands::Integer(v1, v2) => {
+                            ExpressionTerm::IntegerLiteral(try_or_ok!(v1.checked_add(v2)))
+                        }
+                        NumericBinaryOperands::Decimal(v1, v2) => {
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(v1.checked_add(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::Duration(v1, v2) => {
+                            ExpressionTerm::DurationLiteral(try_or_ok!(v1.checked_add(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::YearMonthDuration(v1, v2) => {
+                            ExpressionTerm::YearMonthDurationLiteral(try_or_ok!(v1.checked_add(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DayTimeDuration(v1, v2) => {
+                            ExpressionTerm::DayTimeDurationLiteral(try_or_ok!(v1.checked_add(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTimeDuration(v1, v2) => {
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(v1.checked_add_duration(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTimeYearMonthDuration(v1, v2) => {
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(
+                                v1.checked_add_year_month_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTimeDayTimeDuration(v1, v2) => {
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(
+                                v1.checked_add_day_time_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateDuration(v1, v2) => {
+                            ExpressionTerm::DateLiteral(try_or_ok!(v1.checked_add_duration(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateYearMonthDuration(v1, v2) => {
+                            ExpressionTerm::DateLiteral(try_or_ok!(
+                                v1.checked_add_year_month_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateDayTimeDuration(v1, v2) => {
+                            ExpressionTerm::DateLiteral(try_or_ok!(
+                                v1.checked_add_day_time_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::TimeDuration(v1, v2) => {
+                            ExpressionTerm::TimeLiteral(try_or_ok!(v1.checked_add_duration(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::TimeDayTimeDuration(v1, v2) => {
+                            ExpressionTerm::TimeLiteral(try_or_ok!(
+                                v1.checked_add_day_time_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTime(_, _)
+                        | NumericBinaryOperands::Time(_, _)
+                        | NumericBinaryOperands::Date(_, _) => return Ok(None),
+                    },
+                ))
             })
         }
         Expression::Subtract(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some(match NumericBinaryOperands::new(a(tuple)?, b(tuple)?)? {
-                    NumericBinaryOperands::Float(v1, v2) => ExpressionTerm::FloatLiteral(v1 - v2),
-                    NumericBinaryOperands::Double(v1, v2) => ExpressionTerm::DoubleLiteral(v1 - v2),
-                    NumericBinaryOperands::Integer(v1, v2) => {
-                        ExpressionTerm::IntegerLiteral(v1.checked_sub(v2)?)
-                    }
-                    NumericBinaryOperands::Decimal(v1, v2) => {
-                        ExpressionTerm::DecimalLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTime(v1, v2) => {
-                        ExpressionTerm::DayTimeDurationLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::Date(v1, v2) => {
-                        ExpressionTerm::DayTimeDurationLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::Time(v1, v2) => {
-                        ExpressionTerm::DayTimeDurationLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::Duration(v1, v2) => {
-                        ExpressionTerm::DurationLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::YearMonthDuration(v1, v2) => {
-                        ExpressionTerm::YearMonthDurationLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DayTimeDuration(v1, v2) => {
-                        ExpressionTerm::DayTimeDurationLiteral(v1.checked_sub(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTimeDuration(v1, v2) => {
-                        ExpressionTerm::DateTimeLiteral(v1.checked_sub_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTimeYearMonthDuration(v1, v2) => {
-                        ExpressionTerm::DateTimeLiteral(v1.checked_sub_year_month_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateTimeDayTimeDuration(v1, v2) => {
-                        ExpressionTerm::DateTimeLiteral(v1.checked_sub_day_time_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateDuration(v1, v2) => {
-                        ExpressionTerm::DateLiteral(v1.checked_sub_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateYearMonthDuration(v1, v2) => {
-                        ExpressionTerm::DateLiteral(v1.checked_sub_year_month_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::DateDayTimeDuration(v1, v2) => {
-                        ExpressionTerm::DateLiteral(v1.checked_sub_day_time_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::TimeDuration(v1, v2) => {
-                        ExpressionTerm::TimeLiteral(v1.checked_sub_duration(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    NumericBinaryOperands::TimeDayTimeDuration(v1, v2) => {
-                        ExpressionTerm::TimeLiteral(v1.checked_sub_day_time_duration(v2)?)
-                    }
-                })
+                Ok(Some(
+                    match try_or_ok!(NumericBinaryOperands::new(
+                        try_or_ok!(a(tuple)?),
+                        try_or_ok!(b(tuple)?),
+                    )) {
+                        NumericBinaryOperands::Float(v1, v2) => {
+                            ExpressionTerm::FloatLiteral(v1 - v2)
+                        }
+                        NumericBinaryOperands::Double(v1, v2) => {
+                            ExpressionTerm::DoubleLiteral(v1 - v2)
+                        }
+                        NumericBinaryOperands::Integer(v1, v2) => {
+                            ExpressionTerm::IntegerLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        NumericBinaryOperands::Decimal(v1, v2) => {
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTime(v1, v2) => {
+                            ExpressionTerm::DayTimeDurationLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::Date(v1, v2) => {
+                            ExpressionTerm::DayTimeDurationLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::Time(v1, v2) => {
+                            ExpressionTerm::DayTimeDurationLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::Duration(v1, v2) => {
+                            ExpressionTerm::DurationLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::YearMonthDuration(v1, v2) => {
+                            ExpressionTerm::YearMonthDurationLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DayTimeDuration(v1, v2) => {
+                            ExpressionTerm::DayTimeDurationLiteral(try_or_ok!(v1.checked_sub(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTimeDuration(v1, v2) => {
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(v1.checked_sub_duration(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTimeYearMonthDuration(v1, v2) => {
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(
+                                v1.checked_sub_year_month_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateTimeDayTimeDuration(v1, v2) => {
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(
+                                v1.checked_sub_day_time_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateDuration(v1, v2) => {
+                            ExpressionTerm::DateLiteral(try_or_ok!(v1.checked_sub_duration(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateYearMonthDuration(v1, v2) => {
+                            ExpressionTerm::DateLiteral(try_or_ok!(
+                                v1.checked_sub_year_month_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::DateDayTimeDuration(v1, v2) => {
+                            ExpressionTerm::DateLiteral(try_or_ok!(
+                                v1.checked_sub_day_time_duration(v2)
+                            ))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::TimeDuration(v1, v2) => {
+                            ExpressionTerm::TimeLiteral(try_or_ok!(v1.checked_sub_duration(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        NumericBinaryOperands::TimeDayTimeDuration(v1, v2) => {
+                            ExpressionTerm::TimeLiteral(try_or_ok!(
+                                v1.checked_sub_day_time_duration(v2)
+                            ))
+                        }
+                    },
+                ))
             })
         }
         Expression::Multiply(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some(match NumericBinaryOperands::new(a(tuple)?, b(tuple)?)? {
-                    NumericBinaryOperands::Float(v1, v2) => ExpressionTerm::FloatLiteral(v1 * v2),
-                    NumericBinaryOperands::Double(v1, v2) => ExpressionTerm::DoubleLiteral(v1 * v2),
-                    NumericBinaryOperands::Integer(v1, v2) => {
-                        ExpressionTerm::IntegerLiteral(v1.checked_mul(v2)?)
-                    }
-                    NumericBinaryOperands::Decimal(v1, v2) => {
-                        ExpressionTerm::DecimalLiteral(v1.checked_mul(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    _ => return None,
-                })
+                Ok(Some(
+                    match try_or_ok!(NumericBinaryOperands::new(
+                        try_or_ok!(a(tuple)?),
+                        try_or_ok!(b(tuple)?),
+                    )) {
+                        NumericBinaryOperands::Float(v1, v2) => {
+                            ExpressionTerm::FloatLiteral(v1 * v2)
+                        }
+                        NumericBinaryOperands::Double(v1, v2) => {
+                            ExpressionTerm::DoubleLiteral(v1 * v2)
+                        }
+                        NumericBinaryOperands::Integer(v1, v2) => {
+                            ExpressionTerm::IntegerLiteral(try_or_ok!(v1.checked_mul(v2)))
+                        }
+                        NumericBinaryOperands::Decimal(v1, v2) => {
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(v1.checked_mul(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        _ => return Ok(None),
+                    },
+                ))
             })
         }
         Expression::Divide(a, b) => {
             let a = build_expression_evaluator(a, context)?;
             let b = build_expression_evaluator(b, context)?;
             Rc::new(move |tuple| {
-                Some(match NumericBinaryOperands::new(a(tuple)?, b(tuple)?)? {
-                    NumericBinaryOperands::Float(v1, v2) => ExpressionTerm::FloatLiteral(v1 / v2),
-                    NumericBinaryOperands::Double(v1, v2) => ExpressionTerm::DoubleLiteral(v1 / v2),
-                    NumericBinaryOperands::Integer(v1, v2) => {
-                        ExpressionTerm::DecimalLiteral(Decimal::from(v1).checked_div(v2)?)
-                    }
-                    NumericBinaryOperands::Decimal(v1, v2) => {
-                        ExpressionTerm::DecimalLiteral(v1.checked_div(v2)?)
-                    }
-                    #[cfg(feature = "sep-0002")]
-                    _ => return None,
-                })
+                Ok(Some(
+                    match try_or_ok!(NumericBinaryOperands::new(
+                        try_or_ok!(a(tuple)?),
+                        try_or_ok!(b(tuple)?),
+                    )) {
+                        NumericBinaryOperands::Float(v1, v2) => {
+                            ExpressionTerm::FloatLiteral(v1 / v2)
+                        }
+                        NumericBinaryOperands::Double(v1, v2) => {
+                            ExpressionTerm::DoubleLiteral(v1 / v2)
+                        }
+                        NumericBinaryOperands::Integer(v1, v2) => ExpressionTerm::DecimalLiteral(
+                            try_or_ok!(Decimal::from(v1).checked_div(v2)),
+                        ),
+                        NumericBinaryOperands::Decimal(v1, v2) => {
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(v1.checked_div(v2)))
+                        }
+                        #[cfg(feature = "sep-0002")]
+                        _ => return Ok(None),
+                    },
+                ))
             })
         }
         Expression::UnaryPlus(e) => {
             let e = build_expression_evaluator(e, context)?;
             Rc::new(move |tuple| {
-                Some(match e(tuple)? {
+                Ok(Some(match try_or_ok!(e(tuple)?) {
                     ExpressionTerm::FloatLiteral(value) => ExpressionTerm::FloatLiteral(value),
                     ExpressionTerm::DoubleLiteral(value) => ExpressionTerm::DoubleLiteral(value),
                     ExpressionTerm::IntegerLiteral(value) => ExpressionTerm::IntegerLiteral(value),
@@ -402,41 +499,45 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     ExpressionTerm::DayTimeDurationLiteral(value) => {
                         ExpressionTerm::DayTimeDurationLiteral(value)
                     }
-                    _ => return None,
-                })
+                    _ => return Ok(None),
+                }))
             })
         }
         Expression::UnaryMinus(e) => {
             let e = build_expression_evaluator(e, context)?;
             Rc::new(move |tuple| {
-                Some(match e(tuple)? {
+                Ok(Some(match try_or_ok!(e(tuple)?) {
                     ExpressionTerm::FloatLiteral(value) => ExpressionTerm::FloatLiteral(-value),
                     ExpressionTerm::DoubleLiteral(value) => ExpressionTerm::DoubleLiteral(-value),
                     ExpressionTerm::IntegerLiteral(value) => {
-                        ExpressionTerm::IntegerLiteral(value.checked_neg()?)
+                        ExpressionTerm::IntegerLiteral(try_or_ok!(value.checked_neg()))
                     }
                     ExpressionTerm::DecimalLiteral(value) => {
-                        ExpressionTerm::DecimalLiteral(value.checked_neg()?)
+                        ExpressionTerm::DecimalLiteral(try_or_ok!(value.checked_neg()))
                     }
                     #[cfg(feature = "sep-0002")]
                     ExpressionTerm::DurationLiteral(value) => {
-                        ExpressionTerm::DurationLiteral(value.checked_neg()?)
+                        ExpressionTerm::DurationLiteral(try_or_ok!(value.checked_neg()))
                     }
                     #[cfg(feature = "sep-0002")]
                     ExpressionTerm::YearMonthDurationLiteral(value) => {
-                        ExpressionTerm::YearMonthDurationLiteral(value.checked_neg()?)
+                        ExpressionTerm::YearMonthDurationLiteral(try_or_ok!(value.checked_neg()))
                     }
                     #[cfg(feature = "sep-0002")]
                     ExpressionTerm::DayTimeDurationLiteral(value) => {
-                        ExpressionTerm::DayTimeDurationLiteral(value.checked_neg()?)
+                        ExpressionTerm::DayTimeDurationLiteral(try_or_ok!(value.checked_neg()))
                     }
-                    _ => return None,
-                })
+                    _ => return Ok(None),
+                }))
             })
         }
         Expression::Not(e) => {
             let e = build_expression_evaluator(e, context)?;
-            Rc::new(move |tuple| Some((!e(tuple)?.effective_boolean_value()?).into()))
+            Rc::new(move |tuple| {
+                Ok(Some(
+                    (!try_or_ok!(try_or_ok!(e(tuple)?).effective_boolean_value())).into(),
+                ))
+            })
         }
         Expression::Coalesce(l) => {
             let l = l
@@ -445,11 +546,11 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                 .collect::<Result<Vec<_>, _>>()?;
             Rc::new(move |tuple| {
                 for e in &l {
-                    if let Some(result) = e(tuple) {
-                        return Some(result);
+                    if let Some(result) = e(tuple)? {
+                        return Ok(Some(result));
                     }
                 }
-                None
+                Ok(None)
             })
         }
         Expression::If(a, b, c) => {
@@ -457,7 +558,7 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
             let b = build_expression_evaluator(b, context)?;
             let c = build_expression_evaluator(c, context)?;
             Rc::new(move |tuple| {
-                if a(tuple)?.effective_boolean_value()? {
+                if try_or_ok!(try_or_ok!(a(tuple)?).effective_boolean_value()) {
                     b(tuple)
                 } else {
                     c(tuple)
@@ -469,60 +570,66 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                 if let Some(e) = try_build_internal_expression_evaluator(&parameters[0], context)? {
                     let externalize = context.build_externalize_term();
                     Rc::new(move |tuple| {
-                        Some(ExpressionTerm::StringLiteral(
-                            match externalize(e(tuple)?)? {
+                        Ok(Some(ExpressionTerm::StringLiteral(
+                            match externalize(try_or_ok!(e(tuple)?))? {
                                 Term::NamedNode(term) => term.into_string(),
-                                Term::BlankNode(_) => return None,
+                                Term::BlankNode(_) => return Ok(None),
                                 Term::Literal(term) => term.into_value(),
                                 #[cfg(feature = "sparql-12")]
-                                Term::Triple(_) => return None,
+                                Term::Triple(_) => return Ok(None),
                             },
-                        ))
+                        )))
                     })
                 } else {
                     let e = build_expression_evaluator(&parameters[0], context)?;
                     Rc::new(move |tuple| {
-                        Some(ExpressionTerm::StringLiteral(match e(tuple)?.into() {
-                            Term::NamedNode(term) => term.into_string(),
-                            Term::BlankNode(_) => return None,
-                            Term::Literal(term) => term.into_value(),
-                            #[cfg(feature = "sparql-12")]
-                            Term::Triple(_) => return None,
-                        }))
+                        Ok(Some(ExpressionTerm::StringLiteral(
+                            match try_or_ok!(e(tuple)?).into() {
+                                Term::NamedNode(term) => term.into_string(),
+                                Term::BlankNode(_) => return Ok(None),
+                                Term::Literal(term) => term.into_value(),
+                                #[cfg(feature = "sparql-12")]
+                                Term::Triple(_) => return Ok(None),
+                            },
+                        )))
                     })
                 }
             }
             Function::Lang => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::StringLiteral(match e(tuple)? {
-                        ExpressionTerm::LangStringLiteral { language, .. } => language,
-                        #[cfg(feature = "sparql-12")]
-                        ExpressionTerm::DirLangStringLiteral { language, .. } => language,
-                        ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => {
-                            return None;
-                        }
-                        #[cfg(feature = "sparql-12")]
-                        ExpressionTerm::Triple(_) => return None,
-                        _ => OxString::default(),
-                    }))
+                    Ok(Some(ExpressionTerm::StringLiteral(
+                        match try_or_ok!(e(tuple)?) {
+                            ExpressionTerm::LangStringLiteral { language, .. } => language,
+                            #[cfg(feature = "sparql-12")]
+                            ExpressionTerm::DirLangStringLiteral { language, .. } => language,
+                            ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => {
+                                return Ok(None);
+                            }
+                            #[cfg(feature = "sparql-12")]
+                            ExpressionTerm::Triple(_) => return Ok(None),
+                            _ => OxString::default(),
+                        },
+                    )))
                 })
             }
             Function::LangMatches => {
                 let language_tag = build_expression_evaluator(&parameters[0], context)?;
                 let language_range = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let ExpressionTerm::StringLiteral(mut language_tag) = language_tag(tuple)?
+                    let ExpressionTerm::StringLiteral(mut language_tag) =
+                        try_or_ok!(language_tag(tuple)?)
                     else {
-                        return None;
+                        return Ok(None);
                     };
                     language_tag.make_mut().make_ascii_lowercase();
-                    let ExpressionTerm::StringLiteral(mut language_range) = language_range(tuple)?
+                    let ExpressionTerm::StringLiteral(mut language_range) =
+                        try_or_ok!(language_range(tuple)?)
                     else {
-                        return None;
+                        return Ok(None);
                     };
                     language_range.make_mut().make_ascii_lowercase();
-                    Some(
+                    Ok(Some(
                         if &*language_range == "*" {
                             !language_tag.is_empty()
                         } else {
@@ -536,172 +643,192 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                                 })
                         }
                         .into(),
-                    )
+                    ))
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::LangDir => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::StringLiteral(match e(tuple)? {
-                        ExpressionTerm::DirLangStringLiteral { direction, .. } => match direction {
-                            BaseDirection::Ltr => "ltr".into(),
-                            BaseDirection::Rtl => "rtl".into(),
+                    Ok(Some(ExpressionTerm::StringLiteral(
+                        match try_or_ok!(e(tuple)?) {
+                            ExpressionTerm::DirLangStringLiteral { direction, .. } => {
+                                match direction {
+                                    BaseDirection::Ltr => "ltr".into(),
+                                    BaseDirection::Rtl => "rtl".into(),
+                                }
+                            }
+                            ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => {
+                                return Ok(None);
+                            }
+                            #[cfg(feature = "sparql-12")]
+                            ExpressionTerm::Triple(_) => return Ok(None),
+                            _ => OxString::default(),
                         },
-                        ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => {
-                            return None;
-                        }
-                        #[cfg(feature = "sparql-12")]
-                        ExpressionTerm::Triple(_) => return None,
-                        _ => OxString::default(),
-                    }))
+                    )))
                 })
             }
             Function::Datatype => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::NamedNode(match e(tuple)? {
-                        ExpressionTerm::StringLiteral(_) => xsd::STRING,
-                        ExpressionTerm::LangStringLiteral { .. } => rdf::LANG_STRING,
-                        #[cfg(feature = "sparql-12")]
-                        ExpressionTerm::DirLangStringLiteral { .. } => rdf::DIR_LANG_STRING,
-                        ExpressionTerm::BooleanLiteral(_) => xsd::BOOLEAN,
-                        ExpressionTerm::IntegerLiteral(_) => xsd::INTEGER,
-                        ExpressionTerm::DecimalLiteral(_) => xsd::DECIMAL,
-                        ExpressionTerm::FloatLiteral(_) => xsd::FLOAT,
-                        ExpressionTerm::DoubleLiteral(_) => xsd::DOUBLE,
-                        ExpressionTerm::DateTimeLiteral(_) => xsd::DATE_TIME,
-                        #[cfg(feature = "sep-0002")]
-                        ExpressionTerm::DateLiteral(_) => xsd::DATE,
-                        #[cfg(feature = "sep-0002")]
-                        ExpressionTerm::TimeLiteral(_) => xsd::TIME,
-                        #[cfg(feature = "calendar-ext")]
-                        ExpressionTerm::GYearLiteral(_) => xsd::G_YEAR,
-                        #[cfg(feature = "calendar-ext")]
-                        ExpressionTerm::GYearMonthLiteral(_) => xsd::G_YEAR_MONTH,
-                        #[cfg(feature = "calendar-ext")]
-                        ExpressionTerm::GMonthLiteral(_) => xsd::G_MONTH,
-                        #[cfg(feature = "calendar-ext")]
-                        ExpressionTerm::GMonthDayLiteral(_) => xsd::G_MONTH_DAY,
-                        #[cfg(feature = "calendar-ext")]
-                        ExpressionTerm::GDayLiteral(_) => xsd::G_DAY,
-                        #[cfg(feature = "sep-0002")]
-                        ExpressionTerm::DurationLiteral(_) => xsd::DURATION,
-                        #[cfg(feature = "sep-0002")]
-                        ExpressionTerm::YearMonthDurationLiteral(_) => xsd::YEAR_MONTH_DURATION,
-                        #[cfg(feature = "sep-0002")]
-                        ExpressionTerm::DayTimeDurationLiteral(_) => xsd::DAY_TIME_DURATION,
-                        ExpressionTerm::OtherTypedLiteral { datatype, .. } => datatype,
-                        ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => {
-                            return None;
-                        }
-                        #[cfg(feature = "sparql-12")]
-                        ExpressionTerm::Triple(_) => return None,
-                    }))
+                    Ok(Some(ExpressionTerm::NamedNode(
+                        match try_or_ok!(e(tuple)?) {
+                            ExpressionTerm::StringLiteral(_) => xsd::STRING,
+                            ExpressionTerm::LangStringLiteral { .. } => rdf::LANG_STRING,
+                            #[cfg(feature = "sparql-12")]
+                            ExpressionTerm::DirLangStringLiteral { .. } => rdf::DIR_LANG_STRING,
+                            ExpressionTerm::BooleanLiteral(_) => xsd::BOOLEAN,
+                            ExpressionTerm::IntegerLiteral(_) => xsd::INTEGER,
+                            ExpressionTerm::DecimalLiteral(_) => xsd::DECIMAL,
+                            ExpressionTerm::FloatLiteral(_) => xsd::FLOAT,
+                            ExpressionTerm::DoubleLiteral(_) => xsd::DOUBLE,
+                            ExpressionTerm::DateTimeLiteral(_) => xsd::DATE_TIME,
+                            #[cfg(feature = "sep-0002")]
+                            ExpressionTerm::DateLiteral(_) => xsd::DATE,
+                            #[cfg(feature = "sep-0002")]
+                            ExpressionTerm::TimeLiteral(_) => xsd::TIME,
+                            #[cfg(feature = "calendar-ext")]
+                            ExpressionTerm::GYearLiteral(_) => xsd::G_YEAR,
+                            #[cfg(feature = "calendar-ext")]
+                            ExpressionTerm::GYearMonthLiteral(_) => xsd::G_YEAR_MONTH,
+                            #[cfg(feature = "calendar-ext")]
+                            ExpressionTerm::GMonthLiteral(_) => xsd::G_MONTH,
+                            #[cfg(feature = "calendar-ext")]
+                            ExpressionTerm::GMonthDayLiteral(_) => xsd::G_MONTH_DAY,
+                            #[cfg(feature = "calendar-ext")]
+                            ExpressionTerm::GDayLiteral(_) => xsd::G_DAY,
+                            #[cfg(feature = "sep-0002")]
+                            ExpressionTerm::DurationLiteral(_) => xsd::DURATION,
+                            #[cfg(feature = "sep-0002")]
+                            ExpressionTerm::YearMonthDurationLiteral(_) => xsd::YEAR_MONTH_DURATION,
+                            #[cfg(feature = "sep-0002")]
+                            ExpressionTerm::DayTimeDurationLiteral(_) => xsd::DAY_TIME_DURATION,
+                            ExpressionTerm::OtherTypedLiteral { datatype, .. } => datatype,
+                            ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => {
+                                return Ok(None);
+                            }
+                            #[cfg(feature = "sparql-12")]
+                            ExpressionTerm::Triple(_) => return Ok(None),
+                        },
+                    )))
                 })
             }
             Function::Iri => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 let base_iri = context.base_iri();
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::NamedNode(match e(tuple)? {
-                        ExpressionTerm::NamedNode(iri) => iri,
-                        ExpressionTerm::StringLiteral(iri) => {
-                            NamedNode::new_unchecked(if let Some(base_iri) = &base_iri {
-                                OxString::new_owned(&base_iri.resolve(&iri).ok()?.into_inner())
-                            } else {
-                                Iri::parse(iri).ok()?.into_inner()
-                            })
-                        }
-                        _ => return None,
-                    }))
+                    Ok(Some(ExpressionTerm::NamedNode(
+                        match try_or_ok!(e(tuple)?) {
+                            ExpressionTerm::NamedNode(iri) => iri,
+                            ExpressionTerm::StringLiteral(iri) => {
+                                NamedNode::new_unchecked(if let Some(base_iri) = &base_iri {
+                                    OxString::new_owned(
+                                        &try_or_ok!(base_iri.resolve(&iri).ok()).into_inner(),
+                                    )
+                                } else {
+                                    try_or_ok!(Iri::parse(iri).ok()).into_inner()
+                                })
+                            }
+                            _ => return Ok(None),
+                        },
+                    )))
                 })
             }
             Function::BNode => match parameters.first() {
                 Some(id) => {
                     let id = build_expression_evaluator(id, context)?;
                     Rc::new(move |tuple| {
-                        let ExpressionTerm::StringLiteral(id) = id(tuple)? else {
-                            return None;
+                        let ExpressionTerm::StringLiteral(id) = try_or_ok!(id(tuple)?) else {
+                            return Ok(None);
                         };
-                        Some(ExpressionTerm::BlankNode(BlankNode::new(id).ok()?))
+                        Ok(Some(ExpressionTerm::BlankNode(try_or_ok!(
+                            BlankNode::new(id).ok()
+                        ))))
                     })
                 }
-                None => Rc::new(|_| Some(ExpressionTerm::BlankNode(BlankNode::default()))),
+                None => Rc::new(|_| Ok(Some(ExpressionTerm::BlankNode(BlankNode::default())))),
             },
             Function::Rand => {
-                Rc::new(|_| Some(ExpressionTerm::DoubleLiteral(random::<f64>().into())))
+                Rc::new(|_| Ok(Some(ExpressionTerm::DoubleLiteral(random::<f64>().into()))))
             }
             Function::Abs => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| match e(tuple)? {
-                    ExpressionTerm::IntegerLiteral(value) => {
-                        Some(ExpressionTerm::IntegerLiteral(value.checked_abs()?))
-                    }
-                    ExpressionTerm::DecimalLiteral(value) => {
-                        Some(ExpressionTerm::DecimalLiteral(value.checked_abs()?))
-                    }
-                    ExpressionTerm::FloatLiteral(value) => {
-                        Some(ExpressionTerm::FloatLiteral(value.abs()))
-                    }
-                    ExpressionTerm::DoubleLiteral(value) => {
-                        Some(ExpressionTerm::DoubleLiteral(value.abs()))
-                    }
-                    _ => None,
+                Rc::new(move |tuple| {
+                    Ok(match try_or_ok!(e(tuple)?) {
+                        ExpressionTerm::IntegerLiteral(value) => Some(
+                            ExpressionTerm::IntegerLiteral(try_or_ok!(value.checked_abs())),
+                        ),
+                        ExpressionTerm::DecimalLiteral(value) => Some(
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(value.checked_abs())),
+                        ),
+                        ExpressionTerm::FloatLiteral(value) => {
+                            Some(ExpressionTerm::FloatLiteral(value.abs()))
+                        }
+                        ExpressionTerm::DoubleLiteral(value) => {
+                            Some(ExpressionTerm::DoubleLiteral(value.abs()))
+                        }
+                        _ => None,
+                    })
                 })
             }
             Function::Ceil => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| match e(tuple)? {
-                    ExpressionTerm::IntegerLiteral(value) => {
-                        Some(ExpressionTerm::IntegerLiteral(value))
-                    }
-                    ExpressionTerm::DecimalLiteral(value) => {
-                        Some(ExpressionTerm::DecimalLiteral(value.checked_ceil()?))
-                    }
-                    ExpressionTerm::FloatLiteral(value) => {
-                        Some(ExpressionTerm::FloatLiteral(value.ceil()))
-                    }
-                    ExpressionTerm::DoubleLiteral(value) => {
-                        Some(ExpressionTerm::DoubleLiteral(value.ceil()))
-                    }
-                    _ => None,
+                Rc::new(move |tuple| {
+                    Ok(match try_or_ok!(e(tuple)?) {
+                        ExpressionTerm::IntegerLiteral(value) => {
+                            Some(ExpressionTerm::IntegerLiteral(value))
+                        }
+                        ExpressionTerm::DecimalLiteral(value) => Some(
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(value.checked_ceil())),
+                        ),
+                        ExpressionTerm::FloatLiteral(value) => {
+                            Some(ExpressionTerm::FloatLiteral(value.ceil()))
+                        }
+                        ExpressionTerm::DoubleLiteral(value) => {
+                            Some(ExpressionTerm::DoubleLiteral(value.ceil()))
+                        }
+                        _ => None,
+                    })
                 })
             }
             Function::Floor => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| match e(tuple)? {
-                    ExpressionTerm::IntegerLiteral(value) => {
-                        Some(ExpressionTerm::IntegerLiteral(value))
-                    }
-                    ExpressionTerm::DecimalLiteral(value) => {
-                        Some(ExpressionTerm::DecimalLiteral(value.checked_floor()?))
-                    }
-                    ExpressionTerm::FloatLiteral(value) => {
-                        Some(ExpressionTerm::FloatLiteral(value.floor()))
-                    }
-                    ExpressionTerm::DoubleLiteral(value) => {
-                        Some(ExpressionTerm::DoubleLiteral(value.floor()))
-                    }
-                    _ => None,
+                Rc::new(move |tuple| {
+                    Ok(match try_or_ok!(e(tuple)?) {
+                        ExpressionTerm::IntegerLiteral(value) => {
+                            Some(ExpressionTerm::IntegerLiteral(value))
+                        }
+                        ExpressionTerm::DecimalLiteral(value) => Some(
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(value.checked_floor())),
+                        ),
+                        ExpressionTerm::FloatLiteral(value) => {
+                            Some(ExpressionTerm::FloatLiteral(value.floor()))
+                        }
+                        ExpressionTerm::DoubleLiteral(value) => {
+                            Some(ExpressionTerm::DoubleLiteral(value.floor()))
+                        }
+                        _ => None,
+                    })
                 })
             }
             Function::Round => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| match e(tuple)? {
-                    ExpressionTerm::IntegerLiteral(value) => {
-                        Some(ExpressionTerm::IntegerLiteral(value))
-                    }
-                    ExpressionTerm::DecimalLiteral(value) => {
-                        Some(ExpressionTerm::DecimalLiteral(value.checked_round()?))
-                    }
-                    ExpressionTerm::FloatLiteral(value) => {
-                        Some(ExpressionTerm::FloatLiteral(value.round()))
-                    }
-                    ExpressionTerm::DoubleLiteral(value) => {
-                        Some(ExpressionTerm::DoubleLiteral(value.round()))
-                    }
-                    _ => None,
+                Rc::new(move |tuple| {
+                    Ok(match try_or_ok!(e(tuple)?) {
+                        ExpressionTerm::IntegerLiteral(value) => {
+                            Some(ExpressionTerm::IntegerLiteral(value))
+                        }
+                        ExpressionTerm::DecimalLiteral(value) => Some(
+                            ExpressionTerm::DecimalLiteral(try_or_ok!(value.checked_round())),
+                        ),
+                        ExpressionTerm::FloatLiteral(value) => {
+                            Some(ExpressionTerm::FloatLiteral(value.round()))
+                        }
+                        ExpressionTerm::DoubleLiteral(value) => {
+                            Some(ExpressionTerm::DoubleLiteral(value.round()))
+                        }
+                        _ => None,
+                    })
                 })
             }
             Function::Concat => {
@@ -713,7 +840,8 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     let mut args = Vec::with_capacity(l.len());
                     let mut language = None;
                     for e in &l {
-                        let (value, e_language) = to_string_and_language(e(tuple)?)?;
+                        let (value, e_language) =
+                            try_or_ok!(to_string_and_language(try_or_ok!(e(tuple)?)));
                         if let Some(lang) = &language {
                             if *lang != e_language {
                                 language = Some(None)
@@ -723,10 +851,10 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                         }
                         args.push(value);
                     }
-                    Some(build_plain_literal(
+                    Ok(Some(build_plain_literal(
                         OxString::concat(args),
                         language.flatten(),
-                    ))
+                    )))
                 })
             }
             Function::SubStr => {
@@ -737,19 +865,21 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     .map(|l| build_expression_evaluator(l, context))
                     .transpose()?;
                 Rc::new(move |tuple| {
-                    let (source, language) = to_string_and_language(source(tuple)?)?;
+                    let (source, language) =
+                        try_or_ok!(to_string_and_language(try_or_ok!(source(tuple)?)));
 
-                    let starting_location: usize =
-                        if let ExpressionTerm::IntegerLiteral(v) = starting_loc(tuple)? {
-                            usize::try_from(i64::from(v)).ok()?
-                        } else {
-                            return None;
-                        };
+                    let starting_location: usize = if let ExpressionTerm::IntegerLiteral(v) =
+                        try_or_ok!(starting_loc(tuple)?)
+                    {
+                        try_or_ok!(usize::try_from(i64::from(v)).ok())
+                    } else {
+                        return Ok(None);
+                    };
                     let length = if let Some(length) = &length {
-                        if let ExpressionTerm::IntegerLiteral(v) = length(tuple)? {
-                            Some(usize::try_from(i64::from(v)).ok()?)
+                        if let ExpressionTerm::IntegerLiteral(v) = try_or_ok!(length(tuple)?) {
+                            Some(try_or_ok!(usize::try_from(i64::from(v)).ok()))
                         } else {
-                            return None;
+                            return Ok(None);
                         }
                     } else {
                         None
@@ -758,7 +888,7 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     // We want to slice on char indices, not byte indices
                     let mut start_iter = source
                         .char_indices()
-                        .skip(starting_location.checked_sub(1)?)
+                        .skip(try_or_ok!(starting_location.checked_sub(1)))
                         .peekable();
                     let result = if let Some((start_position, _)) = start_iter.peek().copied() {
                         OxString::new_owned(if let Some(length) = length {
@@ -774,16 +904,16 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     } else {
                         OxString::default()
                     };
-                    Some(build_plain_literal(result, language))
+                    Ok(Some(build_plain_literal(result, language)))
                 })
             }
             Function::StrLen => {
                 let arg = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    let (string, _) = to_string_and_language(arg(tuple)?)?;
-                    Some(ExpressionTerm::IntegerLiteral(
-                        i64::try_from(string.chars().count()).ok()?.into(),
-                    ))
+                    let (string, _) = try_or_ok!(to_string_and_language(try_or_ok!(arg(tuple)?)));
+                    Ok(Some(ExpressionTerm::IntegerLiteral(
+                        try_or_ok!(i64::try_from(string.chars().count()).ok()).into(),
+                    )))
                 })
             }
             Function::Replace => {
@@ -793,17 +923,20 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     compile_static_pattern_if_exists(&parameters[1], parameters.get(3))
                 {
                     Rc::new(move |tuple| {
-                        let (text, language) = to_string_and_language(arg(tuple)?)?;
-                        let ExpressionTerm::StringLiteral(replacement) = replacement(tuple)? else {
-                            return None;
+                        let (text, language) =
+                            try_or_ok!(to_string_and_language(try_or_ok!(arg(tuple)?)));
+                        let ExpressionTerm::StringLiteral(replacement) =
+                            try_or_ok!(replacement(tuple)?)
+                        else {
+                            return Ok(None);
                         };
-                        Some(build_plain_literal(
+                        Ok(Some(build_plain_literal(
                             match regex.replace_all(text.as_str(), replacement.as_str()) {
                                 Cow::Owned(replaced) => OxString::new_owned(&replaced),
                                 Cow::Borrowed(_) => text,
                             },
                             language,
-                        ))
+                        )))
                     })
                 } else {
                     let pattern = build_expression_evaluator(&parameters[1], context)?;
@@ -812,71 +945,80 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                         .map(|flags| build_expression_evaluator(flags, context))
                         .transpose()?;
                     Rc::new(move |tuple| {
-                        let ExpressionTerm::StringLiteral(pattern) = pattern(tuple)? else {
-                            return None;
+                        let ExpressionTerm::StringLiteral(pattern) = try_or_ok!(pattern(tuple)?)
+                        else {
+                            return Ok(None);
                         };
                         let options = if let Some(flags) = &flags {
-                            let ExpressionTerm::StringLiteral(options) = flags(tuple)? else {
-                                return None;
+                            let ExpressionTerm::StringLiteral(options) = try_or_ok!(flags(tuple)?)
+                            else {
+                                return Ok(None);
                             };
                             Some(options)
                         } else {
                             None
                         };
-                        let regex = compile_pattern(&pattern, options.as_deref())?;
-                        let (text, language) = to_string_and_language(arg(tuple)?)?;
-                        let ExpressionTerm::StringLiteral(replacement) = replacement(tuple)? else {
-                            return None;
+                        let regex = try_or_ok!(compile_pattern(&pattern, options.as_deref()));
+                        let (text, language) =
+                            try_or_ok!(to_string_and_language(try_or_ok!(arg(tuple)?)));
+                        let ExpressionTerm::StringLiteral(replacement) =
+                            try_or_ok!(replacement(tuple)?)
+                        else {
+                            return Ok(None);
                         };
-                        Some(build_plain_literal(
+                        Ok(Some(build_plain_literal(
                             match regex.replace_all(text.as_str(), replacement.as_str()) {
                                 Cow::Owned(replaced) => OxString::new_owned(&replaced),
                                 Cow::Borrowed(_) => text,
                             },
                             language,
-                        ))
+                        )))
                     })
                 }
             }
             Function::UCase => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    let (mut value, language) = to_string_and_language(e(tuple)?)?;
+                    let (mut value, language) =
+                        try_or_ok!(to_string_and_language(try_or_ok!(e(tuple)?)));
                     let value = if value.is_ascii() {
                         value.make_mut().make_ascii_uppercase();
                         value
                     } else {
                         OxString::new_owned(&value.to_uppercase())
                     };
-                    Some(build_plain_literal(value, language))
+                    Ok(Some(build_plain_literal(value, language)))
                 })
             }
             Function::LCase => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    let (mut value, language) = to_string_and_language(e(tuple)?)?;
+                    let (mut value, language) =
+                        try_or_ok!(to_string_and_language(try_or_ok!(e(tuple)?)));
                     let value = if value.is_ascii() {
                         value.make_mut().make_ascii_lowercase();
                         value
                     } else {
                         OxString::new_owned(&value.to_lowercase())
                     };
-                    Some(build_plain_literal(value, language))
+                    Ok(Some(build_plain_literal(value, language)))
                 })
             }
             Function::StrStarts => {
                 let arg1 = build_expression_evaluator(&parameters[0], context)?;
                 let arg2 = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let (arg1, arg2, _) =
-                        to_argument_compatible_strings(arg1(tuple)?, arg2(tuple)?)?;
-                    Some(arg1.starts_with(arg2.as_str()).into())
+                    let (arg1, arg2, _) = try_or_ok!(to_argument_compatible_strings(
+                        try_or_ok!(arg1(tuple)?),
+                        try_or_ok!(arg2(tuple)?),
+                    ));
+                    Ok(Some(arg1.starts_with(arg2.as_str()).into()))
                 })
             }
             Function::EncodeForUri => {
                 let ltrl = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    let (ltlr, _) = to_string_and_language(ltrl(tuple)?)?;
+                    let (ltlr, _) = try_or_ok!(to_string_and_language(try_or_ok!(ltrl(tuple)?)));
                     let mut result = Vec::with_capacity(ltlr.len());
                     for c in ltlr.bytes() {
                         match c {
@@ -900,63 +1042,71 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                             }
                         }
                     }
-                    Some(ExpressionTerm::StringLiteral(OxString::new_owned(
-                        str::from_utf8(&result).ok()?,
-                    )))
+                    Ok(Some(ExpressionTerm::StringLiteral(OxString::new_owned(
+                        try_or_ok!(str::from_utf8(&result).ok()),
+                    ))))
                 })
             }
             Function::StrEnds => {
                 let arg1 = build_expression_evaluator(&parameters[0], context)?;
                 let arg2 = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let (arg1, arg2, _) =
-                        to_argument_compatible_strings(arg1(tuple)?, arg2(tuple)?)?;
-                    Some(arg1.ends_with(arg2.as_str()).into())
+                    let (arg1, arg2, _) = try_or_ok!(to_argument_compatible_strings(
+                        try_or_ok!(arg1(tuple)?),
+                        try_or_ok!(arg2(tuple)?),
+                    ));
+                    Ok(Some(arg1.ends_with(arg2.as_str()).into()))
                 })
             }
             Function::Contains => {
                 let arg1 = build_expression_evaluator(&parameters[0], context)?;
                 let arg2 = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let (arg1, arg2, _) =
-                        to_argument_compatible_strings(arg1(tuple)?, arg2(tuple)?)?;
-                    Some(arg1.contains(arg2.as_str()).into())
+                    let (arg1, arg2, _) = try_or_ok!(to_argument_compatible_strings(
+                        try_or_ok!(arg1(tuple)?),
+                        try_or_ok!(arg2(tuple)?),
+                    ));
+                    Ok(Some(arg1.contains(arg2.as_str()).into()))
                 })
             }
             Function::StrBefore => {
                 let arg1 = build_expression_evaluator(&parameters[0], context)?;
                 let arg2 = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let (arg1, arg2, language) =
-                        to_argument_compatible_strings(arg1(tuple)?, arg2(tuple)?)?;
-                    Some(if let Some(position) = arg1.find(arg2.as_str()) {
+                    let (arg1, arg2, language) = try_or_ok!(to_argument_compatible_strings(
+                        try_or_ok!(arg1(tuple)?),
+                        try_or_ok!(arg2(tuple)?),
+                    ));
+                    Ok(Some(if let Some(position) = arg1.find(arg2.as_str()) {
                         build_plain_literal(OxString::new_owned(&arg1[..position]), language)
                     } else {
                         ExpressionTerm::StringLiteral(OxString::default())
-                    })
+                    }))
                 })
             }
             Function::StrAfter => {
                 let arg1 = build_expression_evaluator(&parameters[0], context)?;
                 let arg2 = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let (arg1, arg2, language) =
-                        to_argument_compatible_strings(arg1(tuple)?, arg2(tuple)?)?;
-                    Some(if let Some(position) = arg1.find(arg2.as_str()) {
+                    let (arg1, arg2, language) = try_or_ok!(to_argument_compatible_strings(
+                        try_or_ok!(arg1(tuple)?),
+                        try_or_ok!(arg2(tuple)?),
+                    ));
+                    Ok(Some(if let Some(position) = arg1.find(arg2.as_str()) {
                         build_plain_literal(
                             OxString::new_owned(&arg1[position + arg2.len()..]),
                             language,
                         )
                     } else {
                         ExpressionTerm::StringLiteral(OxString::default())
-                    })
+                    }))
                 })
             }
             Function::Year => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::IntegerLiteral(
-                        match e(tuple)? {
+                    Ok(Some(ExpressionTerm::IntegerLiteral(
+                        match try_or_ok!(e(tuple)?) {
                             ExpressionTerm::DateTimeLiteral(date_time) => date_time.year(),
                             #[cfg(feature = "sep-0002")]
                             ExpressionTerm::DateLiteral(date) => date.year(),
@@ -964,17 +1114,17 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                             ExpressionTerm::GYearMonthLiteral(year_month) => year_month.year(),
                             #[cfg(feature = "calendar-ext")]
                             ExpressionTerm::GYearLiteral(year) => year.year(),
-                            _ => return None,
+                            _ => return Ok(None),
                         }
                         .into(),
-                    ))
+                    )))
                 })
             }
             Function::Month => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::IntegerLiteral(
-                        match e(tuple)? {
+                    Ok(Some(ExpressionTerm::IntegerLiteral(
+                        match try_or_ok!(e(tuple)?) {
                             ExpressionTerm::DateTimeLiteral(date_time) => date_time.month(),
                             #[cfg(feature = "sep-0002")]
                             ExpressionTerm::DateLiteral(date) => date.month(),
@@ -984,17 +1134,17 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                             ExpressionTerm::GMonthDayLiteral(month_day) => month_day.month(),
                             #[cfg(feature = "calendar-ext")]
                             ExpressionTerm::GMonthLiteral(month) => month.month(),
-                            _ => return None,
+                            _ => return Ok(None),
                         }
                         .into(),
-                    ))
+                    )))
                 })
             }
             Function::Day => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::IntegerLiteral(
-                        match e(tuple)? {
+                    Ok(Some(ExpressionTerm::IntegerLiteral(
+                        match try_or_ok!(e(tuple)?) {
                             ExpressionTerm::DateTimeLiteral(date_time) => date_time.day(),
                             #[cfg(feature = "sep-0002")]
                             ExpressionTerm::DateLiteral(date) => date.day(),
@@ -1002,62 +1152,66 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                             ExpressionTerm::GMonthDayLiteral(month_day) => month_day.day(),
                             #[cfg(feature = "calendar-ext")]
                             ExpressionTerm::GDayLiteral(day) => day.day(),
-                            _ => return None,
+                            _ => return Ok(None),
                         }
                         .into(),
-                    ))
+                    )))
                 })
             }
             Function::Hours => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::IntegerLiteral(
-                        match e(tuple)? {
+                    Ok(Some(ExpressionTerm::IntegerLiteral(
+                        match try_or_ok!(e(tuple)?) {
                             ExpressionTerm::DateTimeLiteral(date_time) => date_time.hour(),
                             #[cfg(feature = "sep-0002")]
                             ExpressionTerm::TimeLiteral(time) => time.hour(),
-                            _ => return None,
+                            _ => return Ok(None),
                         }
                         .into(),
-                    ))
+                    )))
                 })
             }
             Function::Minutes => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::IntegerLiteral(
-                        match e(tuple)? {
+                    Ok(Some(ExpressionTerm::IntegerLiteral(
+                        match try_or_ok!(e(tuple)?) {
                             ExpressionTerm::DateTimeLiteral(date_time) => date_time.minute(),
                             #[cfg(feature = "sep-0002")]
                             ExpressionTerm::TimeLiteral(time) => time.minute(),
-                            _ => return None,
+                            _ => return Ok(None),
                         }
                         .into(),
-                    ))
+                    )))
                 })
             }
             Function::Seconds => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTerm::DecimalLiteral(match e(tuple)? {
-                        ExpressionTerm::DateTimeLiteral(date_time) => date_time.second(),
-                        #[cfg(feature = "sep-0002")]
-                        ExpressionTerm::TimeLiteral(time) => time.second(),
-                        _ => return None,
-                    }))
+                    Ok(Some(ExpressionTerm::DecimalLiteral(
+                        match try_or_ok!(e(tuple)?) {
+                            ExpressionTerm::DateTimeLiteral(date_time) => date_time.second(),
+                            #[cfg(feature = "sep-0002")]
+                            ExpressionTerm::TimeLiteral(time) => time.second(),
+                            _ => return Ok(None),
+                        },
+                    )))
                 })
             }
             Function::Timezone => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    let result = match e(tuple)? {
+                    let result = try_or_ok!(match try_or_ok!(e(tuple)?) {
                         ExpressionTerm::DateTimeLiteral(date_time) => date_time.timezone(),
                         #[cfg(feature = "sep-0002")]
                         ExpressionTerm::TimeLiteral(time) => time.timezone(),
                         #[cfg(feature = "sep-0002")]
                         ExpressionTerm::DateLiteral(date) => date.timezone(),
                         #[cfg(feature = "calendar-ext")]
-                        ExpressionTerm::GYearMonthLiteral(year_month) => year_month.timezone(),
+                        ExpressionTerm::GYearMonthLiteral(year_month) => {
+                            year_month.timezone()
+                        }
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GYearLiteral(year) => year.timezone(),
                         #[cfg(feature = "calendar-ext")]
@@ -1067,24 +1221,24 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GMonthLiteral(month) => month.timezone(),
                         _ => None,
-                    }?;
+                    });
                     #[cfg(feature = "sep-0002")]
                     {
-                        Some(ExpressionTerm::DayTimeDurationLiteral(result))
+                        Ok(Some(ExpressionTerm::DayTimeDurationLiteral(result)))
                     }
                     #[cfg(not(feature = "sep-0002"))]
                     {
-                        Some(ExpressionTerm::OtherTypedLiteral {
+                        Ok(Some(ExpressionTerm::OtherTypedLiteral {
                             value: OxString::new_owned(&result.to_string()),
                             datatype: xsd::DAY_TIME_DURATION,
-                        })
+                        }))
                     }
                 })
             }
             Function::Tz => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    let timezone_offset = match e(tuple)? {
+                    let timezone_offset = match try_or_ok!(e(tuple)?) {
                         ExpressionTerm::DateTimeLiteral(date_time) => date_time.timezone_offset(),
                         #[cfg(feature = "sep-0002")]
                         ExpressionTerm::TimeLiteral(time) => time.timezone_offset(),
@@ -1102,13 +1256,13 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                         ExpressionTerm::GDayLiteral(day) => day.timezone_offset(),
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GMonthLiteral(month) => month.timezone_offset(),
-                        _ => return None,
+                        _ => return Ok(None),
                     };
-                    Some(ExpressionTerm::StringLiteral(
+                    Ok(Some(ExpressionTerm::StringLiteral(
                         timezone_offset.map_or_else(OxString::default, |o| {
                             OxString::new_owned(o.to_string().as_str())
                         }),
-                    ))
+                    )))
                 })
             }
             #[cfg(feature = "sep-0002")]
@@ -1116,66 +1270,76 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                 let dt = build_expression_evaluator(&parameters[0], context)?;
                 let tz = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let timezone_offset = Some(
-                        match tz(tuple)? {
+                    let timezone_offset = Some(try_or_ok!(
+                        match try_or_ok!(tz(tuple)?) {
                             ExpressionTerm::DayTimeDurationLiteral(tz) => {
                                 TimezoneOffset::try_from(tz)
                             }
-                            ExpressionTerm::DurationLiteral(tz) => TimezoneOffset::try_from(tz),
-                            _ => return None,
+                            ExpressionTerm::DurationLiteral(tz) => {
+                                TimezoneOffset::try_from(tz)
+                            }
+                            _ => return Ok(None),
                         }
-                        .ok()?,
-                    );
-                    Some(match dt(tuple)? {
+                        .ok()
+                    ));
+                    Ok(Some(match try_or_ok!(dt(tuple)?) {
                         ExpressionTerm::DateTimeLiteral(date_time) => {
-                            ExpressionTerm::DateTimeLiteral(date_time.adjust(timezone_offset)?)
+                            ExpressionTerm::DateTimeLiteral(try_or_ok!(
+                                date_time.adjust(timezone_offset)
+                            ))
                         }
                         ExpressionTerm::TimeLiteral(time) => {
-                            ExpressionTerm::TimeLiteral(time.adjust(timezone_offset)?)
+                            ExpressionTerm::TimeLiteral(try_or_ok!(time.adjust(timezone_offset)))
                         }
                         ExpressionTerm::DateLiteral(date) => {
-                            ExpressionTerm::DateLiteral(date.adjust(timezone_offset)?)
+                            ExpressionTerm::DateLiteral(try_or_ok!(date.adjust(timezone_offset)))
                         }
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GYearMonthLiteral(year_month) => {
-                            ExpressionTerm::GYearMonthLiteral(year_month.adjust(timezone_offset)?)
+                            ExpressionTerm::GYearMonthLiteral(try_or_ok!(
+                                year_month.adjust(timezone_offset)
+                            ))
                         }
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GYearLiteral(year) => {
-                            ExpressionTerm::GYearLiteral(year.adjust(timezone_offset)?)
+                            ExpressionTerm::GYearLiteral(try_or_ok!(year.adjust(timezone_offset)))
                         }
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GMonthDayLiteral(month_day) => {
-                            ExpressionTerm::GMonthDayLiteral(month_day.adjust(timezone_offset)?)
+                            ExpressionTerm::GMonthDayLiteral(try_or_ok!(
+                                month_day.adjust(timezone_offset)
+                            ))
                         }
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GDayLiteral(day) => {
-                            ExpressionTerm::GDayLiteral(day.adjust(timezone_offset)?)
+                            ExpressionTerm::GDayLiteral(try_or_ok!(day.adjust(timezone_offset)))
                         }
                         #[cfg(feature = "calendar-ext")]
                         ExpressionTerm::GMonthLiteral(month) => {
-                            ExpressionTerm::GMonthLiteral(month.adjust(timezone_offset)?)
+                            ExpressionTerm::GMonthLiteral(try_or_ok!(month.adjust(timezone_offset)))
                         }
-                        _ => return None,
-                    })
+                        _ => return Ok(None),
+                    }))
                 })
             }
             Function::Now => {
                 let now = context.now();
-                Rc::new(move |_| Some(ExpressionTerm::DateTimeLiteral(now)))
+                Rc::new(move |_| Ok(Some(ExpressionTerm::DateTimeLiteral(now))))
             }
             Function::Uuid => Rc::new(move |_| {
                 let mut buffer = String::with_capacity(44);
                 buffer.push_str("urn:uuid:");
                 generate_uuid(&mut buffer);
-                Some(ExpressionTerm::NamedNode(NamedNode::new_unchecked(
+                Ok(Some(ExpressionTerm::NamedNode(NamedNode::new_unchecked(
                     OxString::new_owned(&buffer),
-                )))
+                ))))
             }),
             Function::StrUuid => Rc::new(move |_| {
                 let mut buffer = String::with_capacity(36);
                 generate_uuid(&mut buffer);
-                Some(ExpressionTerm::StringLiteral(OxString::new_owned(&buffer)))
+                Ok(Some(ExpressionTerm::StringLiteral(OxString::new_owned(
+                    &buffer,
+                ))))
             }),
             Function::Md5 => build_hash_expression_evaluator::<_, Md5>(parameters, context)?,
             Function::Sha1 => build_hash_expression_evaluator::<_, Sha1>(parameters, context)?,
@@ -1186,16 +1350,20 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                 let lexical_form = build_expression_evaluator(&parameters[0], context)?;
                 let lang_tag = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let ExpressionTerm::StringLiteral(value) = lexical_form(tuple)? else {
-                        return None;
+                    let ExpressionTerm::StringLiteral(value) = try_or_ok!(lexical_form(tuple)?)
+                    else {
+                        return Ok(None);
                     };
-                    let ExpressionTerm::StringLiteral(language) = lang_tag(tuple)? else {
-                        return None;
+                    let ExpressionTerm::StringLiteral(language) = try_or_ok!(lang_tag(tuple)?)
+                    else {
+                        return Ok(None);
                     };
-                    Some(
-                        Term::from(Literal::new_language_tagged_literal(value, language).ok()?)
-                            .into(),
-                    )
+                    Ok(Some(
+                        Term::from(try_or_ok!(
+                            Literal::new_language_tagged_literal(value, language).ok()
+                        ))
+                        .into(),
+                    ))
                 })
             }
             #[cfg(feature = "sparql-12")]
@@ -1204,101 +1372,121 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                 let lang_tag = build_expression_evaluator(&parameters[1], context)?;
                 let direction = build_expression_evaluator(&parameters[2], context)?;
                 Rc::new(move |tuple| {
-                    let ExpressionTerm::StringLiteral(value) = lexical_form(tuple)? else {
-                        return None;
+                    let ExpressionTerm::StringLiteral(value) = try_or_ok!(lexical_form(tuple)?)
+                    else {
+                        return Ok(None);
                     };
-                    let ExpressionTerm::StringLiteral(language) = lang_tag(tuple)? else {
-                        return None;
+                    let ExpressionTerm::StringLiteral(language) = try_or_ok!(lang_tag(tuple)?)
+                    else {
+                        return Ok(None);
                     };
-                    let ExpressionTerm::StringLiteral(direction) = direction(tuple)? else {
-                        return None;
+                    let ExpressionTerm::StringLiteral(direction) = try_or_ok!(direction(tuple)?)
+                    else {
+                        return Ok(None);
                     };
                     let direction = match direction.as_str() {
                         "ltr" => BaseDirection::Ltr,
                         "rtl" => BaseDirection::Rtl,
-                        _ => return None,
+                        _ => return Ok(None),
                     };
-                    Some(
-                        Term::from(
+                    Ok(Some(
+                        Term::from(try_or_ok!(
                             Literal::new_directional_language_tagged_literal(
                                 value, language, direction,
                             )
-                            .ok()?,
-                        )
+                            .ok()
+                        ))
                         .into(),
-                    )
+                    ))
                 })
             }
             Function::StrDt => {
                 let lexical_form = build_expression_evaluator(&parameters[0], context)?;
                 let datatype = build_expression_evaluator(&parameters[1], context)?;
                 Rc::new(move |tuple| {
-                    let ExpressionTerm::StringLiteral(value) = lexical_form(tuple)? else {
-                        return None;
+                    let ExpressionTerm::StringLiteral(value) = try_or_ok!(lexical_form(tuple)?)
+                    else {
+                        return Ok(None);
                     };
-                    let ExpressionTerm::NamedNode(datatype) = datatype(tuple)? else {
-                        return None;
+                    let ExpressionTerm::NamedNode(datatype) = try_or_ok!(datatype(tuple)?) else {
+                        return Ok(None);
                     };
-                    Some(Term::from(Literal::new_typed_literal(value, datatype)).into())
+                    Ok(Some(
+                        Term::from(Literal::new_typed_literal(value, datatype)).into(),
+                    ))
                 })
             }
 
             Function::IsIri => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| Some(matches!(e(tuple)?, ExpressionTerm::NamedNode(_)).into()))
+                Rc::new(move |tuple| {
+                    Ok(Some(
+                        matches!(try_or_ok!(e(tuple)?), ExpressionTerm::NamedNode(_)).into(),
+                    ))
+                })
             }
             Function::IsBlank => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| Some(matches!(e(tuple)?, ExpressionTerm::BlankNode(_)).into()))
+                Rc::new(move |tuple| {
+                    Ok(Some(
+                        matches!(try_or_ok!(e(tuple)?), ExpressionTerm::BlankNode(_)).into(),
+                    ))
+                })
             }
             Function::IsLiteral => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(
-                        match e(tuple)? {
+                    Ok(Some(
+                        match try_or_ok!(e(tuple)?) {
                             ExpressionTerm::NamedNode(_) | ExpressionTerm::BlankNode(_) => false,
                             #[cfg(feature = "sparql-12")]
                             ExpressionTerm::Triple(_) => false,
                             _ => true,
                         }
                         .into(),
-                    )
+                    ))
                 })
             }
             Function::IsNumeric => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(
+                    Ok(Some(
                         matches!(
-                            e(tuple)?,
+                            try_or_ok!(e(tuple)?),
                             ExpressionTerm::IntegerLiteral(_)
                                 | ExpressionTerm::DecimalLiteral(_)
                                 | ExpressionTerm::FloatLiteral(_)
                                 | ExpressionTerm::DoubleLiteral(_)
                         )
                         .into(),
-                    )
+                    ))
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::HasLang => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(
+                    Ok(Some(
                         matches!(
-                            e(tuple)?,
+                            try_or_ok!(e(tuple)?),
                             ExpressionTerm::LangStringLiteral { .. }
                                 | ExpressionTerm::DirLangStringLiteral { .. }
                         )
                         .into(),
-                    )
+                    ))
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::HasLangDir => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    Some(matches!(e(tuple)?, ExpressionTerm::DirLangStringLiteral { .. }).into())
+                    Ok(Some(
+                        matches!(
+                            try_or_ok!(e(tuple)?),
+                            ExpressionTerm::DirLangStringLiteral { .. }
+                        )
+                        .into(),
+                    ))
                 })
             }
             Function::Regex => {
@@ -1307,8 +1495,9 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                     compile_static_pattern_if_exists(&parameters[1], parameters.get(2))
                 {
                     Rc::new(move |tuple| {
-                        let (text, _) = to_string_and_language(text(tuple)?)?;
-                        Some(regex.is_match(&text).into())
+                        let (text, _) =
+                            try_or_ok!(to_string_and_language(try_or_ok!(text(tuple)?)));
+                        Ok(Some(regex.is_match(&text).into()))
                     })
                 } else {
                     let pattern = build_expression_evaluator(&parameters[1], context)?;
@@ -1317,20 +1506,23 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                         .map(|flags| build_expression_evaluator(flags, context))
                         .transpose()?;
                     Rc::new(move |tuple| {
-                        let ExpressionTerm::StringLiteral(pattern) = pattern(tuple)? else {
-                            return None;
+                        let ExpressionTerm::StringLiteral(pattern) = try_or_ok!(pattern(tuple)?)
+                        else {
+                            return Ok(None);
                         };
                         let options = if let Some(flags) = &flags {
-                            let ExpressionTerm::StringLiteral(options) = flags(tuple)? else {
-                                return None;
+                            let ExpressionTerm::StringLiteral(options) = try_or_ok!(flags(tuple)?)
+                            else {
+                                return Ok(None);
                             };
                             Some(options)
                         } else {
                             None
                         };
-                        let regex = compile_pattern(&pattern, options.as_deref())?;
-                        let (text, _) = to_string_and_language(text(tuple)?)?;
-                        Some(regex.is_match(&text).into())
+                        let regex = try_or_ok!(compile_pattern(&pattern, options.as_deref()));
+                        let (text, _) =
+                            try_or_ok!(to_string_and_language(try_or_ok!(text(tuple)?)));
+                        Ok(Some(regex.is_match(&text).into()))
                     })
                 }
             }
@@ -1340,46 +1532,57 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                 let p = build_expression_evaluator(&parameters[1], context)?;
                 let o = build_expression_evaluator(&parameters[2], context)?;
                 Rc::new(move |tuple| {
-                    Some(ExpressionTriple::new(s(tuple)?, p(tuple)?, o(tuple)?)?.into())
+                    Ok(Some(
+                        try_or_ok!(ExpressionTriple::new(
+                            try_or_ok!(s(tuple)?),
+                            try_or_ok!(p(tuple)?),
+                            try_or_ok!(o(tuple)?),
+                        ))
+                        .into(),
+                    ))
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::Subject => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    if let ExpressionTerm::Triple(t) = e(tuple)? {
+                    Ok(if let ExpressionTerm::Triple(t) = try_or_ok!(e(tuple)?) {
                         Some(t.subject.into())
                     } else {
                         None
-                    }
+                    })
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::Predicate => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    if let ExpressionTerm::Triple(t) = e(tuple)? {
+                    Ok(if let ExpressionTerm::Triple(t) = try_or_ok!(e(tuple)?) {
                         Some(t.predicate.into())
                     } else {
                         None
-                    }
+                    })
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::Object => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
                 Rc::new(move |tuple| {
-                    if let ExpressionTerm::Triple(t) = e(tuple)? {
+                    Ok(if let ExpressionTerm::Triple(t) = try_or_ok!(e(tuple)?) {
                         Some(t.object)
                     } else {
                         None
-                    }
+                    })
                 })
             }
             #[cfg(feature = "sparql-12")]
             Function::IsTriple => {
                 let e = build_expression_evaluator(&parameters[0], context)?;
-                Rc::new(move |tuple| Some(matches!(e(tuple)?, ExpressionTerm::Triple(_)).into()))
+                Rc::new(move |tuple| {
+                    Ok(Some(
+                        matches!(try_or_ok!(e(tuple)?), ExpressionTerm::Triple(_)).into(),
+                    ))
+                })
             }
             Function::Custom(function_name) => {
                 if let Some(function) = context.custom_functions().get(function_name).cloned() {
@@ -1388,11 +1591,11 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                         .map(|e| build_expression_evaluator(e, context))
                         .collect::<Result<Vec<_>, _>>()?;
                     return Ok(Rc::new(move |tuple| {
-                        let args = args
-                            .iter()
-                            .map(|f| Some(f(tuple)?.into()))
-                            .collect::<Option<Vec<_>>>()?;
-                        Some(function(&args)?.into())
+                        let mut values = Vec::with_capacity(args.len());
+                        for evaluator in &args {
+                            values.push(try_or_ok!(evaluator(tuple)?).into());
+                        }
+                        Ok(function(&values).map(Into::into))
                     }));
                 }
 
@@ -1409,7 +1612,7 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
                                 );
                             }
                             let e = build_expression_evaluator(&parameters[0], context)?;
-                            return Ok(Rc::new(move |tuple| ($eval)(e(tuple)?)));
+                            return Ok(Rc::new(move |tuple| Ok(($eval)(try_or_ok!(e(tuple)?)))));
                         }
                     }};
                 }
@@ -1659,22 +1862,30 @@ pub fn build_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
 pub fn try_build_internal_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>>(
     expression: &Expression,
     context: &mut C,
-) -> Result<Option<ExpressionEvaluator<'a, C::Tuple, C::Term>>, ExpressionEvaluationError<C::Error>>
+) -> Result<
+    Option<ExpressionEvaluator<'a, C::Tuple, C::Term, C::Error>>,
+    ExpressionEvaluationError<C::Error>,
+>
+where
+    C::Error: 'a,
 {
     Ok(Some(match expression {
         Expression::NamedNode(t) => {
             let t = context
                 .internalize_named_node(t)
                 .map_err(ExpressionEvaluationError::Context)?;
-            Rc::new(move |_| Some(t.clone()))
+            Rc::new(move |_| Ok(Some(t.clone())))
         }
         Expression::Literal(t) => {
             let t = context
                 .internalize_literal(t)
                 .map_err(ExpressionEvaluationError::Context)?;
-            Rc::new(move |_| Some(t.clone()))
+            Rc::new(move |_| Ok(Some(t.clone())))
         }
-        Expression::Variable(v) => Rc::new(context.build_variable_lookup(v)),
+        Expression::Variable(v) => {
+            let lookup = context.build_variable_lookup(v);
+            Rc::new(move |tuple| Ok(lookup(tuple)))
+        }
         Expression::Coalesce(l) => {
             let Some(l) = l
                 .iter()
@@ -1685,11 +1896,11 @@ pub fn try_build_internal_expression_evaluator<'a, C: ExpressionEvaluatorContext
             };
             Rc::new(move |tuple| {
                 for e in &l {
-                    if let Some(result) = e(tuple) {
-                        return Some(result);
+                    if let Some(result) = e(tuple)? {
+                        return Ok(Some(result));
                     }
                 }
-                None
+                Ok(None)
             })
         }
         Expression::If(a, b, c) => {
@@ -1701,7 +1912,7 @@ pub fn try_build_internal_expression_evaluator<'a, C: ExpressionEvaluatorContext
                 return Ok(None);
             };
             Rc::new(move |tuple| {
-                if a(tuple)?.effective_boolean_value()? {
+                if try_or_ok!(try_or_ok!(a(tuple)?).effective_boolean_value()) {
                     b(tuple)
                 } else {
                     c(tuple)
@@ -1715,15 +1926,22 @@ pub fn try_build_internal_expression_evaluator<'a, C: ExpressionEvaluatorContext
 fn build_hash_expression_evaluator<'a, C: ExpressionEvaluatorContext<'a>, H: Digest>(
     parameters: &[Expression],
     context: &mut C,
-) -> Result<ExpressionEvaluator<'a, C::Tuple, ExpressionTerm>, ExpressionEvaluationError<C::Error>>
+) -> Result<
+    ExpressionEvaluator<'a, C::Tuple, ExpressionTerm, C::Error>,
+    ExpressionEvaluationError<C::Error>,
+>
+where
+    C::Error: 'a,
 {
     let arg = build_expression_evaluator(&parameters[0], context)?;
     Ok(Rc::new(move |tuple| {
-        let ExpressionTerm::StringLiteral(input) = arg(tuple)? else {
-            return None;
+        let ExpressionTerm::StringLiteral(input) = try_or_ok!(arg(tuple)?) else {
+            return Ok(None);
         };
         let hash = hex::encode(H::new().chain_update(input.as_str()).finalize());
-        Some(ExpressionTerm::StringLiteral(OxString::new_owned(&hash)))
+        Ok(Some(ExpressionTerm::StringLiteral(OxString::new_owned(
+            &hash,
+        ))))
     }))
 }
 

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -365,18 +365,20 @@ impl QueryEvaluator {
 
             fn build_internalize_expression_term(
                 &mut self,
-            ) -> impl Fn(ExpressionTerm) -> Option<Term> + 'a {
-                |t| Some(t.into())
+            ) -> impl Fn(ExpressionTerm) -> Result<Term, QueryEvaluationError> + 'a {
+                |t| Ok(t.into())
             }
 
             fn build_externalize_expression_term(
                 &mut self,
-            ) -> impl Fn(Term) -> Option<ExpressionTerm> + 'a {
-                |t| Some(t.into())
+            ) -> impl Fn(Term) -> Result<ExpressionTerm, QueryEvaluationError> + 'a {
+                |t| Ok(t.into())
             }
 
-            fn build_externalize_term(&mut self) -> impl Fn(Term) -> Option<Term> + 'a {
-                Some
+            fn build_externalize_term(
+                &mut self,
+            ) -> impl Fn(Term) -> Result<Term, QueryEvaluationError> + 'a {
+                Ok
             }
 
             fn now(&mut self) -> DateTime {
@@ -400,11 +402,13 @@ impl QueryEvaluator {
             },
         )
         .ok()?(&substitutions.into_iter().collect::<HashMap<_, _>>())
+        .ok()
+        .flatten()
     }
 
     /// Evaluates a SPARQL expression against an empty dataset with optional variable substitutions.
     ///
-    /// Returns the computed term or `None` if an error occurs or the expression is invalid.
+    /// Returns the computed term or `None` if the expression is invalid.
     pub fn evaluate_expression<'a>(
         &self,
         expression: &sparopt::algebra::Expression,


### PR DESCRIPTION
Do not hide them as regular evaluation error