### PR TITLE
oxrdf: expose per-blank-node canonical hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 - `sparopt`: `GraphPattern::join_order_variables`, exposing the join / variable-elimination order chosen by `Optimizer::optimize_graph_pattern` for consumption by external execution engines (e.g. worst-case-optimal join executors).
+- `oxrdf`: the `Dataset::canonical_hashes` method returning a content-derived hash per blank node without modifying the dataset.
+- Python: the `Dataset.canonical_hashes` method returning a content-derived hash per blank node without modifying the dataset.
 
 
 # [0.5.7] - 2026-04-19

--- a/lib/oxrdf/src/dataset.rs
+++ b/lib/oxrdf/src/dataset.rs
@@ -609,50 +609,14 @@ impl Dataset {
         &self,
         algorithm: CanonicalizationAlgorithm,
     ) -> HashMap<InternedBlankNode, BlankNode> {
-        let hash_algorithm = match algorithm {
-            CanonicalizationAlgorithm::Unstable => None,
-            #[cfg(feature = "rdfc-10")]
-            CanonicalizationAlgorithm::Rdfc10 { hash_algorithm } => Some(hash_algorithm),
-        };
+        let hash_algorithm = Self::canonicalization_hash_algorithm(algorithm);
         // https://www.w3.org/TR/rdf-canon/#canon-algo-algo
-        // 1)
+        // 1) and 2)
         let mut canonicalization_state = CanonicalizationState {
-            blank_node_to_quads_map: QuadsPerBlankNode::new(),
+            blank_node_to_quads_map: self.build_blank_node_to_quads_map(),
             hash_to_blank_nodes_map: BTreeMap::new(),
             canonical_issuer: IdentifierIssuer::new("c14n"),
         };
-        // 2)
-        for quad in &self.spog {
-            if let InternedNamedOrBlankNode::BlankNode(bnode) = quad.0 {
-                Self::add_quad_to_blank_node_to_quads_map_for_blank_node(
-                    bnode,
-                    quad,
-                    &mut canonicalization_state.blank_node_to_quads_map,
-                );
-            }
-            if let InternedTerm::BlankNode(bnode) = &quad.2 {
-                Self::add_quad_to_blank_node_to_quads_map_for_blank_node(
-                    *bnode,
-                    quad,
-                    &mut canonicalization_state.blank_node_to_quads_map,
-                );
-            }
-            #[cfg(feature = "rdf-12")]
-            if let InternedTerm::Triple(t) = &quad.2 {
-                Self::add_quad_to_blank_node_to_quads_map_based_on_triple(
-                    t,
-                    quad,
-                    &mut canonicalization_state.blank_node_to_quads_map,
-                );
-            }
-            if let InternedGraphName::BlankNode(bnode) = &quad.3 {
-                Self::add_quad_to_blank_node_to_quads_map_for_blank_node(
-                    *bnode,
-                    quad,
-                    &mut canonicalization_state.blank_node_to_quads_map,
-                );
-            }
-        }
         // 3)
         for n in canonicalization_state.blank_node_to_quads_map.keys() {
             // 3.1)
@@ -727,6 +691,54 @@ impl Dataset {
         canonicalization_state
             .canonical_issuer
             .issued_identifier_map
+    }
+
+    fn canonicalization_hash_algorithm(
+        algorithm: CanonicalizationAlgorithm,
+    ) -> Option<CanonicalizationHashAlgorithm> {
+        match algorithm {
+            CanonicalizationAlgorithm::Unstable => None,
+            #[cfg(feature = "rdfc-10")]
+            CanonicalizationAlgorithm::Rdfc10 { hash_algorithm } => Some(hash_algorithm),
+        }
+    }
+
+    /// Builds the [blank node to quads map](https://www.w3.org/TR/rdf-canon/#dfn-blank-node-to-quads-map)
+    /// (step 2 of the canonicalization algorithm).
+    fn build_blank_node_to_quads_map(&self) -> QuadsPerBlankNode<'_> {
+        let mut blank_node_to_quads_map = QuadsPerBlankNode::new();
+        for quad in &self.spog {
+            if let InternedNamedOrBlankNode::BlankNode(bnode) = quad.0 {
+                Self::add_quad_to_blank_node_to_quads_map_for_blank_node(
+                    bnode,
+                    quad,
+                    &mut blank_node_to_quads_map,
+                );
+            }
+            if let InternedTerm::BlankNode(bnode) = &quad.2 {
+                Self::add_quad_to_blank_node_to_quads_map_for_blank_node(
+                    *bnode,
+                    quad,
+                    &mut blank_node_to_quads_map,
+                );
+            }
+            #[cfg(feature = "rdf-12")]
+            if let InternedTerm::Triple(t) = &quad.2 {
+                Self::add_quad_to_blank_node_to_quads_map_based_on_triple(
+                    t,
+                    quad,
+                    &mut blank_node_to_quads_map,
+                );
+            }
+            if let InternedGraphName::BlankNode(bnode) = &quad.3 {
+                Self::add_quad_to_blank_node_to_quads_map_for_blank_node(
+                    *bnode,
+                    quad,
+                    &mut blank_node_to_quads_map,
+                );
+            }
+        }
+        blank_node_to_quads_map
     }
 
     #[cfg(feature = "rdf-12")]

--- a/lib/oxrdf/src/dataset.rs
+++ b/lib/oxrdf/src/dataset.rs
@@ -605,6 +605,29 @@ impl Dataset {
             .collect()
     }
 
+    /// Returns a map from each blank node of the dataset to a content-derived hash
+    /// following the [RDF Dataset Canonicalization](https://www.w3.org/TR/rdf-canon/) hashing.
+    ///
+    /// Unlike [`canonicalize_blank_nodes`](Self::canonicalize_blank_nodes), a blank node hash only
+    /// depends on the subgraph reachable from it, so an unrelated change does not alter the hash of
+    /// an untouched blank node. Automorphic (interchangeable) blank nodes share the same hash.
+    ///
+    /// <div class="warning">Only `CanonicalizationAlgorithm::Rdfc10` produces hashes that are stable across Oxigraph versions.</div>
+    ///
+    /// <div class="warning">
+    ///     This implementation's worst-case complexity is exponential with respect to the number of blank nodes in the input dataset.
+    ///     See [the RDFC specification section about it](https://www.w3.org/TR/rdf-canon/#dataset-poisoning).
+    /// </div>
+    pub fn canonical_hashes(
+        &self,
+        algorithm: CanonicalizationAlgorithm,
+    ) -> HashMap<BlankNode, String> {
+        self.canonical_interned_hashes(algorithm)
+            .into_iter()
+            .map(|(from, hash)| (from.decode_from(&self.interner), hash))
+            .collect()
+    }
+
     fn canonicalize_interned_blank_nodes(
         &self,
         algorithm: CanonicalizationAlgorithm,
@@ -691,6 +714,41 @@ impl Dataset {
         canonicalization_state
             .canonical_issuer
             .issued_identifier_map
+    }
+
+    fn canonical_interned_hashes(
+        &self,
+        algorithm: CanonicalizationAlgorithm,
+    ) -> HashMap<InternedBlankNode, String> {
+        let hash_algorithm = Self::canonicalization_hash_algorithm(algorithm);
+        let canonicalization_state = CanonicalizationState {
+            blank_node_to_quads_map: self.build_blank_node_to_quads_map(),
+            hash_to_blank_nodes_map: BTreeMap::new(),
+            canonical_issuer: IdentifierIssuer::new("c14n"),
+        };
+        let mut hashes =
+            HashMap::with_capacity(canonicalization_state.blank_node_to_quads_map.len());
+        for n in canonicalization_state.blank_node_to_quads_map.keys() {
+            // Combine the first and n-degree hashes so the result depends only on the subgraph
+            // reachable from the blank node, never on whether another node shares its first
+            // degree hash. The canonical issuer stays empty so the n-degree hash is built from
+            // content, not from the c14n labeling.
+            let first_degree =
+                self.hash_first_degree_quads(&canonicalization_state, *n, hash_algorithm);
+            let mut temporary_issuer = IdentifierIssuer::new("b");
+            Self::issue_identifier(&mut temporary_issuer, *n);
+            let (_, n_degree) = self.hash_n_degree_quads(
+                &canonicalization_state,
+                *n,
+                &temporary_issuer,
+                hash_algorithm,
+            );
+            hashes.insert(
+                *n,
+                Self::hash_function(&format!("{first_degree} {n_degree}"), hash_algorithm),
+            );
+        }
+        hashes
     }
 
     fn canonicalization_hash_algorithm(
@@ -2072,5 +2130,86 @@ mod tests {
         expected.insert(QuadRef::new(&c14n2, &p, &c14n1, GraphNameRef::DefaultGraph));
         expected.insert(QuadRef::new(&c14n3, &p, &c14n0, GraphNameRef::DefaultGraph));
         assert_eq!(dataset, expected);
+    }
+
+    #[test]
+    fn test_canonical_hashes() {
+        let p = NamedNode::new_unchecked("http://example.com/#p");
+        let q = NamedNode::new_unchecked("http://example.com/#q");
+        let r = NamedNode::new_unchecked("http://example.com/#r");
+        let e0 = BlankNode::new_unchecked("e0");
+        let e1 = BlankNode::new_unchecked("e1");
+        let e2 = BlankNode::new_unchecked("e2");
+        let e3 = BlankNode::new_unchecked("e3");
+
+        let mut dataset = Dataset::new();
+        dataset.insert(QuadRef::new(&p, &q, &e0, GraphNameRef::DefaultGraph));
+        dataset.insert(QuadRef::new(&p, &q, &e1, GraphNameRef::DefaultGraph));
+        dataset.insert(QuadRef::new(&e0, &p, &e2, GraphNameRef::DefaultGraph));
+        dataset.insert(QuadRef::new(&e1, &p, &e3, GraphNameRef::DefaultGraph));
+        dataset.insert(QuadRef::new(&e2, &r, &e3, GraphNameRef::DefaultGraph));
+        let algorithm = CanonicalizationAlgorithm::Rdfc10 {
+            hash_algorithm: CanonicalizationHashAlgorithm::Sha256,
+        };
+
+        // e0 and e1 share a first degree hash, so this exercises the n-degree path.
+        let hashes = dataset.canonical_hashes(algorithm);
+        assert_eq!(hashes.len(), 4);
+        assert_eq!(hashes.values().collect::<HashSet<_>>().len(), 4);
+
+        // A disconnected blank node leaves the existing hashes unchanged.
+        let mut extended = dataset.clone();
+        extended.insert(QuadRef::new(
+            &p,
+            &q,
+            &BlankNode::new_unchecked("e4"),
+            GraphNameRef::DefaultGraph,
+        ));
+        let extended_hashes = extended.canonical_hashes(algorithm);
+        for (node, hash) in &hashes {
+            assert_eq!(extended_hashes.get(node), Some(hash));
+        }
+
+        assert_eq!(dataset.len(), 5);
+        assert!(dataset.contains(QuadRef::new(&e0, &p, &e2, GraphNameRef::DefaultGraph)));
+    }
+
+    #[test]
+    fn test_canonical_hashes_share_hash_for_automorphic_nodes() {
+        let p = NamedNode::new_unchecked("http://example.com/#p");
+        let o = NamedNode::new_unchecked("http://example.com/#o");
+        let e0 = BlankNode::new_unchecked("e0");
+        let e1 = BlankNode::new_unchecked("e1");
+
+        let mut dataset = Dataset::new();
+        dataset.insert(QuadRef::new(&e0, &p, &o, GraphNameRef::DefaultGraph));
+        dataset.insert(QuadRef::new(&e1, &p, &o, GraphNameRef::DefaultGraph));
+
+        // e0 and e1 are interchangeable, so they share a hash.
+        let hashes = dataset.canonical_hashes(CanonicalizationAlgorithm::Rdfc10 {
+            hash_algorithm: CanonicalizationHashAlgorithm::Sha256,
+        });
+        assert_eq!(hashes.len(), 2);
+        assert_eq!(hashes[&e0], hashes[&e1]);
+    }
+
+    #[test]
+    fn test_canonical_hashes_are_stable_under_disconnected_additions() {
+        let p = NamedNode::new_unchecked("http://example.com/#p");
+        let o = NamedNode::new_unchecked("http://example.com/#o");
+        let x = BlankNode::new_unchecked("x");
+        let y = BlankNode::new_unchecked("y");
+        let algorithm = CanonicalizationAlgorithm::Rdfc10 {
+            hash_algorithm: CanonicalizationHashAlgorithm::Sha256,
+        };
+
+        let mut base = Dataset::new();
+        base.insert(QuadRef::new(&x, &p, &o, GraphNameRef::DefaultGraph));
+        let base_hash = base.canonical_hashes(algorithm)[&x].clone();
+
+        // Adding a disconnected blank node that shares x's first degree hash must not change x's hash.
+        let mut extended = base.clone();
+        extended.insert(QuadRef::new(&y, &p, &o, GraphNameRef::DefaultGraph));
+        assert_eq!(extended.canonical_hashes(algorithm)[&x], base_hash);
     }
 }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1,8 +1,11 @@
-use crate::model::{PyGraphNameRef, PyNamedNodeRef, PyNamedOrBlankNodeRef, PyQuad, PyTermRef};
+use crate::model::{
+    PyBlankNode, PyGraphNameRef, PyNamedNodeRef, PyNamedOrBlankNodeRef, PyQuad, PyTermRef,
+};
 use oxigraph::model::Quad;
 use oxigraph::model::dataset::{CanonicalizationAlgorithm, CanonicalizationHashAlgorithm, Dataset};
 use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
+use std::collections::HashMap;
 use std::fmt;
 
 /// An in-memory `RDF dataset <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset>`_.
@@ -212,6 +215,33 @@ impl PyDataset {
     /// True
     fn canonicalize(&mut self, algorithm: &PyCanonicalizationAlgorithm) {
         self.inner.canonicalize(algorithm.inner)
+    }
+
+    /// Computes a content-derived hash for each blank node without modifying the dataset.
+    ///
+    /// Unlike the labels produced by :py:meth:`canonicalize`, a blank node hash only depends on the subgraph reachable from it, so an unrelated change does not alter the hash of an untouched blank node. Automorphic (interchangeable) blank nodes share the same hash.
+    ///
+    /// Warning: :py:attr:`CanonicalizationAlgorithm.UNSTABLE` may produce different hashes between PyOxigraph versions; the RDFC 1.0 algorithms are stable.
+    ///
+    /// Warning: This implementation's worst-case complexity is exponential with respect to the number of blank nodes in the input dataset.
+    ///
+    /// :param algorithm: the canonicalization algorithm to use.
+    /// :type algorithm: CanonicalizationAlgorithm
+    /// :return: the mapping from each blank node to its hash.
+    /// :rtype: dict[BlankNode, str]
+    ///
+    /// >>> d = Dataset([Quad(BlankNode('a'), NamedNode('http://example.com/p'), Literal('x'))])
+    /// >>> d.canonical_hashes(CanonicalizationAlgorithm.RDFC_1_0)
+    /// {<BlankNode value=a>: '3bd53f7c7e8126517572962facf21123a3c507f585cda575b712a5dee1b7e496'}
+    fn canonical_hashes(
+        &self,
+        algorithm: &PyCanonicalizationAlgorithm,
+    ) -> HashMap<PyBlankNode, String> {
+        self.inner
+            .canonical_hashes(algorithm.inner)
+            .into_iter()
+            .map(|(node, hash)| (node.into(), hash))
+            .collect()
     }
 
     fn __bool__(&self) -> bool {


### PR DESCRIPTION
## What this does

Adds `Dataset::canonical_hashes` (oxrdf) and its pyoxigraph binding `Dataset.canonical_hashes(algorithm) -> dict[BlankNode, str]`: a content-derived hash for each blank node, computed without modifying the dataset.

## Why

RDFC-1.0 `canonicalize` relabels blank nodes to ordinal `_:c14nN` labels. A label is a global sort position, so inserting one blank node shifts the label of every node after it — unusable for diffs (#1788). The canonical *hashes* underneath the algorithm don't have this problem: a blank node's hash depends only on the subgraph reachable from it, so an unrelated edit leaves untouched nodes' hashes unchanged. Exposing them lets consumers derive diff-stable `_:h<hash>` labels.

## How

Each blank node's hash combines its RDFC-1.0 *Hash First Degree Quads* (which captures the ground terms attached to it) with its *Hash N-Degree Quads* (which distinguishes nodes that share a first-degree hash, e.g. RDF-list cells). Both are computed with an empty canonical issuer, so the hash is built purely from the content reachable from the node and never from the global `c14nN` labeling — which is what keeps it stable under unrelated edits. Automorphic blank nodes share a hash.

The n-degree hash is computed for every blank node (`canonicalize` can skip it for nodes already distinguished by their first-degree hash), so this can be somewhat more expensive than `canonicalize`. It also recomputes those hashes rather than reusing them, since `canonicalize` discards them and keeps only the `c14nN` labels.

## On the maintainer's suggestion in #1788

The maintainer suggested exposing the existing `canonicalize_blank_nodes` mapping (`dict[BlankNode, BlankNode]`). That mapping's values are the ordinal `c14nN` labels — a global sort position — so inserting one blank node shifts the label of every node after it. That's the exact churn the issue is about, so the label mapping doesn't actually deliver diff-locality. This PR exposes the underlying content hashes, which do. (Happy to also add the non-mutating label accessor if it's still wanted — it's a trivial addition.)

## Tests

- Rust `test_canonical_hashes`: four distinguishable nodes get four distinct hashes (exercising the n-degree path), the hashes don't change when a disconnected node is added, and the dataset is not mutated.
- Rust `test_canonical_hashes_share_hash_for_automorphic_nodes`: interchangeable blank nodes share a hash.
- Rust `test_canonical_hashes_are_stable_under_disconnected_additions`: adding a disconnected blank node that shares an existing node's first-degree hash does not change that node's hash.
- Python doctest on `Dataset.canonical_hashes`.

Closes #1788
