### PR TITLE
Fixed JS sample code to use '.quad()'

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -37,7 +37,7 @@ import dataModel from "@rdfjs/data-model";
 const store = new Store();
 const ex = dataModel.namedNode("http://example/");
 const schemaName = dataModel.namedNode("http://schema.org/name");
-store.add(dataModel.triple(ex, schemaName, dataModel.literal("example")));
+store.add(dataModel.quad(ex, schemaName, dataModel.literal("example")));
 for (const binding of store.query("SELECT ?name WHERE { <http://example/> <http://schema.org/name> ?name }")) {
     console.log(binding.get("name").value);
 }


### PR DESCRIPTION
There is no '.triple()' method on the RDF/JS Data Model, so this sample JavaScript fails whenever anyone tries it. The fix is to use '.quad()' instead (the 'graph' parameter can be 'undefined', so nothing else needs to change in this sample code).