### PR TITLE
Add --fail-on-named-graphs to load

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -125,9 +125,13 @@ pub enum Command {
         ///
         /// By default, the default graph is used.
         ///
-        /// Only available when loading a graph file (N-Triples, Turtle...) and not a dataset file (N-Quads, TriG...).
+        /// Default graph statements from dataset formats are loaded into this graph.
+        /// Named graph statements keep their original graph names.
         #[arg(long, value_hint = ValueHint::Url)]
         graph: Option<String>,
+        /// Fail if the input contains named graph statements
+        #[arg(long, conflicts_with = "lenient")]
+        fail_on_named_graphs: bool,
     },
     /// Dump the store content into a file
     Dump {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,6 +103,7 @@ pub fn main() -> anyhow::Result<()> {
             format,
             base,
             graph,
+            fail_on_named_graphs,
         } => {
             let store = Store::open(&location)?;
             let format = if let Some(format) = format {
@@ -151,6 +152,7 @@ pub fn main() -> anyhow::Result<()> {
                     base.as_deref(),
                     graph,
                     lenient,
+                    fail_on_named_graphs,
                 )?;
                 loader.commit()?;
             } else {
@@ -209,6 +211,7 @@ pub fn main() -> anyhow::Result<()> {
                                             base.as_deref(),
                                             graph,
                                             lenient,
+                                            fail_on_named_graphs,
                                         )
                                     } else {
                                         bulk_load_file(
@@ -220,6 +223,7 @@ pub fn main() -> anyhow::Result<()> {
                                             base.as_deref(),
                                             graph,
                                             lenient,
+                                            fail_on_named_graphs,
                                         )
                                     }
                                 } {
@@ -582,8 +586,12 @@ fn bulk_load_read(
     base_iri: Option<&str>,
     to_graph_name: Option<NamedNode>,
     lenient: bool,
+    fail_on_named_graphs: bool,
 ) -> anyhow::Result<()> {
     let mut parser = RdfParser::from_format(format);
+    if fail_on_named_graphs {
+        parser = parser.without_named_graphs();
+    }
     if let Some(to_graph_name) = to_graph_name {
         parser = parser.with_default_graph(to_graph_name);
     }
@@ -606,8 +614,12 @@ fn bulk_load_file(
     base_iri: Option<&str>,
     to_graph_name: Option<NamedNode>,
     lenient: bool,
+    fail_on_named_graphs: bool,
 ) -> anyhow::Result<()> {
     let mut parser = RdfParser::from_format(format);
+    if fail_on_named_graphs {
+        parser = parser.without_named_graphs();
+    }
     if let Some(to_graph_name) = to_graph_name {
         parser = parser.with_default_graph(to_graph_name);
     }
@@ -2168,6 +2180,60 @@ mod tests {
                 predicate::str::contains("Error while loading file")
                     .and(predicate::str::contains("Error while opening file")),
             );
+        Ok(())
+    }
+
+    #[test]
+    fn cli_load_can_fail_on_named_graphs() -> Result<()> {
+        let store_dir = TempDir::new()?;
+        let input_file = NamedTempFile::new("input.nq")?;
+        input_file.write_str(
+            "<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/original> .",
+        )?;
+        cli_command()
+            .arg("load")
+            .arg("--location")
+            .arg(store_dir.path())
+            .arg("--file")
+            .arg(input_file.path())
+            .arg("--fail-on-named-graphs")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Named graphs are not allowed"));
+        assert_cli_state(&store_dir, "");
+
+        cli_command()
+            .arg("load")
+            .arg("--location")
+            .arg(store_dir.path())
+            .args(["--format", "nq", "--fail-on-named-graphs"])
+            .write_stdin(
+                "<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/original> .",
+            )
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Named graphs are not allowed"));
+        assert_cli_state(&store_dir, "");
+
+        let json_ld_file = NamedTempFile::new("input.jsonld")?;
+        json_ld_file.write_str(
+            r#"{"@id":"http://example.com/s","http://example.com/p":{"@id":"http://example.com/o"}}"#,
+        )?;
+        cli_command()
+            .arg("load")
+            .arg("--location")
+            .arg(store_dir.path())
+            .arg("--file")
+            .arg(json_ld_file.path())
+            .arg("--graph")
+            .arg("http://example.com/target")
+            .arg("--fail-on-named-graphs")
+            .assert()
+            .success();
+        assert_cli_state(
+            &store_dir,
+            "<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/target> .\n",
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #1863.

## Summary

- Add `oxigraph load --fail-on-named-graphs` for callers that require graph-only input semantics.
- Apply `RdfParser::without_named_graphs` to both stdin and file loading paths.
- Keep dataset formats compatible with `--graph`, including loading default-graph JSON-LD into the requested target graph.
- Make `--fail-on-named-graphs` conflict with `--lenient` so the requested failure cannot be swallowed as a recoverable parse error.

## Rationale

`RdfParser::with_default_graph` intentionally remaps only default-graph statements; named graph statements retain their graph names. Rejecting all dataset-capable formats would prevent common single-graph JSON-LD use cases because JSON-LD has no separate graph-only media type.

The new opt-in flag expresses the actual strictness requirement directly: reject content containing named graphs while continuing to support dataset-capable formats whose content only uses the default graph.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=8 cargo test --features rdf-12` (full native workspace suite)
- `cargo test -p oxigraph-cli cli_load_can_fail_on_named_graphs --features rdf-12`
- `cargo clippy -p oxigraph-cli --features rdf-12 --all-targets -- -D warnings`
- `cargo clippy -p oxigraph-cli --no-default-features --all-targets -- -D warnings`
- `cargo llvm-cov --package oxigraph-cli --features rdf-12 -- cli_load_can_fail_on_named_graphs`

The regression test covers rejection from file and stdin input, verifies the store stays empty after each atomic failure, and confirms default-graph JSON-LD still loads successfully into `--graph` when strict mode is enabled.

## Documentation

The `load --help` text now documents dataset-format `--graph` behavior and the new strict named-graph option.
