### PR TITLE
Propagate CONSTRUCT externalization errors

### DIFF
--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -3458,21 +3458,19 @@ impl<'a, D: QueryableDataset<'a>> Iterator for ConstructIterator<'a, D> {
                     Err(error) => return Some(Err(error)),
                 };
                 for template in &self.template {
-                    if let (Some(subject), Some(predicate), Some(object)) = (
+                    let (subject, predicate, object) = match (
                         get_triple_template_value(
                             &template.subject,
                             &tuple,
                             &mut self.bnodes,
                             &self.eval.dataset,
-                        )
-                        .and_then(|t| t.try_into().ok()),
+                        ),
                         get_triple_template_value(
                             &template.predicate,
                             &tuple,
                             &mut self.bnodes,
                             &self.eval.dataset,
-                        )
-                        .and_then(|t| t.try_into().ok()),
+                        ),
                         get_triple_template_value(
                             &template.object,
                             &tuple,
@@ -3480,6 +3478,17 @@ impl<'a, D: QueryableDataset<'a>> Iterator for ConstructIterator<'a, D> {
                             &self.eval.dataset,
                         ),
                     ) {
+                        (Ok(Some(subject)), Ok(Some(predicate)), Ok(Some(object))) => {
+                            (subject, predicate, object)
+                        }
+                        (Err(error), _, _) | (_, Err(error), _) | (_, _, Err(error)) => {
+                            self.bnodes.clear();
+                            return Some(Err(error));
+                        }
+                        _ => continue,
+                    };
+                    if let (Ok(subject), Ok(predicate)) = (subject.try_into(), predicate.try_into())
+                    {
                         let triple = Triple {
                             subject,
                             predicate,
@@ -3594,32 +3603,40 @@ fn get_triple_template_value<'a, D: QueryableDataset<'a>>(
     tuple: &InternalTuple<D::InternalTerm>,
     bnodes: &mut Vec<BlankNode>,
     dataset: &EvalDataset<'a, D>,
-) -> Option<Term> {
+) -> Result<Option<Term>, QueryEvaluationError> {
     match selector {
-        TripleTemplateValue::Constant(term) => Some(term.clone()),
-        TripleTemplateValue::Variable(v) => {
-            let t = tuple.get(*v)?;
-            dataset.externalize_term(t.clone()).ok() // TODO: raise error
-        }
+        TripleTemplateValue::Constant(term) => Ok(Some(term.clone())),
+        TripleTemplateValue::Variable(v) => tuple
+            .get(*v)
+            .map(|t| dataset.externalize_term(t.clone()))
+            .transpose(),
         TripleTemplateValue::BlankNode(bnode) => {
             if *bnode >= bnodes.len() {
                 bnodes.resize_with(*bnode + 1, BlankNode::default)
             }
-            Some(bnodes[*bnode].clone().into())
+            Ok(Some(bnodes[*bnode].clone().into()))
         }
         #[cfg(feature = "sparql-12")]
-        TripleTemplateValue::Triple(triple) => Some(
-            Triple {
-                subject: get_triple_template_value(&triple.subject, tuple, bnodes, dataset)?
-                    .try_into()
-                    .ok()?,
-                predicate: get_triple_template_value(&triple.predicate, tuple, bnodes, dataset)?
-                    .try_into()
-                    .ok()?,
-                object: get_triple_template_value(&triple.object, tuple, bnodes, dataset)?,
-            }
-            .into(),
-        ),
+        TripleTemplateValue::Triple(triple) => {
+            let (Some(subject), Some(predicate), Some(object)) = (
+                get_triple_template_value(&triple.subject, tuple, bnodes, dataset)?,
+                get_triple_template_value(&triple.predicate, tuple, bnodes, dataset)?,
+                get_triple_template_value(&triple.object, tuple, bnodes, dataset)?,
+            ) else {
+                return Ok(None);
+            };
+            let (Ok(subject), Ok(predicate)) = (subject.try_into(), predicate.try_into()) else {
+                return Ok(None);
+            };
+            Ok(Some(
+                Triple {
+                    subject,
+                    predicate,
+                    object,
+                }
+                .into(),
+            ))
+        }
     }
 }
 

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -1023,8 +1023,60 @@ mod tests {
     use super::*;
     use oxrdf::vocab::xsd;
     use oxrdf::{Literal, Term};
+    use spargebra::SparqlParser;
     use spargebra::vocab::sparql;
     use sparopt::algebra::{Expression, QueryExpression};
+
+    struct FailingExternalizationDataset;
+
+    impl<'a> QueryableDataset<'a> for FailingExternalizationDataset {
+        type InternalTerm = u8;
+        type Error = io::Error;
+
+        fn internal_quads_for_pattern(
+            &self,
+            _subject: Option<&u8>,
+            _predicate: Option<&u8>,
+            _object: Option<&u8>,
+            _graph_name: Option<Option<&u8>>,
+        ) -> impl Iterator<Item = Result<InternalQuad<u8>, io::Error>> + use<'a> {
+            std::iter::once(Ok(InternalQuad {
+                subject: 1,
+                predicate: 2,
+                object: 3,
+                graph_name: None,
+            }))
+        }
+
+        fn internalize_term(&self, _term: Term) -> Result<u8, io::Error> {
+            Ok(2)
+        }
+
+        fn externalize_term(&self, term: u8) -> Result<Term, io::Error> {
+            match term {
+                1 => Ok(NamedNode::new_unchecked("http://example.com/s").into()),
+                2 => Ok(NamedNode::new_unchecked("http://example.com/p").into()),
+                _ => Err(io::Error::other("dictionary read failed")),
+            }
+        }
+    }
+
+    #[test]
+    fn construct_propagates_externalization_errors() {
+        let query = SparqlParser::new()
+            .parse_query("CONSTRUCT { ?s <http://example.com/p> ?o } WHERE { ?s ?p ?o }")
+            .unwrap();
+        let results = QueryEvaluator::new()
+            .prepare(&query)
+            .execute(FailingExternalizationDataset)
+            .unwrap();
+        assert!(matches!(&results, QueryResults::Graph(_)));
+        if let QueryResults::Graph(results) = results {
+            let error = results.collect::<Result<Vec<_>, _>>().unwrap_err();
+            assert!(matches!(error, QueryEvaluationError::Dataset(_)));
+            assert_eq!(error.to_string(), "dictionary read failed");
+        }
+    }
 
     #[test]
     fn evaluate_expression_literal_and_arithmetic() {


### PR DESCRIPTION
Fixes #1878.

## Summary

- propagate dataset externalization failures from CONSTRUCT graph iterators
- keep skipping triples for legitimate unbound or invalid template values
- clear per-solution blank-node state before yielding an error
- add a regression test using a fallible `QueryableDataset`

## Testing

- `cargo test --features rdf-12`
- `cargo test -p spareval --lib --no-default-features`
- `cargo test -p spareval --lib --features sparql-12`
- `cargo test -p spareval --lib --features sep-0002`
- `cargo test -p spareval --lib --features sep-0006`
- `cargo clippy --all-targets -- -D warnings -D clippy::all` (`lib/spareval`)
- `cargo clippy --all-targets --features sparql-12 -- -D warnings -D clippy::all` (`lib/spareval`)
- `cargo clippy --all-targets --features sep-0002 -- -D warnings -D clippy::all` (`lib/spareval`)
- `cargo clippy --all-targets --features sep-0006 -- -D warnings -D clippy::all` (`lib/spareval`)
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p spareval`
