### PR TITLE
sparesults: move test to plain data format

### DIFF
--- a/lib/sparesults/src/xml.rs
+++ b/lib/sparesults/src/xml.rs
@@ -567,7 +567,7 @@ impl XmlInnerQueryResultsParser {
                                 predicate_stack: Vec::new(),
                                 object_stack: Vec::new(),
                                 text_buffer: String::new(),
-                                first_text_event_end: None,
+                                first_text_event_end: 0,
                                 last_text_event_start: None,
                                 xml_version: self.xml_version,
                             },
@@ -661,7 +661,7 @@ struct XmlInnerSolutionsParser {
     predicate_stack: Vec<Term>,
     object_stack: Vec<Term>,
     text_buffer: String,
-    first_text_event_end: Option<usize>,
+    first_text_event_end: usize,
     last_text_event_start: Option<usize>,
     xml_version: XmlVersion,
 }
@@ -672,187 +672,196 @@ impl XmlInnerSolutionsParser {
         event: Event<'_>,
     ) -> Result<Option<Vec<Option<Term>>>, QueryResultsParseError> {
         match event {
-            Event::Start(event) => match {
+            Event::Start(event) => {
                 self.text_buffer.clear();
-                self.first_text_event_end = None;
+                self.first_text_event_end = 0;
                 self.last_text_event_start = None;
-                self.state_stack.last()
-            }
-            .ok_or_else(|| {
-                QueryResultsSyntaxError::msg("Extra XML is not allowed at the end of the document")
-            })? {
-                State::Start => {
-                    if event.local_name().as_ref() == b"result" {
-                        self.new_bindings = vec![None; self.mapping.len()];
-                        self.state_stack.push(State::Result);
-                        Ok(None)
-                    } else {
-                        Err(QueryResultsSyntaxError::msg(format!(
-                            "Expecting <result>, found <{}>",
-                            self.decoder.decode(event.name().as_ref())?
-                        ))
-                        .into())
+                match self.state_stack.last().ok_or_else(|| {
+                    QueryResultsSyntaxError::msg(
+                        "Extra XML is not allowed at the end of the document",
+                    )
+                })? {
+                    State::Start => {
+                        if event.local_name().as_ref() == b"result" {
+                            self.new_bindings = vec![None; self.mapping.len()];
+                            self.state_stack.push(State::Result);
+                            Ok(None)
+                        } else {
+                            Err(QueryResultsSyntaxError::msg(format!(
+                                "Expecting <result>, found <{}>",
+                                self.decoder.decode(event.name().as_ref())?
+                            ))
+                            .into())
+                        }
                     }
-                }
-                State::Result => {
-                    if event.local_name().as_ref() == b"binding" {
-                        let Some(attr) = event
-                            .attributes()
-                            .filter_map(Result::ok)
-                            .find(|attr| attr.key.local_name().as_ref() == b"name")
-                        else {
+                    State::Result => {
+                        if event.local_name().as_ref() == b"binding" {
+                            let Some(attr) = event
+                                .attributes()
+                                .filter_map(Result::ok)
+                                .find(|attr| attr.key.local_name().as_ref() == b"name")
+                            else {
+                                return Err(QueryResultsSyntaxError::msg(
+                                    "No name attribute found for the <binding> tag",
+                                )
+                                .into());
+                            };
+                            self.current_var = Some(OxString::new_owned(
+                                &attr
+                                    .decoded_and_normalized_value(self.xml_version, self.decoder)?,
+                            ));
+                            self.state_stack.push(State::Binding);
+                            Ok(None)
+                        } else {
+                            Err(QueryResultsSyntaxError::msg(format!(
+                                "Expecting <binding>, found <{}>",
+                                self.decoder.decode(event.name().as_ref())?
+                            ))
+                            .into())
+                        }
+                    }
+                    State::Binding | State::Subject | State::Predicate | State::Object => {
+                        if self.term.is_some() {
                             return Err(QueryResultsSyntaxError::msg(
-                                "No name attribute found for the <binding> tag",
+                                "There is already a value for the current binding",
                             )
                             .into());
-                        };
-                        self.current_var = Some(OxString::new_owned(
-                            &attr.decoded_and_normalized_value(self.xml_version, self.decoder)?,
-                        ));
-                        self.state_stack.push(State::Binding);
-                        Ok(None)
-                    } else {
-                        Err(QueryResultsSyntaxError::msg(format!(
-                            "Expecting <binding>, found <{}>",
-                            self.decoder.decode(event.name().as_ref())?
-                        ))
-                        .into())
-                    }
-                }
-                State::Binding | State::Subject | State::Predicate | State::Object => {
-                    if self.term.is_some() {
-                        return Err(QueryResultsSyntaxError::msg(
-                            "There is already a value for the current binding",
-                        )
-                        .into());
-                    }
-                    if event.local_name().as_ref() == b"uri" {
-                        self.state_stack.push(State::Uri);
-                        Ok(None)
-                    } else if event.local_name().as_ref() == b"bnode" {
-                        self.state_stack.push(State::BNode);
-                        Ok(None)
-                    } else if event.local_name().as_ref() == b"literal" {
-                        for attr in event.attributes() {
-                            let attr = attr.map_err(Error::from)?;
-                            if attr.key.as_ref() == b"xml:lang" {
-                                self.lang =
-                                    Some(OxString::new_owned(&attr.decoded_and_normalized_value(
-                                        self.xml_version,
-                                        self.decoder,
-                                    )?));
-                            } else if attr.key.local_name().as_ref() == b"datatype" {
-                                let iri = attr
-                                    .decoded_and_normalized_value(self.xml_version, self.decoder)?;
-                                self.datatype = Some(
-                                    NamedNode::new(OxString::new_owned(&iri)).map_err(|e| {
-                                        QueryResultsSyntaxError::msg(format!(
-                                            "Invalid datatype IRI '{iri}': {e}"
-                                        ))
-                                    })?,
-                                );
-                            }
-                            #[cfg(feature = "sparql-12")]
-                            if attr.key.as_ref() == b"its:dir" {
-                                let value = attr
-                                    .decoded_and_normalized_value(self.xml_version, self.decoder)?;
-                                self.direction = Some(
-                                    match attr
-                                        .decoded_and_normalized_value(
+                        }
+                        if event.local_name().as_ref() == b"uri" {
+                            self.state_stack.push(State::Uri);
+                            Ok(None)
+                        } else if event.local_name().as_ref() == b"bnode" {
+                            self.state_stack.push(State::BNode);
+                            Ok(None)
+                        } else if event.local_name().as_ref() == b"literal" {
+                            for attr in event.attributes() {
+                                let attr = attr.map_err(Error::from)?;
+                                if attr.key.as_ref() == b"xml:lang" {
+                                    self.lang = Some(OxString::new_owned(
+                                        &attr.decoded_and_normalized_value(
                                             self.xml_version,
                                             self.decoder,
-                                        )?
-                                        .as_ref()
-                                    {
-                                        "ltr" => BaseDirection::Ltr,
-                                        "rtl" => BaseDirection::Rtl,
-                                        _ => {
-                                            return Err(QueryResultsSyntaxError::msg(format!(
-                                                "Invalid its:dir value '{value}', expecting 'ltr' or 'rtl'"
-                                            )).into());
-                                        }
-                                    },
-                                );
+                                        )?,
+                                    ));
+                                } else if attr.key.local_name().as_ref() == b"datatype" {
+                                    let iri = attr.decoded_and_normalized_value(
+                                        self.xml_version,
+                                        self.decoder,
+                                    )?;
+                                    self.datatype = Some(
+                                        NamedNode::new(OxString::new_owned(&iri)).map_err(|e| {
+                                            QueryResultsSyntaxError::msg(format!(
+                                                "Invalid datatype IRI '{iri}': {e}"
+                                            ))
+                                        })?,
+                                    );
+                                }
+                                #[cfg(feature = "sparql-12")]
+                                if attr.key.as_ref() == b"its:dir" {
+                                    let value = attr.decoded_and_normalized_value(
+                                        self.xml_version,
+                                        self.decoder,
+                                    )?;
+                                    self.direction = Some(
+                                        match attr
+                                            .decoded_and_normalized_value(
+                                                self.xml_version,
+                                                self.decoder,
+                                            )?
+                                            .as_ref()
+                                        {
+                                            "ltr" => BaseDirection::Ltr,
+                                            "rtl" => BaseDirection::Rtl,
+                                            _ => {
+                                                return Err(QueryResultsSyntaxError::msg(format!(
+                                                    "Invalid its:dir value '{value}', expecting 'ltr' or 'rtl'"
+                                                )).into());
+                                            }
+                                        },
+                                    );
+                                }
                             }
+                            self.state_stack.push(State::Literal);
+                            Ok(None)
+                        } else if event.local_name().as_ref() == b"triple" {
+                            self.state_stack.push(State::Triple);
+                            Ok(None)
+                        } else {
+                            Err(QueryResultsSyntaxError::msg(format!(
+                                "Expecting <uri>, <bnode> or <literal> found <{}>",
+                                self.decoder.decode(event.name().as_ref())?
+                            ))
+                            .into())
                         }
-                        self.state_stack.push(State::Literal);
-                        Ok(None)
-                    } else if event.local_name().as_ref() == b"triple" {
-                        self.state_stack.push(State::Triple);
-                        Ok(None)
-                    } else {
-                        Err(QueryResultsSyntaxError::msg(format!(
-                            "Expecting <uri>, <bnode> or <literal> found <{}>",
-                            self.decoder.decode(event.name().as_ref())?
-                        ))
-                        .into())
                     }
-                }
-                State::Triple => {
-                    if event.local_name().as_ref() == b"subject" {
-                        self.state_stack.push(State::Subject);
-                        Ok(None)
-                    } else if event.local_name().as_ref() == b"predicate" {
-                        self.state_stack.push(State::Predicate);
-                        Ok(None)
-                    } else if event.local_name().as_ref() == b"object" {
-                        self.state_stack.push(State::Object);
-                        Ok(None)
-                    } else {
-                        Err(QueryResultsSyntaxError::msg(format!(
-                            "Expecting <subject>, <predicate> or <object> found <{}>",
-                            self.decoder.decode(event.name().as_ref())?
-                        ))
-                        .into())
+                    State::Triple => {
+                        if event.local_name().as_ref() == b"subject" {
+                            self.state_stack.push(State::Subject);
+                            Ok(None)
+                        } else if event.local_name().as_ref() == b"predicate" {
+                            self.state_stack.push(State::Predicate);
+                            Ok(None)
+                        } else if event.local_name().as_ref() == b"object" {
+                            self.state_stack.push(State::Object);
+                            Ok(None)
+                        } else {
+                            Err(QueryResultsSyntaxError::msg(format!(
+                                "Expecting <subject>, <predicate> or <object> found <{}>",
+                                self.decoder.decode(event.name().as_ref())?
+                            ))
+                            .into())
+                        }
                     }
+                    State::Uri => Err(QueryResultsSyntaxError::msg(format!(
+                        "<uri> must only contain a string, found <{}>",
+                        self.decoder.decode(event.name().as_ref())?
+                    ))
+                    .into()),
+                    State::BNode => Err(QueryResultsSyntaxError::msg(format!(
+                        "<bnode> must only contain a string, found <{}>",
+                        self.decoder.decode(event.name().as_ref())?
+                    ))
+                    .into()),
+                    State::Literal => Err(QueryResultsSyntaxError::msg(format!(
+                        "<literal> must only contain a string, found <{}>",
+                        self.decoder.decode(event.name().as_ref())?
+                    ))
+                    .into()),
                 }
-                State::Uri => Err(QueryResultsSyntaxError::msg(format!(
-                    "<uri> must only contain a string, found <{}>",
-                    self.decoder.decode(event.name().as_ref())?
-                ))
-                .into()),
-                State::BNode => Err(QueryResultsSyntaxError::msg(format!(
-                    "<bnode> must only contain a string, found <{}>",
-                    self.decoder.decode(event.name().as_ref())?
-                ))
-                .into()),
-                State::Literal => Err(QueryResultsSyntaxError::msg(format!(
-                    "<literal> must only contain a string, found <{}>",
-                    self.decoder.decode(event.name().as_ref())?
-                ))
-                .into()),
-            },
+            }
             Event::Text(event) => {
                 let start = self.text_buffer.len();
                 self.text_buffer
                     .push_str(&event.xml_content(self.xml_version)?);
                 if start == 0 {
-                    self.first_text_event_end = Some(self.text_buffer.len());
+                    self.first_text_event_end = self.text_buffer.len();
                 }
                 self.last_text_event_start = Some(start);
                 Ok(None)
             }
             Event::End(_) => {
-                let value = take(&mut self.text_buffer);
-                let first_text_event_end = self.first_text_event_end.take();
-                let last_text_event_start = self.last_text_event_start.take();
                 let state = self.state_stack.pop().ok_or_else(|| {
                     QueryResultsSyntaxError::msg(
                         "Extra XML is not allowed at the end of the document",
                     )
                 })?;
-                let start = first_text_event_end.map_or(0, |end| {
-                    end - value[..end]
+                let start = self.first_text_event_end
+                    - self.text_buffer[..self.first_text_event_end]
                         .trim_start_matches(['\t', '\n', '\r', ' '])
-                        .len()
-                });
-                let end = last_text_event_start.map_or(value.len(), |start| {
-                    start
-                        + value[start..]
-                            .trim_end_matches(['\t', '\n', '\r', ' '])
-                            .len()
-                });
-                let value = OxString::new_owned(if start < end { &value[start..end] } else { "" });
+                        .len();
+                let end = self
+                    .last_text_event_start
+                    .map_or(self.text_buffer.len(), |start| {
+                        start
+                            + self.text_buffer[start..]
+                                .trim_end_matches(['\t', '\n', '\r', ' '])
+                                .len()
+                    });
+                let value =
+                    OxString::new_owned(self.text_buffer.get(start..end).unwrap_or_default());
+                self.text_buffer.clear();
+                self.first_text_event_end = 0;
+                self.last_text_event_start = None;
                 match state {
                     State::Start => Ok(None),
                     State::Result => Ok(Some(take(&mut self.new_bindings))),
@@ -1113,46 +1122,5 @@ fn map_xml_error(error: Error) -> io::Error {
             Arc::try_unwrap(error).unwrap_or_else(|error| io::Error::new(error.kind(), error))
         }
         _ => io::Error::new(io::ErrorKind::InvalidData, error),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[expect(clippy::panic_in_result_fn)]
-    fn parse_literal_boundary_whitespace() -> Result<(), QueryResultsSyntaxError> {
-        let SliceXmlQueryResultsParserOutput::Solutions { mut solutions, .. } =
-            SliceXmlQueryResultsParserOutput::read(br#"<sparql xmlns="http://www.w3.org/2005/sparql-results#"><head><variable name="x"/></head><results>
-                <result><binding name="x"><literal datatype="http://www.w3.org/2001/XMLSchema#boolean"> true </literal></binding></result>
-                <result><binding name="x"><literal> &#32;&#9;&#10;&#13;padded&#13;&#10;&#9;&#32; </literal></binding></result>
-            </results></sparql>"#)?
-        else {
-            return Err(QueryResultsSyntaxError::msg("Expected solutions"));
-        };
-        assert_eq!(
-            solutions.parse_next()?,
-            Some(vec![Some(
-                Literal::new_typed_literal("true", xsd::BOOLEAN).into()
-            )])
-        );
-        assert_eq!(
-            solutions.parse_next()?,
-            Some(vec![Some(Literal::from(" \t\n\rpadded\r\n\t ").into())])
-        );
-        assert_eq!(solutions.parse_next()?, None);
-        Ok(())
-    }
-
-    #[test]
-    fn preserve_uri_boundary_whitespace_references() -> Result<(), QueryResultsSyntaxError> {
-        let SliceXmlQueryResultsParserOutput::Solutions { mut solutions, .. } =
-            SliceXmlQueryResultsParserOutput::read(br#"<sparql xmlns="http://www.w3.org/2005/sparql-results#"><head><variable name="x"/></head><results><result><binding name="x"><uri>&#32;https://example.com/</uri></binding></result></results></sparql>"#)?
-        else {
-            return Err(QueryResultsSyntaxError::msg("Expected solutions"));
-        };
-        solutions.parse_next().unwrap_err();
-        Ok(())
     }
 }

--- a/testsuite/oxigraph-tests/sparql-results/boundary_whitespace.srx
+++ b/testsuite/oxigraph-tests/sparql-results/boundary_whitespace.srx
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="x"/>
+  </head>
+  <results>
+    <result>
+      <binding name="x">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean"> true </literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="x">
+        <literal> &#32;&#9;&#10;&#13;padded&#13;&#10;&#9;&#32; </literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="x">
+        <uri>
+          http://example.com
+        </uri>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/testsuite/oxigraph-tests/sparql-results/boundary_whitespace_expected.srx
+++ b/testsuite/oxigraph-tests/sparql-results/boundary_whitespace_expected.srx
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="x"/>
+  </head>
+  <results>
+    <result>
+      <binding name="x">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">true</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="x">
+        <literal>&#32;&#9;&#10;&#13;padded&#13;&#10;&#9;&#32;</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="x">
+        <uri>http://example.com</uri>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/testsuite/oxigraph-tests/sparql-results/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql-results/manifest.ttl
@@ -13,6 +13,7 @@
     :results_tsv_duplicated_variables
     :results_json_ignored_keys
     :results_xml_ignored_keys
+    :results_xml_boundary_whitespace
     :results_json_typed_literal
     :late_head
     ) .
@@ -36,6 +37,11 @@
 :results_xml_ignored_keys rdf:type ox:PositiveXmlResultsSyntaxTest ;
     mf:name "Ignore unknown attributes on tags" ;
     mf:action <ignored_keys.srx> .
+
+:results_xml_boundary_whitespace rdf:type ox:PositiveXmlResultsSyntaxTest ;
+    mf:name "Whitespace at textual terms boundaries" ;
+    mf:action <boundary_whitespace.srx> ;
+    mf:result <boundary_whitespace_expected.srx> .
 
 :results_json_typed_literal rdf:type ox:PositiveJsonResultsSyntaxTest ;
     mf:name "typed-literal term type is allowed" ;


### PR DESCRIPTION
Small code simplification: avoids to `take` the text_buffer to keep the allocated space between iterations and reduce the number of allocations