### PR TITLE
Make Graph Store PUT replacements atomic

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1126,19 +1126,13 @@ fn handle_request(
                         false
                     }
                 };
-                if RequestParams::from_request_url(request).contains("no_transaction") {
-                    transaction.commit().map_err(internal_server_error)?;
-                    web_load_graph(store, request, format, &GraphName::from(target), None)?;
-                } else {
-                    web_load_graph(
-                        store,
-                        request,
-                        format,
-                        &GraphName::from(target),
-                        Some(&mut transaction),
-                    )?;
-                    transaction.commit().map_err(internal_server_error)?;
-                }
+                web_load_graph(
+                    store,
+                    request,
+                    format,
+                    &GraphName::from(target),
+                    Some(transaction),
+                )?;
                 Response::builder()
                     .status(if new {
                         StatusCode::CREATED
@@ -1152,13 +1146,7 @@ fn handle_request(
                     .ok_or_else(|| unsupported_media_type(&content_type))?;
                 let mut transaction = store.start_transaction().map_err(internal_server_error)?;
                 transaction.clear().map_err(internal_server_error)?;
-                if RequestParams::from_request_url(request).contains("no_transaction") {
-                    transaction.commit().map_err(internal_server_error)?;
-                    web_load_dataset(store, request, format, None)?;
-                } else {
-                    web_load_dataset(store, request, format, Some(&mut transaction))?;
-                    transaction.commit().map_err(internal_server_error)?;
-                }
+                web_load_dataset(store, request, format, Some(transaction))?;
                 Response::builder()
                     .status(StatusCode::NO_CONTENT)
                     .body(Body::empty())
@@ -1902,7 +1890,7 @@ fn web_load_graph(
     request: &mut Request<Body>,
     format: RdfFormat,
     to_graph_name: &GraphName,
-    transaction: Option<&mut Transaction<'_>>,
+    transaction: Option<Transaction<'_>>,
 ) -> Result<(), HttpError> {
     let args = RequestParams::from_request_url(request);
     let base_iri = if let GraphName::NamedNode(graph_name) = to_graph_name {
@@ -1920,15 +1908,19 @@ fn web_load_graph(
         parser = parser.with_base_iri(base_iri).map_err(bad_request)?;
     }
     if args.contains("no_transaction") {
+        if let Some(transaction) = transaction {
+            transaction.commit().map_err(internal_server_error)?;
+        }
         let mut loader = web_bulk_loader(store, request);
         loader
             .load_from_reader(parser, request.body_mut())
             .map_err(loader_to_http_error)?;
         loader.commit().map_err(internal_server_error)
-    } else if let Some(transaction) = transaction {
+    } else if let Some(mut transaction) = transaction {
         transaction
             .load_from_reader(parser, request.body_mut())
-            .map_err(loader_to_http_error)
+            .map_err(loader_to_http_error)?;
+        transaction.commit().map_err(internal_server_error)
     } else {
         store
             .load_from_reader(parser, request.body_mut())
@@ -1940,7 +1932,7 @@ fn web_load_dataset(
     store: &Store,
     request: &mut Request<Body>,
     format: RdfFormat,
-    transaction: Option<&mut Transaction<'_>>,
+    transaction: Option<Transaction<'_>>,
 ) -> Result<(), HttpError> {
     let args = RequestParams::from_request_url(request);
     let mut parser = RdfParser::from_format(format);
@@ -1948,15 +1940,19 @@ fn web_load_dataset(
         parser = parser.lenient();
     }
     if args.contains("no_transaction") {
+        if let Some(transaction) = transaction {
+            transaction.commit().map_err(internal_server_error)?;
+        }
         let mut loader = web_bulk_loader(store, request);
         loader
             .load_from_reader(parser, request.body_mut())
             .map_err(loader_to_http_error)?;
         loader.commit().map_err(internal_server_error)
-    } else if let Some(transaction) = transaction {
+    } else if let Some(mut transaction) = transaction {
         transaction
             .load_from_reader(parser, request.body_mut())
-            .map_err(loader_to_http_error)
+            .map_err(loader_to_http_error)?;
+        transaction.commit().map_err(internal_server_error)
     } else {
         store
             .load_from_reader(parser, request.body_mut())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ use oxigraph::io::{DocumentLoader, JsonLdProfileSet, RdfFormat, RdfParser, RdfSe
 use oxigraph::model::{GraphName, IriParseError, NamedNode, NamedOrBlankNode, OxString};
 use oxigraph::sparql::results::{QueryResultsFormat, QueryResultsSerializer};
 use oxigraph::sparql::{CancellationToken, QueryResults, SparqlEvaluator};
-use oxigraph::store::{BulkLoader, LoaderError, Store};
+use oxigraph::store::{BulkLoader, LoaderError, Store, Transaction};
 use oxiri::{Iri, IriRef};
 use rand::random;
 use rayon_core::ThreadPoolBuilder;
@@ -1103,31 +1103,42 @@ fn handle_request(
             if let Some(target) = store_target(request)? {
                 let format = RdfFormat::from_media_type(&content_type)
                     .ok_or_else(|| unsupported_media_type(&content_type))?;
-                let new = !match &target {
+                let mut transaction = store.start_transaction().map_err(internal_server_error)?;
+                let new = match &target {
                     NamedGraphName::NamedNode(target) => {
-                        if store
+                        if transaction
                             .contains_named_graph(&target.clone().into())
                             .map_err(internal_server_error)?
                         {
-                            store
+                            transaction
                                 .clear_graph(&target.clone().into())
                                 .map_err(internal_server_error)?;
-                            true
-                        } else {
-                            store
-                                .insert_named_graph(target.clone())
-                                .map_err(internal_server_error)?;
                             false
+                        } else {
+                            transaction.insert_named_graph(target.clone());
+                            true
                         }
                     }
                     NamedGraphName::DefaultGraph => {
-                        store
+                        transaction
                             .clear_graph(&GraphName::DefaultGraph)
                             .map_err(internal_server_error)?;
-                        true
+                        false
                     }
                 };
-                web_load_graph(store, request, format, &GraphName::from(target))?;
+                if RequestParams::from_request_url(request).contains("no_transaction") {
+                    transaction.commit().map_err(internal_server_error)?;
+                    web_load_graph(store, request, format, &GraphName::from(target), None)?;
+                } else {
+                    web_load_graph(
+                        store,
+                        request,
+                        format,
+                        &GraphName::from(target),
+                        Some(&mut transaction),
+                    )?;
+                    transaction.commit().map_err(internal_server_error)?;
+                }
                 Response::builder()
                     .status(if new {
                         StatusCode::CREATED
@@ -1139,8 +1150,15 @@ fn handle_request(
             } else {
                 let format = RdfFormat::from_media_type(&content_type)
                     .ok_or_else(|| unsupported_media_type(&content_type))?;
-                store.clear().map_err(internal_server_error)?;
-                web_load_dataset(store, request, format)?;
+                let mut transaction = store.start_transaction().map_err(internal_server_error)?;
+                transaction.clear().map_err(internal_server_error)?;
+                if RequestParams::from_request_url(request).contains("no_transaction") {
+                    transaction.commit().map_err(internal_server_error)?;
+                    web_load_dataset(store, request, format, None)?;
+                } else {
+                    web_load_dataset(store, request, format, Some(&mut transaction))?;
+                    transaction.commit().map_err(internal_server_error)?;
+                }
                 Response::builder()
                     .status(StatusCode::NO_CONTENT)
                     .body(Body::empty())
@@ -1190,7 +1208,7 @@ fn handle_request(
                 let format = RdfFormat::from_media_type(&content_type)
                     .ok_or_else(|| unsupported_media_type(&content_type))?;
                 let new = assert_that_graph_exists(store, &target).is_ok();
-                web_load_graph(store, request, format, &GraphName::from(target))?;
+                web_load_graph(store, request, format, &GraphName::from(target), None)?;
                 Response::builder()
                     .status(if new {
                         StatusCode::CREATED
@@ -1203,12 +1221,12 @@ fn handle_request(
                 let format = RdfFormat::from_media_type(&content_type)
                     .ok_or_else(|| unsupported_media_type(&content_type))?;
                 if format.supports_datasets() {
-                    web_load_dataset(store, request, format)?;
+                    web_load_dataset(store, request, format, None)?;
                     Response::builder().status(StatusCode::NO_CONTENT)
                 } else {
                     let graph =
                         resolve_with_base(request, &format!("/store/{:x}", random::<u128>()))?;
-                    web_load_graph(store, request, format, &graph.clone().into())?;
+                    web_load_graph(store, request, format, &graph.clone().into(), None)?;
                     Response::builder()
                         .status(StatusCode::CREATED)
                         .header(LOCATION, graph.as_str())
@@ -1884,6 +1902,7 @@ fn web_load_graph(
     request: &mut Request<Body>,
     format: RdfFormat,
     to_graph_name: &GraphName,
+    transaction: Option<&mut Transaction<'_>>,
 ) -> Result<(), HttpError> {
     let args = RequestParams::from_request_url(request);
     let base_iri = if let GraphName::NamedNode(graph_name) = to_graph_name {
@@ -1906,6 +1925,10 @@ fn web_load_graph(
             .load_from_reader(parser, request.body_mut())
             .map_err(loader_to_http_error)?;
         loader.commit().map_err(internal_server_error)
+    } else if let Some(transaction) = transaction {
+        transaction
+            .load_from_reader(parser, request.body_mut())
+            .map_err(loader_to_http_error)
     } else {
         store
             .load_from_reader(parser, request.body_mut())
@@ -1917,6 +1940,7 @@ fn web_load_dataset(
     store: &Store,
     request: &mut Request<Body>,
     format: RdfFormat,
+    transaction: Option<&mut Transaction<'_>>,
 ) -> Result<(), HttpError> {
     let args = RequestParams::from_request_url(request);
     let mut parser = RdfParser::from_format(format);
@@ -1929,6 +1953,10 @@ fn web_load_dataset(
             .load_from_reader(parser, request.body_mut())
             .map_err(loader_to_http_error)?;
         loader.commit().map_err(internal_server_error)
+    } else if let Some(transaction) = transaction {
+        transaction
+            .load_from_reader(parser, request.body_mut())
+            .map_err(loader_to_http_error)
     } else {
         store
             .load_from_reader(parser, request.body_mut())
@@ -3349,6 +3377,61 @@ mod tests {
         server.test_body(
             request,
             "<http://example.com> <http://example.com/p> <http://example.com/o2> .\n",
+        )
+    }
+
+    #[test]
+    fn graph_store_put_parse_error_preserves_existing_data() -> Result<()> {
+        let server = ServerTest::new()?;
+
+        let triple = "<http://example.com/s> <http://example.com/p> <http://example.com/o> .";
+        server.test_status(
+            Request::builder()
+                .method(Method::PUT)
+                .uri("http://localhost/store?default")
+                .header(CONTENT_TYPE, "application/n-triples")
+                .body(triple)?,
+            StatusCode::NO_CONTENT,
+        )?;
+        server.test_status(
+            Request::builder()
+                .method(Method::PUT)
+                .uri("http://localhost/store?default")
+                .header(CONTENT_TYPE, "text/turtle")
+                .body("<http://example.com/s> <http://example.com/p> .")?,
+            StatusCode::BAD_REQUEST,
+        )?;
+        server.test_body(
+            Request::builder()
+                .uri("http://localhost/store?default")
+                .header(ACCEPT, "application/n-triples")
+                .body(())?,
+            &format!("{triple}\n"),
+        )?;
+
+        let quad = "<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/g> .";
+        server.test_status(
+            Request::builder()
+                .method(Method::PUT)
+                .uri("http://localhost/store")
+                .header(CONTENT_TYPE, "application/n-quads")
+                .body(quad)?,
+            StatusCode::NO_CONTENT,
+        )?;
+        server.test_status(
+            Request::builder()
+                .method(Method::PUT)
+                .uri("http://localhost/store")
+                .header(CONTENT_TYPE, "application/n-quads")
+                .body("<http://example.com/s> <http://example.com/p> .")?,
+            StatusCode::BAD_REQUEST,
+        )?;
+        server.test_body(
+            Request::builder()
+                .uri("http://localhost/store")
+                .header(ACCEPT, "application/n-quads")
+                .body(())?,
+            &format!("{quad}\n"),
         )
     }
 


### PR DESCRIPTION
## Summary

- run Graph Store `PUT` clear and load operations in the same transaction
- preserve the existing `no_transaction` bulk-loading behavior
- add a regression test for failed default-graph and whole-dataset replacements

If parsing a transactional `PUT` fails, dropping the transaction now rolls back the preceding clear and leaves the existing data unchanged.

Closes #1895.

## Validation

- `cargo fmt -- --check`
- `taplo check`
- `cargo test --package oxigraph-cli graph_store_put_parse_error_preserves_existing_data`
- `cargo test --package oxigraph-cli graph_store`
- `cargo test --features rdf-12`
- `cd cli && cargo clippy --all-targets -- -D warnings -D clippy::all`
- `cd cli && cargo clippy --all-targets --no-default-features -- -D warnings -D clippy::all`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
