### PR TITLE
Fix Graph Store POST creation status

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1195,7 +1195,11 @@ fn handle_request(
             if let Some(target) = store_target(request)? {
                 let format = RdfFormat::from_media_type(&content_type)
                     .ok_or_else(|| unsupported_media_type(&content_type))?;
-                let new = assert_that_graph_exists(store, &target).is_ok();
+                let new = match assert_that_graph_exists(store, &target) {
+                    Ok(()) => false,
+                    Err((StatusCode::NOT_FOUND, _)) => true,
+                    Err(error) => return Err(error),
+                };
                 web_load_graph(store, request, format, &GraphName::from(target), None)?;
                 Response::builder()
                     .status(if new {
@@ -3345,7 +3349,7 @@ mod tests {
             .uri("http://localhost/store?graph=http://example.com")
             .header(CONTENT_TYPE, "text/turtle")
             .body("<> <http://example.com/p> <http://example.com/o1> .")?;
-        server.test_status(request, StatusCode::NO_CONTENT)?;
+        server.test_status(request, StatusCode::CREATED)?;
 
         // GET
         let request = Request::builder()
@@ -3610,7 +3614,7 @@ mod tests {
 
         // POST - existing graph
         let request = Request::builder()
-            .method(Method::PUT)
+            .method(Method::POST)
             .uri("http://localhost/store/person/1.ttl")
             .header(CONTENT_TYPE, "text/turtle; charset=utf-8")
             .body(())?;
@@ -3649,7 +3653,7 @@ mod tests {
 
         // POST - empty graph to existing graph
         let request = Request::builder()
-            .method(Method::PUT)
+            .method(Method::POST)
             .uri(location)
             .header(CONTENT_TYPE, "text/turtle; charset=utf-8")
             .body(())?;
@@ -3678,7 +3682,7 @@ mod tests {
             .uri("http://localhost/store/person/1.ttl?no_transaction&lenient")
             .header(CONTENT_TYPE, "text/turtle; charset=utf-8")
             .body(invalid_data)?;
-        server.test_status(request, StatusCode::NO_CONTENT)?;
+        server.test_status(request, StatusCode::CREATED)?;
 
         // GET of POST
         let request = Request::builder()
@@ -3750,7 +3754,7 @@ mod tests {
             .uri("http://localhost/store?lenient&graph=http://example.com")
             .header(CONTENT_TYPE, "text/turtle")
             .body("< s> < p> \"\\uD83D\\uDC68\" .")?;
-        server.test_status(request, StatusCode::NO_CONTENT)?;
+        server.test_status(request, StatusCode::CREATED)?;
 
         // GET
         let request = Request::builder()


### PR DESCRIPTION
Closes #1898.

## Summary

- Return `201 Created` when a targeted Graph Store `POST` creates a missing named graph.
- Return `204 No Content` when a targeted `POST` merges into an existing graph.
- Exercise both states in the existing Graph Store tests, including lenient and `no_transaction` paths.

## Why

The targeted `POST` handler used `assert_that_graph_exists(...).is_ok()` as its `new` flag. That made the flag true for an existing graph and false for a missing graph, reversing the two success statuses. The replacement treats only the helper's `404 Not Found` result as a new graph and still propagates storage errors.

## Validation

- [x] `cargo test -p oxigraph-cli graph_store -- --nocapture`
- [x] `cargo test -p oxigraph-cli lenient_load -- --nocapture`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all` (from `cli/`)
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings -D clippy::all` (from `cli/`)
- [x] `cargo test --workspace --exclude sparql-smith`
