### PR TITLE
Fix JSON-LD scoped contexts and expansion options

### DIFF
--- a/lib/oxjsonld/README.md
+++ b/lib/oxjsonld/README.md
@@ -16,6 +16,18 @@ The parser supports two modes:
 - [Streaming JSON-LD](https://www.w3.org/TR/json-ld11-streaming/) that can avoid buffering in a few cases.
 - To enable it, call the [`with_profile(JsonLdProfile::Streaming)`](JsonLdParser::with_profile) method.
 
+## Standards support
+
+OxJSON-LD follows the latest JSON-LD processing algorithms. The
+`JsonLdProcessingMode::JsonLd1_0` mode rejects JSON-LD 1.1-only features, but
+is not a strict backward-compatibility mode for algorithm edge cases that
+changed between JSON-LD 1.0 and 1.1.
+
+When the `rdf-12` feature is enabled, JSON-LD base direction is converted to
+native RDF 1.2 directional language-tagged literals. Without this feature,
+base direction is ignored. The alternative JSON-LD 1.1 `rdfDirection`
+representations (`i18n-datatype` and `compound-literal`) are not supported.
+
 Usage example counting the number of people in a JSON-LD file:
 
 ```rust

--- a/lib/oxjsonld/src/context.rs
+++ b/lib/oxjsonld/src/context.rs
@@ -86,6 +86,7 @@ pub struct JsonLdLoadDocumentOptions {
 }
 
 /// Returned information about a remote JSON-LD document or context.
+#[derive(Clone)]
 pub struct JsonLdRemoteDocument {
     /// The retrieved document
     pub document: Vec<u8>,
@@ -318,12 +319,17 @@ impl JsonLdContextProcessor {
                         }
                         // 5.7.3) and 5.7.4)
                         JsonNode::String(value) => {
+                            let has_absolute_iri_form =
+                                IriRef::parse_unchecked(value.clone()).is_absolute();
                             match self.resolve_iri(
                                 value,
                                 result.base_iri.as_ref(),
                                 JsonLdErrorCode::InvalidBaseIri,
                             ) {
                                 Ok(base_iri) => result.base_iri = Some(base_iri),
+                                // Invalid IRIs are discarded during RDF conversion. Do not
+                                // fall back to the previous base for relative values.
+                                Err(_) if has_absolute_iri_form => result.base_iri = None,
                                 Err(e) => errors.push(e),
                             }
                         }
@@ -1499,7 +1505,7 @@ pub fn is_keyword(value: &str) -> bool {
     )
 }
 
-fn json_slice_to_node(data: &[u8]) -> Result<JsonNode, JsonSyntaxError> {
+pub(crate) fn json_slice_to_node(data: &[u8]) -> Result<JsonNode, JsonSyntaxError> {
     let mut parser = SliceJsonParser::new(data);
     json_node_from_events(std::iter::from_fn(|| match parser.parse_next() {
         Ok(JsonEvent::Eof) => None,

--- a/lib/oxjsonld/src/expansion.rs
+++ b/lib/oxjsonld/src/expansion.rs
@@ -1,6 +1,6 @@
 use crate::context::{
     JsonLdContext, JsonLdContextProcessor, JsonLdLoadDocumentOptions, JsonLdRemoteDocument,
-    has_keyword_form, is_keyword, json_node_from_events,
+    JsonNode, has_keyword_form, is_keyword, json_node_from_events, json_slice_to_node,
 };
 use crate::error::JsonLdErrorCode;
 use crate::profile::JsonLdProcessingMode;
@@ -49,6 +49,9 @@ pub enum JsonLdValue {
 }
 
 enum JsonLdExpansionState {
+    Initialize {
+        expand_context: JsonLdRemoteDocument,
+    },
     Element {
         active_property: Option<OxString>,
         active_context: Arc<JsonLdContext>,
@@ -248,18 +251,24 @@ impl JsonLdExpansionConverter {
         streaming: bool,
         lenient: bool,
         processing_mode: JsonLdProcessingMode,
+        expand_context: Option<JsonLdRemoteDocument>,
     ) -> Self {
         let root_context = Arc::new(JsonLdContext::new_empty(base_url.clone()));
+        let element_state = JsonLdExpansionState::Element {
+            active_property: None,
+            active_context: Arc::clone(&root_context),
+            is_array: false,
+            container: &[],
+            reverse: false,
+            in_included: false,
+            extra_node: None,
+        };
         Self {
-            state: vec![JsonLdExpansionState::Element {
-                active_property: None,
-                active_context: Arc::clone(&root_context),
-                is_array: false,
-                container: &[],
-                reverse: false,
-                in_included: false,
-                extra_node: None,
-            }],
+            state: if let Some(expand_context) = expand_context {
+                vec![JsonLdExpansionState::Initialize { expand_context }]
+            } else {
+                vec![element_state]
+            },
             is_end: false,
             streaming,
             lenient,
@@ -311,6 +320,19 @@ impl JsonLdExpansionConverter {
         // Large hack to fetch the last state but keep it if we are in an array
         let state = self.state.pop().expect("Empty stack");
         match state {
+            JsonLdExpansionState::Initialize { expand_context } => {
+                self.apply_expand_context(expand_context, errors);
+                self.state.push(JsonLdExpansionState::Element {
+                    active_property: None,
+                    active_context: Arc::clone(&self.root_context),
+                    is_array: false,
+                    container: &[],
+                    reverse: false,
+                    in_included: false,
+                    extra_node: None,
+                });
+                self.convert_event(event, results, errors);
+            }
             JsonLdExpansionState::Element {
                 active_property,
                 mut active_context,
@@ -2258,8 +2280,17 @@ impl JsonLdExpansionConverter {
                 JsonEvent::ObjectKey(key) => {
                     // Events for the @index
                     let mut map_context = Arc::clone(&active_context);
-                    if let Some(parent_context) = &map_context.previous_context {
-                        map_context = Arc::clone(parent_context);
+                    if container.contains(&"@id") || container.contains(&"@type") {
+                        if let Some(parent_context) = &map_context.previous_context {
+                            map_context = Arc::clone(parent_context);
+                        }
+                    }
+                    if container.contains(&"@type") {
+                        if let Some(scoped_context) =
+                            self.new_scoped_context(&map_context, key.as_ref(), false, true, errors)
+                        {
+                            map_context = Arc::new(scoped_context);
+                        }
                     }
                     let extra_node = if self
                         .expand_iri(&active_context, OxString::new_owned(&key), false, true)
@@ -2689,6 +2720,34 @@ impl JsonLdExpansionConverter {
         }
     }
 
+    fn apply_expand_context(
+        &mut self,
+        expand_context: JsonLdRemoteDocument,
+        errors: &mut Vec<JsonLdSyntaxError>,
+    ) {
+        let context_base = Iri::parse(expand_context.document_url).ok();
+        let local_context = match json_slice_to_node(&expand_context.document) {
+            Ok(JsonNode::Object(mut context)) => context
+                .remove("@context")
+                .unwrap_or(JsonNode::Object(context)),
+            Ok(context) => context,
+            Err(error) => {
+                errors.push(error.into());
+                return;
+            }
+        };
+        self.root_context = Arc::new(self.context_processor.process_context(
+            &self.root_context,
+            local_context,
+            context_base.as_ref().or(self.base_url.as_ref()),
+            &mut Vec::new(),
+            false,
+            true,
+            true,
+            errors,
+        ));
+    }
+
     /// [IRI Expansion](https://www.w3.org/TR/json-ld-api/#iri-expansion)
     ///
     /// `local context` is always `null`
@@ -3038,7 +3097,8 @@ impl JsonLdExpansionConverter {
                 | JsonLdExpansionState::NestStart { active_context, .. } => {
                     return active_context;
                 }
-                JsonLdExpansionState::Index
+                JsonLdExpansionState::Initialize { .. }
+                | JsonLdExpansionState::Index
                 | JsonLdExpansionState::Graph
                 | JsonLdExpansionState::RootGraph
                 | JsonLdExpansionState::Included

--- a/lib/oxjsonld/src/to_rdf.rs
+++ b/lib/oxjsonld/src/to_rdf.rs
@@ -65,6 +65,7 @@ pub struct JsonLdParser {
     lenient: bool,
     profile: JsonLdProfileSet,
     base: Option<Iri<OxString>>,
+    expand_context: Option<JsonLdRemoteDocument>,
 }
 
 impl JsonLdParser {
@@ -140,6 +141,15 @@ impl JsonLdParser {
     pub fn with_base_iri(mut self, base_iri: &str) -> Result<Self, IriParseError> {
         self.base = Some(Iri::parse(OxString::new_owned(base_iri))?);
         Ok(self)
+    }
+
+    /// Sets a context to apply before expanding the input document.
+    ///
+    /// It corresponds to the [`expandContext` option from the algorithm specification](https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-expandcontext).
+    #[inline]
+    pub fn with_expand_context(mut self, expand_context: JsonLdRemoteDocument) -> Self {
+        self.expand_context = Some(expand_context);
+        self
     }
 
     /// Parses a JSON-LD file from a [`Read`] implementation.
@@ -286,6 +296,7 @@ impl JsonLdParser {
                 self.profile.contains(JsonLdProfile::Streaming),
                 self.lenient,
                 self.processing_mode,
+                self.expand_context,
             ),
             expended_events: Vec::new(),
             to_rdf: JsonLdToRdfConverter {

--- a/testsuite/src/parser_evaluator.rs
+++ b/testsuite/src/parser_evaluator.rs
@@ -199,14 +199,22 @@ fn evaluate_jsonld_to_rdf_test(test: &Test) -> Result<()> {
             None
         }
     });
+    let expand_context = test.option.get(&jld::EXPAND_CONTEXT).and_then(|t| {
+        if let Term::NamedNode(i) = t {
+            Some(i.as_str())
+        } else {
+            None
+        }
+    });
     if test
         .kinds
         .iter()
         .any(|t| t.as_ref() == jld::POSITIVE_EVALUATION_TEST)
     {
         let action = test.action.as_deref().context("No action found")?;
-        let mut actual_dataset = parse_json_ld(action, profile, processing_mode, base_url)?
-            .with_context(|| format!("Parse error on file {action}"))?;
+        let mut actual_dataset =
+            parse_json_ld(action, profile, processing_mode, base_url, expand_context)?
+                .with_context(|| format!("Parse error on file {action}"))?;
         actual_dataset.canonicalize(CanonicalizationAlgorithm::Unstable);
         let results = test.result.as_ref().context("No tests result found")?;
         let mut expected_dataset = load_dataset(results, guess_rdf_format(results)?, false, false)
@@ -224,7 +232,7 @@ fn evaluate_jsonld_to_rdf_test(test: &Test) -> Result<()> {
         .any(|t| t.as_ref() == jld::NEGATIVE_EVALUATION_TEST)
     {
         let action = test.action.as_deref().context("No action found")?;
-        let result = parse_json_ld(action, profile, processing_mode, base_url)?;
+        let result = parse_json_ld(action, profile, processing_mode, base_url, expand_context)?;
         ensure!(
             result.is_err(),
             "Properly parsed file even if it should not"
@@ -245,7 +253,7 @@ fn evaluate_jsonld_to_rdf_test(test: &Test) -> Result<()> {
         .any(|t| t.as_ref() == jld::POSITIVE_SYNTAX_TEST)
     {
         let action = test.action.as_deref().context("No action found")?;
-        parse_json_ld(action, profile, processing_mode, base_url)?
+        parse_json_ld(action, profile, processing_mode, base_url, expand_context)?
             .with_context(|| format!("Parse error on file {action}"))?;
         Ok(())
     } else {
@@ -350,11 +358,19 @@ fn parse_json_ld(
     profile: JsonLdProfileSet,
     processing_mode: JsonLdProcessingMode,
     base_url: Option<&str>,
+    expand_context: Option<&str>,
 ) -> Result<Result<Dataset, JsonLdSyntaxError>> {
-    Ok(JsonLdParser::new()
+    let mut parser = JsonLdParser::new()
         .with_profile(profile)
         .with_processing_mode(processing_mode)
-        .with_base_iri(base_url.unwrap_or(url))?
+        .with_base_iri(base_url.unwrap_or(url))?;
+    if let Some(expand_context) = expand_context {
+        parser = parser.with_expand_context(JsonLdRemoteDocument {
+            document: read_file_to_string(expand_context)?.into(),
+            document_url: OxString::new_owned(expand_context),
+        });
+    }
+    Ok(parser
         .for_slice(&read_file_to_string(url)?)
         .with_load_document_callback(|url, _| {
             Ok(JsonLdRemoteDocument {

--- a/testsuite/src/vocab.rs
+++ b/testsuite/src/vocab.rs
@@ -99,6 +99,9 @@ pub mod jld {
 
     pub const BASE: NamedNode =
         NamedNode::new_const_unchecked("https://w3c.github.io/json-ld-api/tests/vocab#base");
+    pub const EXPAND_CONTEXT: NamedNode = NamedNode::new_const_unchecked(
+        "https://w3c.github.io/json-ld-api/tests/vocab#expandContext",
+    );
     pub const NEGATIVE_EVALUATION_TEST: NamedNode = NamedNode::new_const_unchecked(
         "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
     );

--- a/testsuite/tests/parser.rs
+++ b/testsuite/tests/parser.rs
@@ -153,10 +153,6 @@ fn jsonld_to_rdf_testsuite() -> Result<()> {
     check_testsuite(
         "https://w3c.github.io/json-ld-api/tests/toRdf-manifest.jsonld",
         &[
-            // Weird @base IRI support
-            "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12",
-            // expandContext
-            "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te077",
             // produceGeneralizedRdf
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0118",
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075",
@@ -174,9 +170,7 @@ fn jsonld_to_rdf_testsuite() -> Result<()> {
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi10",
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi11",
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi12",
-            // Scoped contexts somehow propagate to elements inside containers?
-            "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc013",
-            // specVersion json-ld-1.0
+            // JSON-LD 1.0 compatibility edge cases are intentionally not supported.
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te026",
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te071",
             "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te115",
@@ -198,8 +192,6 @@ fn jsonld_to_rdf_streaming_testsuite() -> Result<()> {
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021",
-            // expandContext option
-            "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te077",
             // normative option
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tdi09",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tdi10",
@@ -207,7 +199,6 @@ fn jsonld_to_rdf_streaming_testsuite() -> Result<()> {
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tdi12",
             // produceGeneralizedRdf option
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#t0118",
-            "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te068",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te075",
             // rdfDirection option
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tdi09",
@@ -223,8 +214,7 @@ fn jsonld_to_rdf_streaming_testsuite() -> Result<()> {
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tdi05",
             #[cfg(feature = "rdf-12")]
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tdi06",
-            // specVersion json-ld-1.0
-            "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te026",
+            // JSON-LD 1.0 compatibility edge cases are intentionally not supported.
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te071",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te115",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te116",
@@ -232,9 +222,8 @@ fn jsonld_to_rdf_streaming_testsuite() -> Result<()> {
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#ter03",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#ter24",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#ter32",
-            // Scoped contexts somehow propagate to elements inside containers?
-            "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tc013",
             // something is before @type
+            "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te026",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te038",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te014",
             "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tin06",


### PR DESCRIPTION
Addresses the supported subset of #1901.

## Summary

This fixes three JSON-LD expansion and toRDF conformance gaps in `oxjsonld` and its W3C harness:

- apply a type key's scoped context before expanding its type-map value, while limiting previous-context rollback to `@id` and `@type` maps;
- recover from an invalid absolute-form `@base` without reusing a stale base, allowing invalid relative RDF terms to be discarded; and
- support the JSON-LD API `expandContext` option through `JsonLdParser::with_expand_context` and the W3C harness.

The one-time expansion-context initialization uses a dedicated converter state, so the ordinary parsing path does not check an unused option for every JSON event.

The `oxjsonld` README now documents two intentional support boundaries confirmed in #1901:

- `JsonLdProcessingMode::JsonLd1_0` gates JSON-LD 1.1-only features but is not a strict backward-compatibility mode for JSON-LD 1.0 algorithm edge cases; and
- RDF direction uses native RDF 1.2 directional literals with the `rdf-12` feature and is otherwise ignored; the older `i18n-datatype` and `compound-literal` representations are not supported.

## Conformance results

Corpora:

- JSON-LD API: `289ebf37c30846ba2dab8a33559cc4d348161e0d`
- JSON-LD streaming: `948d24ce66a129734a97efba01cb5d6d8552f4f5`

| Suite | Before | After | Newly executed and passing |
| --- | ---: | ---: | ---: |
| JSON-LD toRDF | 446/467 | 449/467 | 3 |
| Streaming JSON-LD toRDF | 456/483 | 459/483 | 3 |

Newly passing standard cases: `tc013`, `te077`, and `tli12`.

Newly executed and passing streaming cases: `tc013`, `te077`, and the previously stale skip `te068`.

## Scope boundaries

The JSON-LD 1.0 compatibility and alternate RDF-direction cases remain explicitly skipped and documented as intentional non-goals. This PR also does not broaden `oxrdf` or the streaming parser's buffering contract:

- generalized-RDF cases require blank-node predicates that cannot be represented by the current `oxrdf::Quad` API; and
- remaining streaming cases require buffering for late `@id`, `@type`, or graph identity.

## Compatibility and performance

The new parser option is additive. When no expansion context is supplied, parser state and event processing remain on the existing default path.

## Verification

The following pass on branch head `9f325e1`:

```console
cd lib/oxjsonld
cargo test --all-targets
cargo test --all-targets --all-features
cargo clippy --all-targets --all-features -- -D warnings -D clippy::all
rustup run 1.87.0 cargo test --all-targets

cd ../..
cargo test -p oxigraph-testsuite --test parser --all-features
cargo test -p oxigraph-testsuite --test parser jsonld_to_rdf_ --no-default-features
cargo fmt --all --check
git diff --check
```
