### PR TITLE
Fix SPARQL slice cardinality estimates

### DIFF
--- a/lib/sparopt/src/optimizer.rs
+++ b/lib/sparopt/src/optimizer.rs
@@ -1349,9 +1349,9 @@ fn estimate_query_expression_size(
             offset,
             limit,
         } => {
-            let inner = estimate_query_expression_size(inner, input_types);
+            let inner = estimate_query_expression_size(inner, input_types).saturating_sub(*offset);
             if let Some(limit) = limit {
-                min(inner, *limit - *offset)
+                min(inner, *limit)
             } else {
                 inner
             }
@@ -1494,5 +1494,28 @@ fn does_contain_exists(expression: &Expression) -> bool {
         Expression::If(a, b, c) => {
             does_contain_exists(a) || does_contain_exists(b) || does_contain_exists(c)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn estimate_slice_size(offset: u64, limit: Option<u64>) -> u64 {
+        estimate_query_expression_size(
+            &QueryExpression::slice(
+                QueryExpression::values(Vec::new(), vec![Vec::new(); 5]),
+                offset,
+                limit,
+            ),
+            &VariableTypes::default(),
+        )
+    }
+
+    #[test]
+    fn slice_size_applies_offset_before_limit() {
+        assert_eq!(estimate_slice_size(2, Some(1)), 1);
+        assert_eq!(estimate_slice_size(6, Some(1)), 0);
+        assert_eq!(estimate_slice_size(2, None), 3);
     }
 }


### PR DESCRIPTION
Closes #1903.

## Summary

- Apply `OFFSET` to the estimated input cardinality with saturating subtraction.
- Cap the remaining cardinality with `LIMIT` instead of subtracting `OFFSET` from `LIMIT`.
- Cover ordinary limiting, `OFFSET > LIMIT`, and OFFSET-without-LIMIT estimates.

## Why

The slice estimator used `limit - offset`, even though SPARQL applies OFFSET to the input and then LIMIT to the remaining rows. When OFFSET exceeded LIMIT, debug builds and builds with overflow checks enabled panicked during join ordering. Builds without overflow checks used a wrapped, incorrect cardinality estimate. Slices without a LIMIT also failed to account for OFFSET.

## Validation

- [x] `cargo test --workspace --exclude sparql-smith`
- [x] `cargo test -p sparopt slice_size_applies_offset_before_limit`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all` from `lib/sparopt`
- [x] `cargo fmt -- --check`
- [x] Re-ran the issue reproduction through `oxigraph query`; it now succeeds with the expected empty result set.

No documentation changes are needed because this corrects an internal optimizer estimate without changing the SPARQL interface.
