### PR TITLE
Reject incomplete SPARQL boolean results

### DIFF
--- a/lib/sparesults/src/json.rs
+++ b/lib/sparesults/src/json.rs
@@ -462,7 +462,7 @@ enum JsonInnerReaderState {
     },
     AfterBindings,
     BeforeBoolean,
-    AfterRoot(bool),
+    AfterRoot,
     Ignore {
         level: usize,
         after: JsonInnerReaderStateAfterIgnore,
@@ -513,8 +513,14 @@ impl JsonInnerReader {
                         Ok(None)
                     }
                     "results" => {
-                        self.state = JsonInnerReaderState::BeforeResults;
-                        Ok(None)
+                        if self.boolean.is_some() {
+                            Err(QueryResultsSyntaxError::msg(
+                                "SPARQL JSON results must not contain both 'boolean' and 'results' keys",
+                            ))
+                        } else {
+                            self.state = JsonInnerReaderState::BeforeResults;
+                            Ok(None)
+                        }
                     }
                     "boolean" => {
                         self.state = JsonInnerReaderState::BeforeBoolean;
@@ -529,8 +535,8 @@ impl JsonInnerReader {
                     }
                 },
                 JsonEvent::EndObject => {
-                    if let Some(value) = self.boolean {
-                        self.state = JsonInnerReaderState::AfterRoot(value);
+                    if self.boolean.is_some() {
+                        self.state = JsonInnerReaderState::AfterRoot;
                         Ok(None)
                     } else {
                         Err(QueryResultsSyntaxError::msg(
@@ -760,9 +766,14 @@ impl JsonInnerReader {
                     Err(QueryResultsSyntaxError::msg("Unexpected boolean value"))
                 }
             }
-            JsonInnerReaderState::AfterRoot(value) => {
+            JsonInnerReaderState::AfterRoot => {
                 if event == JsonEvent::Eof {
-                    Ok(Some(JsonInnerQueryResults::Boolean(*value)))
+                    let value = self.boolean.ok_or_else(|| {
+                        QueryResultsSyntaxError::msg(
+                            "SPARQL JSON results must contain a 'boolean' key",
+                        )
+                    })?;
+                    Ok(Some(JsonInnerQueryResults::Boolean(value)))
                 } else {
                     Err(QueryResultsSyntaxError::msg(
                         "Extra JSON is not allowed at the end of the document",

--- a/lib/sparesults/src/json.rs
+++ b/lib/sparesults/src/json.rs
@@ -437,6 +437,7 @@ struct JsonInnerReader {
     solutions: Vec<(Vec<OxString>, Vec<Term>)>,
     vars_read: bool,
     solutions_read: bool,
+    boolean: Option<bool>,
 }
 
 #[expect(clippy::allow_attributes)]
@@ -461,6 +462,7 @@ enum JsonInnerReaderState {
     },
     AfterBindings,
     BeforeBoolean,
+    AfterRoot(bool),
     Ignore {
         level: usize,
         after: JsonInnerReaderStateAfterIgnore,
@@ -485,6 +487,7 @@ impl JsonInnerReader {
             solutions: Vec::new(),
             vars_read: false,
             solutions_read: false,
+            boolean: None,
         }
     }
 
@@ -525,9 +528,16 @@ impl JsonInnerReader {
                         Ok(None)
                     }
                 },
-                JsonEvent::EndObject => Err(QueryResultsSyntaxError::msg(
-                    "SPARQL JSON results must contain a 'boolean' or a 'results' key",
-                )),
+                JsonEvent::EndObject => {
+                    if let Some(value) = self.boolean {
+                        self.state = JsonInnerReaderState::AfterRoot(value);
+                        Ok(None)
+                    } else {
+                        Err(QueryResultsSyntaxError::msg(
+                            "SPARQL JSON results must contain a 'boolean' or a 'results' key",
+                        ))
+                    }
+                }
                 _ => unreachable!(),
             },
             JsonInnerReaderState::BeforeHead => {
@@ -743,9 +753,20 @@ impl JsonInnerReader {
             }
             JsonInnerReaderState::BeforeBoolean => {
                 if let JsonEvent::Boolean(v) = event {
-                    Ok(Some(JsonInnerQueryResults::Boolean(v)))
+                    self.boolean = Some(v);
+                    self.state = JsonInnerReaderState::InRootObject;
+                    Ok(None)
                 } else {
                     Err(QueryResultsSyntaxError::msg("Unexpected boolean value"))
+                }
+            }
+            JsonInnerReaderState::AfterRoot(value) => {
+                if event == JsonEvent::Eof {
+                    Ok(Some(JsonInnerQueryResults::Boolean(*value)))
+                } else {
+                    Err(QueryResultsSyntaxError::msg(
+                        "Extra JSON is not allowed at the end of the document",
+                    ))
                 }
             }
             #[expect(clippy::ref_patterns)]

--- a/lib/sparesults/src/xml.rs
+++ b/lib/sparesults/src/xml.rs
@@ -478,6 +478,8 @@ enum ResultsState {
     Head,
     AfterHead,
     Boolean,
+    AfterBoolean(bool),
+    AfterSparql(bool),
 }
 
 struct XmlInnerQueryResultsParser {
@@ -503,7 +505,11 @@ impl XmlInnerQueryResultsParser {
                         self.state = ResultsState::Sparql;
                         Ok(None)
                     } else {
-                        Err(QueryResultsSyntaxError::msg(format!("Expecting <sparql> tag, found <{}>", event.name().into_inner())).into())
+                        Err(QueryResultsSyntaxError::msg(format!(
+                            "Expecting <sparql> tag, found <{}>",
+                            event.name().into_inner()
+                        ))
+                        .into())
                     }
                 }
                 ResultsState::Sparql => {
@@ -511,22 +517,33 @@ impl XmlInnerQueryResultsParser {
                         self.state = ResultsState::Head;
                         Ok(None)
                     } else {
-                        Err(QueryResultsSyntaxError::msg(format!("Expecting <head> tag, found <{}>", event.name().into_inner())).into())
+                        Err(QueryResultsSyntaxError::msg(format!(
+                            "Expecting <head> tag, found <{}>",
+                            event.name().into_inner()
+                        ))
+                        .into())
                     }
                 }
                 ResultsState::Head => {
                     if event.local_name().into_inner() == "variable" {
-                        let name = event.attributes()
+                        let name = event
+                            .attributes()
                             .filter_map(Result::ok)
                             .find(|attr| attr.key.local_name().into_inner() == "name")
-                            .ok_or_else(|| QueryResultsSyntaxError::msg("No name attribute found for the <variable> tag"))?;
+                            .ok_or_else(|| {
+                                QueryResultsSyntaxError::msg(
+                                    "No name attribute found for the <variable> tag",
+                                )
+                            })?;
                         let name = name.normalized_value(self.xml_version)?;
-                        let variable = Variable::new(OxString::new_owned(&name)).map_err(|e| QueryResultsSyntaxError::msg(format!("Invalid variable name: {e}")))?;
+                        let variable = Variable::new(OxString::new_owned(&name)).map_err(|e| {
+                            QueryResultsSyntaxError::msg(format!("Invalid variable name: {e}"))
+                        })?;
                         if self.variables.contains(&variable) {
                             return Err(QueryResultsSyntaxError::msg(format!(
                                 "The variable {variable} is declared twice"
                             ))
-                                .into());
+                            .into());
                         }
                         self.variables.push(variable);
                         Ok(None)
@@ -534,7 +551,11 @@ impl XmlInnerQueryResultsParser {
                         // no op
                         Ok(None)
                     } else {
-                        Err(QueryResultsSyntaxError::msg(format!("Expecting <variable> or <link> tag, found <{}>", event.name().into_inner())).into())
+                        Err(QueryResultsSyntaxError::msg(format!(
+                            "Expecting <variable> or <link> tag, found <{}>",
+                            event.name().into_inner()
+                        ))
+                        .into())
                     }
                 }
                 ResultsState::AfterHead => {
@@ -567,16 +588,37 @@ impl XmlInnerQueryResultsParser {
                                 xml_version: self.xml_version,
                             },
                         }))
-                    } else if event.local_name().into_inner() != "link" && event.local_name().into_inner() != "results" && event.local_name().into_inner() != "boolean" {
-                        Err(QueryResultsSyntaxError::msg(format!("Expecting sparql tag, found <{}>", event.name().into_inner())).into())
+                    } else if event.local_name().into_inner() != "link"
+                        && event.local_name().into_inner() != "results"
+                        && event.local_name().into_inner() != "boolean"
+                    {
+                        Err(QueryResultsSyntaxError::msg(format!(
+                            "Expecting sparql tag, found <{}>",
+                            event.name().into_inner()
+                        ))
+                        .into())
                     } else {
                         Ok(None)
                     }
                 }
-                ResultsState::Boolean => Err(QueryResultsSyntaxError::msg(format!("Unexpected tag inside of <boolean> tag: <{}>", event.name().into_inner())).into())
+                ResultsState::Boolean => Err(QueryResultsSyntaxError::msg(format!(
+                    "Unexpected tag inside of <boolean> tag: <{}>",
+                    event.name().into_inner()
+                ))
+                .into()),
+                ResultsState::AfterBoolean(_) => Err(QueryResultsSyntaxError::msg(format!(
+                    "Expecting </sparql> tag, found <{}>",
+                    event.name().into_inner()
+                ))
+                .into()),
+                ResultsState::AfterSparql(_) => Err(QueryResultsSyntaxError::msg(
+                    "Extra XML is not allowed at the end of the document",
+                )
+                .into()),
             },
             Event::Text(event) => {
-                self.text_buffer.push_str(&event.xml_content(self.xml_version));
+                self.text_buffer
+                    .push_str(&event.xml_content(self.xml_version));
                 Ok(None)
             }
             Event::GeneralRef(event) => {
@@ -588,12 +630,28 @@ impl XmlInnerQueryResultsParser {
                 let value = value.trim_matches(|c| matches!(c, '\t' | '\n' | '\r' | ' '));
                 match self.state {
                     ResultsState::Boolean => {
-                        if value == "true" {
-                            Ok(Some(XmlInnerQueryResults::Boolean(true)))
+                        let value = if value == "true" {
+                            true
                         } else if value == "false" {
-                            Ok(Some(XmlInnerQueryResults::Boolean(false)))
+                            false
                         } else {
-                            Err(QueryResultsSyntaxError::msg(format!("Unexpected boolean value. Found '{value}'")).into())
+                            return Err(QueryResultsSyntaxError::msg(format!(
+                                "Unexpected boolean value. Found '{value}'"
+                            ))
+                            .into());
+                        };
+                        self.state = ResultsState::AfterBoolean(value);
+                        Ok(None)
+                    }
+                    ResultsState::AfterBoolean(boolean) => {
+                        if event.local_name().into_inner() == "sparql" && value.is_empty() {
+                            self.state = ResultsState::AfterSparql(boolean);
+                            Ok(None)
+                        } else {
+                            Err(QueryResultsSyntaxError::msg(
+                                "Expecting </sparql> tag after the boolean result",
+                            )
+                            .into())
                         }
                     }
                     ResultsState::Head => {
@@ -602,28 +660,46 @@ impl XmlInnerQueryResultsParser {
                         }
                         Ok(None)
                     }
-                    _ => if value.is_empty() {
-                        Err(QueryResultsSyntaxError::msg("Unexpected early file end. All results file must have a <head> and a <result> or <boolean> tag").into())
-                    } else {
-                        Err(QueryResultsSyntaxError::msg(format!("Unexpected textual value found: '{value}'")).into())
+                    _ => {
+                        if value.is_empty() {
+                            Err(QueryResultsSyntaxError::msg("Unexpected early file end. All results file must have a <head> and a <result> or <boolean> tag").into())
+                        } else {
+                            Err(QueryResultsSyntaxError::msg(format!(
+                                "Unexpected textual value found: '{value}'"
+                            ))
+                            .into())
+                        }
                     }
                 }
             }
-            Event::Eof => Err(QueryResultsSyntaxError::msg("Unexpected early file end. All results file must have a <head> and a <result> or <boolean> tag").into()),
+            Event::Eof => {
+                if let ResultsState::AfterSparql(value) = self.state {
+                    if self
+                        .text_buffer
+                        .trim_matches(|c| matches!(c, '\t' | '\n' | '\r' | ' '))
+                        .is_empty()
+                    {
+                        Ok(Some(XmlInnerQueryResults::Boolean(value)))
+                    } else {
+                        Err(QueryResultsSyntaxError::msg(
+                            "Extra XML is not allowed at the end of the document",
+                        )
+                        .into())
+                    }
+                } else {
+                    Err(QueryResultsSyntaxError::msg("Unexpected early file end. All results file must have a <head> and a <result> or <boolean> tag").into())
+                }
+            }
             Event::Decl(event) => {
                 self.xml_version = event.xml_version()?;
                 Ok(None)
             }
-            Event::Comment(_) | Event::PI(_) | Event::DocType(_) => {
-                Ok(None)
-            }
+            Event::Comment(_) | Event::PI(_) | Event::DocType(_) => Ok(None),
             Event::Empty(_) => unreachable!("Empty events are expended"),
-            Event::CData(_) => {
-                Err(QueryResultsSyntaxError::msg(
-                    "<![CDATA[...]]> are not supported in SPARQL XML results",
-                )
-                    .into())
-            }
+            Event::CData(_) => Err(QueryResultsSyntaxError::msg(
+                "<![CDATA[...]]> are not supported in SPARQL XML results",
+            )
+            .into()),
         }
     }
 }

--- a/testsuite/oxigraph-tests/sparql-results/boolean_and_results.srj
+++ b/testsuite/oxigraph-tests/sparql-results/boolean_and_results.srj
@@ -1,0 +1,1 @@
+{"boolean":true,"results":{"bindings":[]}}

--- a/testsuite/oxigraph-tests/sparql-results/boolean_before_head.srj
+++ b/testsuite/oxigraph-tests/sparql-results/boolean_before_head.srj
@@ -1,0 +1,1 @@
+{"boolean":true,"head":{}}

--- a/testsuite/oxigraph-tests/sparql-results/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql-results/manifest.ttl
@@ -12,9 +12,14 @@
     :results_xml_duplicated_variables
     :results_tsv_duplicated_variables
     :results_json_ignored_keys
+    :results_json_boolean_before_head
     :results_xml_ignored_keys
     :results_xml_boundary_whitespace
     :results_json_typed_literal
+    :results_json_truncated_boolean
+    :results_json_trailing_boolean
+    :results_xml_truncated_boolean
+    :results_xml_trailing_boolean
     :late_head
     ) .
 
@@ -34,6 +39,10 @@
     mf:name "Ignore unknown keys in objects" ;
     mf:action <ignored_keys.srj> .
 
+:results_json_boolean_before_head rdf:type ox:PositiveJsonResultsSyntaxTest ;
+    mf:name "Boolean result before head" ;
+    mf:action <boolean_before_head.srj> .
+
 :results_xml_ignored_keys rdf:type ox:PositiveXmlResultsSyntaxTest ;
     mf:name "Ignore unknown attributes on tags" ;
     mf:action <ignored_keys.srx> .
@@ -47,6 +56,22 @@
     mf:name "typed-literal term type is allowed" ;
     mf:action <typed_literal.srj> ;
     mf:result <typed_literal_expected.srj> .
+
+:results_json_truncated_boolean rdf:type ox:NegativeJsonResultsSyntaxTest ;
+    mf:name "Boolean results require a complete JSON object" ;
+    mf:action <truncated_boolean.srj> .
+
+:results_json_trailing_boolean rdf:type ox:NegativeJsonResultsSyntaxTest ;
+    mf:name "Boolean results reject trailing JSON content" ;
+    mf:action <trailing_boolean.srj> .
+
+:results_xml_truncated_boolean rdf:type ox:NegativeXmlResultsSyntaxTest ;
+    mf:name "Boolean results require a complete XML document" ;
+    mf:action <truncated_boolean.srx> .
+
+:results_xml_trailing_boolean rdf:type ox:NegativeXmlResultsSyntaxTest ;
+    mf:name "Boolean results reject trailing XML content" ;
+    mf:action <trailing_boolean.srx> .
 
 :late_head rdf:type ox:PositiveJsonResultsSyntaxTest ;
     mf:name "head after the list of results" ;

--- a/testsuite/oxigraph-tests/sparql-results/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql-results/manifest.ttl
@@ -16,6 +16,7 @@
     :results_xml_ignored_keys
     :results_xml_boundary_whitespace
     :results_json_typed_literal
+    :results_json_boolean_and_results
     :results_json_truncated_boolean
     :results_json_trailing_boolean
     :results_xml_truncated_boolean
@@ -56,6 +57,10 @@
     mf:name "typed-literal term type is allowed" ;
     mf:action <typed_literal.srj> ;
     mf:result <typed_literal_expected.srj> .
+
+:results_json_boolean_and_results rdf:type ox:NegativeJsonResultsSyntaxTest ;
+    mf:name "JSON result cannot contain both boolean and results" ;
+    mf:action <boolean_and_results.srj> .
 
 :results_json_truncated_boolean rdf:type ox:NegativeJsonResultsSyntaxTest ;
     mf:name "Boolean results require a complete JSON object" ;

--- a/testsuite/oxigraph-tests/sparql-results/trailing_boolean.srj
+++ b/testsuite/oxigraph-tests/sparql-results/trailing_boolean.srj
@@ -1,0 +1,1 @@
+{"head":{},"boolean":true} false

--- a/testsuite/oxigraph-tests/sparql-results/trailing_boolean.srx
+++ b/testsuite/oxigraph-tests/sparql-results/trailing_boolean.srx
@@ -1,0 +1,1 @@
+<sparql xmlns="http://www.w3.org/2005/sparql-results#"><head/><boolean>true</boolean></sparql><sparql/>

--- a/testsuite/oxigraph-tests/sparql-results/truncated_boolean.srj
+++ b/testsuite/oxigraph-tests/sparql-results/truncated_boolean.srj
@@ -1,0 +1,1 @@
+{"head":{},"boolean":true

--- a/testsuite/oxigraph-tests/sparql-results/truncated_boolean.srx
+++ b/testsuite/oxigraph-tests/sparql-results/truncated_boolean.srx
@@ -1,0 +1,1 @@
+<sparql xmlns="http://www.w3.org/2005/sparql-results#"><head/><boolean>true</boolean>


### PR DESCRIPTION
## Summary

- wait for the complete JSON result object and EOF before returning an ASK boolean
- wait for `</sparql>` and EOF before returning an XML ASK boolean
- reject truncated and trailing JSON/XML documents while preserving JSON member-order flexibility

The parsers previously returned as soon as they read the JSON boolean token or XML `</boolean>` tag. This left the enclosing result document unread, so incomplete responses and trailing content were accepted as authoritative boolean results.

Closes #1907.

## Testing

- `cargo +1.98.0 fmt -- --check`
- `cargo +1.98.0 test --features rdf-12`
- `cargo +1.98.0 test --all-targets --features async-tokio,sparql-12` (`lib/sparesults`)
- `cargo +1.98.0 clippy --all-targets -- -D warnings -D clippy::all` (`lib/sparesults`)
- `cargo +1.98.0 clippy --all-targets --features async-tokio,sparql-12 -- -D warnings -D clippy::all` (`lib/sparesults`)
- `cargo +1.98.0 test -p oxigraph-testsuite --test oxigraph oxigraph_sparql_results_testsuite`
