### PR TITLE
Add borrowed callbacks for N-Triples and N-Quads

### DIFF
--- a/fuzz/fuzz_targets/nquads.rs
+++ b/fuzz/fuzz_targets/nquads.rs
@@ -67,7 +67,13 @@ fuzz_target!(|data: &[u8]| {
             assert!(errors.is_empty());
             assert_eq!(borrowed_quads, quads);
         }
-        Err(_) => assert!(!errors.is_empty()),
+        Err(error) => {
+            let error = error.to_string();
+            assert!(
+                errors.contains(&error),
+                "the owned parser should report the borrowed parser error {error:?}, found {errors:?}"
+            );
+        }
     }
 
     // We test also unchecked if valid

--- a/fuzz/fuzz_targets/nquads.rs
+++ b/fuzz/fuzz_targets/nquads.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use oxrdf::Quad;
-use oxttl::{NQuadsParser, NQuadsSerializer};
+use oxttl::{NQuadsParser, NQuadsSerializer, TurtleParseError};
 use std::str;
 use std::str::FromStr;
 
@@ -50,6 +50,25 @@ fuzz_target!(|data: &[u8]| {
         parse([data_without_breaks.as_slice()], false);
     assert_eq!(quads, quads_without_split);
     assert_eq!(errors, errors_without_split);
+
+    // We parse using the borrowed callback API. It stops at the first error,
+    // unlike the recovering low-level parser, so its output must be a prefix.
+    let mut borrowed_quads = Vec::new();
+    let borrowed_result = NQuadsParser::new().parse_reader(
+        data_without_breaks.as_slice(),
+        |quad| {
+            borrowed_quads.push(quad.into_owned());
+            Ok::<_, TurtleParseError>(())
+        },
+    );
+    assert!(quads.starts_with(&borrowed_quads));
+    match borrowed_result {
+        Ok(()) => {
+            assert!(errors.is_empty());
+            assert_eq!(borrowed_quads, quads);
+        }
+        Err(_) => assert!(!errors.is_empty()),
+    }
 
     // We test also unchecked if valid
     let (quads_unchecked, errors_unchecked) = parse(data.split(|c| *c == 0xFF), true);

--- a/lib/oxttl/src/lexer.rs
+++ b/lib/oxttl/src/lexer.rs
@@ -13,7 +13,7 @@ use std::str;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum N3Token<'a> {
-    IriRef(OxString),
+    IriRef(N3String<'a>),
     PrefixedName {
         prefix: &'a str,
         local: OxStr<'a>,
@@ -21,8 +21,8 @@ pub enum N3Token<'a> {
     },
     Variable(OxString),
     BlankNodeLabel(&'a str),
-    String(OxString),
-    LongString(OxString),
+    String(N3String<'a>),
+    LongString(N3String<'a>),
     Integer(&'a str),
     Decimal(&'a str),
     Double(&'a str),
@@ -33,6 +33,41 @@ pub enum N3Token<'a> {
     },
     Punctuation(&'a str),
     PlainKeyword(&'a str),
+}
+
+pub enum N3String<'a> {
+    Borrowed(&'a str),
+    Owned(OxString),
+}
+
+impl std::fmt::Debug for N3String<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl PartialEq for N3String<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for N3String<'_> {}
+
+impl N3String<'_> {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Borrowed(value) => value,
+            Self::Owned(value) => value,
+        }
+    }
+
+    pub fn into_owned(self) -> OxString {
+        match self {
+            Self::Borrowed(value) => OxString::new_owned(value),
+            Self::Owned(value) => value,
+        }
+    }
 }
 
 #[derive(Eq, PartialEq)]
@@ -202,11 +237,11 @@ impl N3Lexer {
         }
     }
 
-    fn recognize_iri(
+    fn recognize_iri<'a>(
         &mut self,
-        data: &[u8],
+        data: &'a [u8],
         options: &N3LexerOptions,
-    ) -> Option<(usize, Result<N3Token<'static>, TokenRecognizerError>)> {
+    ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
         // [18] IRIREF  ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>' /* #x00=NULL #01-#x1F=control codes #x20=space */
         self.raw_buffer.clear();
         let mut i = 1;
@@ -215,22 +250,25 @@ impl N3Lexer {
             i += end;
             match data[i] {
                 b'>' => {
-                    let iri = if self.raw_buffer.is_empty() {
-                        &data[1..i]
-                    } else {
-                        self.raw_buffer.extend_from_slice(&data[i - end..i]);
-                        &self.raw_buffer
-                    };
-                    return Some((
-                        i + 1,
-                        Self::parse_iri(
+                    let result = if self.raw_buffer.is_empty() {
+                        Self::parse_borrowed_iri(
                             self.lenient,
                             &mut self.string_buffer,
-                            iri,
+                            &data[1..i],
                             0..i + 1,
                             options,
-                        ),
-                    ));
+                        )
+                    } else {
+                        self.raw_buffer.extend_from_slice(&data[i - end..i]);
+                        Self::parse_owned_iri(
+                            self.lenient,
+                            &mut self.string_buffer,
+                            &self.raw_buffer,
+                            0..i + 1,
+                            options,
+                        )
+                    };
+                    return Some((i + 1, result));
                 }
                 b'\\' => {
                     self.raw_buffer.extend_from_slice(&data[i - end..i]);
@@ -250,7 +288,47 @@ impl N3Lexer {
         }
     }
 
-    fn parse_iri(
+    fn parse_borrowed_iri<'a>(
+        lenient: bool,
+        string_buffer: &mut String,
+        iri: &'a [u8],
+        position: Range<usize>,
+        options: &N3LexerOptions,
+    ) -> Result<N3Token<'a>, TokenRecognizerError> {
+        let iri = str_from_utf8(iri, position.clone())?;
+        if lenient {
+            let Some(base_iri) = options.base_iri.as_ref() else {
+                return Ok(N3Token::IriRef(N3String::Borrowed(iri)));
+            };
+            let iri = IriRef::parse_unchecked(iri);
+            Ok(N3Token::IriRef(if iri.is_absolute() {
+                N3String::Borrowed(iri.into_inner())
+            } else {
+                string_buffer.clear();
+                base_iri.resolve_into_unchecked(&iri, string_buffer);
+                N3String::Owned(OxString::new_owned(string_buffer))
+            }))
+        } else {
+            let iri = IriRef::parse(iri).map_err(|e| (position.clone(), e.to_string()))?;
+            Ok(N3Token::IriRef(if iri.is_absolute() {
+                N3String::Borrowed(iri.into_inner())
+            } else if let Some(base_iri) = options.base_iri.as_ref() {
+                string_buffer.clear();
+                base_iri
+                    .resolve_into(&iri, string_buffer)
+                    .map_err(|e| (position, e.to_string()))?;
+                N3String::Owned(OxString::new_owned(string_buffer))
+            } else {
+                return Err((
+                    position,
+                    format!("{iri} is a relative IRI even if no @base is set"),
+                )
+                    .into());
+            }))
+        }
+    }
+
+    fn parse_owned_iri(
         lenient: bool,
         string_buffer: &mut String,
         iri: &[u8],
@@ -260,33 +338,37 @@ impl N3Lexer {
         let iri = str_from_utf8(iri, position.clone())?;
         if lenient {
             let Some(base_iri) = options.base_iri.as_ref() else {
-                return Ok(N3Token::IriRef(OxString::new_owned(iri)));
+                return Ok(N3Token::IriRef(N3String::Owned(OxString::new_owned(iri))));
             };
             let iri = IriRef::parse_unchecked(iri);
-            Ok(N3Token::IriRef(OxString::new_owned(if iri.is_absolute() {
-                iri.into_inner()
-            } else {
-                string_buffer.clear();
-                base_iri.resolve_into_unchecked(&iri, string_buffer);
-                string_buffer
-            })))
+            Ok(N3Token::IriRef(N3String::Owned(OxString::new_owned(
+                if iri.is_absolute() {
+                    iri.into_inner()
+                } else {
+                    string_buffer.clear();
+                    base_iri.resolve_into_unchecked(&iri, string_buffer);
+                    string_buffer
+                },
+            ))))
         } else {
             let iri = IriRef::parse(iri).map_err(|e| (position.clone(), e.to_string()))?;
-            Ok(N3Token::IriRef(OxString::new_owned(if iri.is_absolute() {
-                iri.into_inner()
-            } else if let Some(base_iri) = options.base_iri.as_ref() {
-                string_buffer.clear();
-                base_iri
-                    .resolve_into(&iri, string_buffer)
-                    .map_err(|e| (position, e.to_string()))?;
-                string_buffer
-            } else {
-                return Err((
-                    position,
-                    format!("{iri} is a relative IRI even if no @base is set"),
-                )
-                    .into());
-            })))
+            Ok(N3Token::IriRef(N3String::Owned(OxString::new_owned(
+                if iri.is_absolute() {
+                    iri.into_inner()
+                } else if let Some(base_iri) = options.base_iri.as_ref() {
+                    string_buffer.clear();
+                    base_iri
+                        .resolve_into(&iri, string_buffer)
+                        .map_err(|e| (position, e.to_string()))?;
+                    string_buffer
+                } else {
+                    return Err((
+                        position,
+                        format!("{iri} is a relative IRI even if no @base is set"),
+                    )
+                        .into());
+                },
+            ))))
         }
     }
 
@@ -690,11 +772,11 @@ impl N3Lexer {
                 .transpose()?,
         })
     }
-    fn recognize_string(
+    fn recognize_string<'a>(
         &mut self,
-        data: &[u8],
+        data: &'a [u8],
         delimiter: u8,
-    ) -> Option<(usize, Result<N3Token<'static>, TokenRecognizerError>)> {
+    ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
         // [22]  STRING_LITERAL_QUOTE         ::=  '"' ([^#x22#x5C#xA#xD] | ECHAR | UCHAR)* '"' /* #x22=" #x5C=\ #xA=new line #xD=carriage return */
         // [23]  STRING_LITERAL_SINGLE_QUOTE  ::=  "'" ([^#x27#x5C#xA#xD] | ECHAR | UCHAR)* "'" /* #x27=' #x5C=\ #xA=new line #xD=carriage return */
         self.raw_buffer.clear();
@@ -712,19 +794,16 @@ impl N3Lexer {
             i += end;
             match data[i] {
                 c if c == delimiter => {
-                    return Some((
-                        i + 1,
-                        str_from_utf8(
-                            if self.raw_buffer.is_empty() {
-                                &data[1..i]
-                            } else {
-                                self.raw_buffer.extend_from_slice(extra_data);
-                                &self.raw_buffer
-                            },
-                            1..i,
-                        )
-                        .map(|s| N3Token::String(OxString::new_owned(s))),
-                    ));
+                    let result = if self.raw_buffer.is_empty() {
+                        str_from_utf8(&data[1..i], 1..i)
+                            .map(|value| N3Token::String(N3String::Borrowed(value)))
+                    } else {
+                        self.raw_buffer.extend_from_slice(extra_data);
+                        str_from_utf8(&self.raw_buffer, 1..i).map(|value| {
+                            N3Token::String(N3String::Owned(OxString::new_owned(value)))
+                        })
+                    };
+                    return Some((i + 1, result));
                 }
                 b'\\' => {
                     self.raw_buffer.extend_from_slice(extra_data);
@@ -759,11 +838,11 @@ impl N3Lexer {
         }
     }
 
-    fn recognize_long_string(
+    fn recognize_long_string<'a>(
         &mut self,
-        data: &[u8],
+        data: &'a [u8],
         delimiter: u8,
-    ) -> Option<(usize, Result<N3Token<'static>, TokenRecognizerError>)> {
+    ) -> Option<(usize, Result<N3Token<'a>, TokenRecognizerError>)> {
         // [24]  STRING_LITERAL_LONG_SINGLE_QUOTE  ::=  "'''" (("'" | "''")? ([^'\] | ECHAR | UCHAR))* "'''"
         // [25]  STRING_LITERAL_LONG_QUOTE         ::=  '"""' (('"' | '""')? ([^"\] | ECHAR | UCHAR))* '"""'
         self.raw_buffer.clear();
@@ -775,19 +854,16 @@ impl N3Lexer {
             match data[i] {
                 c if c == delimiter => {
                     if *data.get(i + 1)? == delimiter && *data.get(i + 2)? == delimiter {
-                        return Some((
-                            i + 3,
-                            str_from_utf8(
-                                if self.raw_buffer.is_empty() {
-                                    &data[3..i]
-                                } else {
-                                    self.raw_buffer.extend_from_slice(extra_data);
-                                    &self.raw_buffer
-                                },
-                                1..i,
-                            )
-                            .map(|s| N3Token::LongString(OxString::new_owned(s))),
-                        ));
+                        let result = if self.raw_buffer.is_empty() {
+                            str_from_utf8(&data[3..i], 1..i)
+                                .map(|value| N3Token::LongString(N3String::Borrowed(value)))
+                        } else {
+                            self.raw_buffer.extend_from_slice(extra_data);
+                            str_from_utf8(&self.raw_buffer, 1..i).map(|value| {
+                                N3Token::LongString(N3String::Owned(OxString::new_owned(value)))
+                            })
+                        };
+                        return Some((i + 3, result));
                     }
                     i += 1;
                     self.raw_buffer.extend_from_slice(extra_data);

--- a/lib/oxttl/src/line_formats.rs
+++ b/lib/oxttl/src/line_formats.rs
@@ -1,38 +1,494 @@
 //! Shared parser implementation for N-Triples and N-Quads.
 
 use crate::MIN_BUFFER_SIZE;
-use crate::lexer::{N3Lexer, N3LexerMode, N3LexerOptions, N3Token, to_lowercase};
+use crate::lexer::{N3Lexer, N3LexerMode, N3LexerOptions, N3String, N3Token, to_lowercase};
 use crate::toolkit::{Lexer, Parser, RuleRecognizer, RuleRecognizerError, TokenOrLineJump};
-#[cfg(feature = "rdf-12")]
-use oxrdf::Triple;
 use oxrdf::vocab::rdf;
-use oxrdf::{BlankNode, GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term};
+#[cfg(feature = "rdf-12")]
+use oxrdf::{BaseDirection, Triple};
+use oxrdf::{
+    BlankNode, BlankNodeRef, GraphName, GraphNameRef, Literal, LiteralRef, NamedNode, NamedNodeRef,
+    NamedOrBlankNode, Quad, QuadRef, Term, TermRef,
+};
 use oxstr::OxString;
 
-pub struct NQuadsRecognizer {
-    stack: Vec<NQuadsState>,
-    subjects: Vec<NamedOrBlankNode>,
-    predicates: Vec<NamedNode>,
-    objects: Vec<Term>,
+#[derive(Clone, Copy)]
+pub(crate) struct TextRange {
+    start: usize,
+    end: usize,
+}
+
+impl TextRange {
+    fn get(self, arena: &str) -> &str {
+        &arena[self.start..self.end]
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum NodeDescriptor {
+    Named(TextRange),
+    Blank(TextRange),
+}
+
+impl NodeDescriptor {
+    fn as_ref(self, arena: &str) -> oxrdf::NamedOrBlankNodeRef<'_> {
+        match self {
+            Self::Named(value) => NamedNodeRef::new_unchecked(value.get(arena)).into(),
+            Self::Blank(value) => BlankNodeRef::new_unchecked(value.get(arena)).into(),
+        }
+    }
+
+    #[cfg(feature = "rdf-12")]
+    fn into_owned(self, arena: &str) -> NamedOrBlankNode {
+        self.as_ref(arena).into_owned()
+    }
+}
+
+pub(crate) enum TermDescriptor {
+    Named(TextRange),
+    Blank(TextRange),
+    Simple(TextRange),
+    LanguageTagged {
+        value: TextRange,
+        language: TextRange,
+    },
+    #[cfg(feature = "rdf-12")]
+    DirectionalLanguageTagged {
+        value: TextRange,
+        language: TextRange,
+        direction: BaseDirection,
+    },
+    Typed {
+        value: TextRange,
+        datatype: TextRange,
+    },
+    #[cfg(feature = "rdf-12")]
+    // `TermRef::Triple` requires an addressable `Triple`. Boxing keeps the
+    // ordinary-term descriptor small and allocates only when a triple term is parsed.
+    Triple(Box<Triple>),
+}
+
+impl TermDescriptor {
+    fn as_ref<'a>(&'a self, arena: &'a str) -> TermRef<'a> {
+        match self {
+            Self::Named(value) => NamedNodeRef::new_unchecked(value.get(arena)).into(),
+            Self::Blank(value) => BlankNodeRef::new_unchecked(value.get(arena)).into(),
+            Self::Simple(value) => LiteralRef::new_simple_literal(value.get(arena)).into(),
+            Self::LanguageTagged { value, language } => {
+                LiteralRef::new_language_tagged_literal_unchecked(
+                    value.get(arena),
+                    language.get(arena),
+                )
+                .into()
+            }
+            #[cfg(feature = "rdf-12")]
+            Self::DirectionalLanguageTagged {
+                value,
+                language,
+                direction,
+            } => LiteralRef::new_directional_language_tagged_literal_unchecked(
+                value.get(arena),
+                language.get(arena),
+                *direction,
+            )
+            .into(),
+            Self::Typed { value, datatype } => LiteralRef::new_typed_literal(
+                value.get(arena),
+                NamedNodeRef::new_unchecked(datatype.get(arena)),
+            )
+            .into(),
+            #[cfg(feature = "rdf-12")]
+            Self::Triple(triple) => triple.as_ref().into(),
+        }
+    }
+
+    #[cfg(feature = "rdf-12")]
+    fn into_owned(self, arena: &str) -> Term {
+        match self {
+            Self::Triple(triple) => triple.into(),
+            term => term.as_ref(arena).into_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) enum GraphDescriptor {
+    #[default]
+    Default,
+    Named(TextRange),
+    Blank(TextRange),
+}
+
+pub(crate) struct BorrowedQuad {
+    arena: String,
+    subject: NodeDescriptor,
+    predicate: TextRange,
+    object: TermDescriptor,
+    graph_name: GraphDescriptor,
+}
+
+impl BorrowedQuad {
+    pub(crate) fn as_ref(&self) -> QuadRef<'_> {
+        QuadRef {
+            subject: self.subject.as_ref(&self.arena),
+            predicate: NamedNodeRef::new_unchecked(self.predicate.get(&self.arena)),
+            object: self.object.as_ref(&self.arena),
+            graph_name: match self.graph_name {
+                GraphDescriptor::Default => GraphNameRef::DefaultGraph,
+                GraphDescriptor::Named(value) => {
+                    NamedNodeRef::new_unchecked(value.get(&self.arena)).into()
+                }
+                GraphDescriptor::Blank(value) => {
+                    BlankNodeRef::new_unchecked(value.get(&self.arena)).into()
+                }
+            },
+        }
+    }
+}
+
+pub(crate) trait NQuadsOutputBuilder {
+    const BUFFER_OUTPUT_UNTIL_LINE_END: bool;
+
+    type Subject;
+    type Predicate;
+    type Object;
+    type LiteralValue;
+    type GraphName;
+    type Output;
+
+    fn named_subject(&mut self, value: N3String<'_>) -> Self::Subject;
+    fn blank_subject(&mut self, value: &str) -> Self::Subject;
+    fn predicate(&mut self, value: N3String<'_>) -> Self::Predicate;
+    fn named_object(&mut self, value: N3String<'_>) -> Self::Object;
+    fn blank_object(&mut self, value: &str) -> Self::Object;
+    fn literal_value(&mut self, value: N3String<'_>) -> Self::LiteralValue;
+    fn simple_literal(&mut self, value: Self::LiteralValue) -> Self::Object;
+    fn language_tagged_literal(
+        &mut self,
+        value: Self::LiteralValue,
+        language: &str,
+        #[cfg(feature = "rdf-12")] direction: Option<BaseDirection>,
+    ) -> Self::Object;
+    fn typed_literal(&mut self, value: Self::LiteralValue, datatype: N3String<'_>) -> Self::Object;
+    #[cfg(feature = "rdf-12")]
+    fn triple(
+        &mut self,
+        subject: Self::Subject,
+        predicate: Self::Predicate,
+        object: Self::Object,
+    ) -> Self::Object;
+    fn named_graph(&mut self, value: N3String<'_>) -> Self::GraphName;
+    fn blank_graph(&mut self, value: &str) -> Self::GraphName;
+    fn default_graph(&mut self) -> Self::GraphName;
+    fn quad(
+        &mut self,
+        subject: Self::Subject,
+        predicate: Self::Predicate,
+        object: Self::Object,
+        graph_name: Self::GraphName,
+    ) -> Self::Output;
+    fn clear(&mut self) {}
+    fn reuse_output(&mut self, _output: Self::Output) {}
+}
+
+#[derive(Default)]
+pub(crate) struct OwnedNQuadsOutputBuilder;
+
+impl NQuadsOutputBuilder for OwnedNQuadsOutputBuilder {
+    const BUFFER_OUTPUT_UNTIL_LINE_END: bool = false;
+
+    type Subject = NamedOrBlankNode;
+    type Predicate = NamedNode;
+    type Object = Term;
+    type LiteralValue = OxString;
+    type GraphName = GraphName;
+    type Output = Quad;
+
+    fn named_subject(&mut self, value: N3String<'_>) -> Self::Subject {
+        NamedNode::new_unchecked(value.into_owned()).into()
+    }
+
+    fn blank_subject(&mut self, value: &str) -> Self::Subject {
+        BlankNode::new_unchecked(OxString::new_owned(value)).into()
+    }
+
+    fn predicate(&mut self, value: N3String<'_>) -> Self::Predicate {
+        NamedNode::new_unchecked(value.into_owned())
+    }
+
+    fn named_object(&mut self, value: N3String<'_>) -> Self::Object {
+        NamedNode::new_unchecked(value.into_owned()).into()
+    }
+
+    fn blank_object(&mut self, value: &str) -> Self::Object {
+        BlankNode::new_unchecked(OxString::new_owned(value)).into()
+    }
+
+    fn literal_value(&mut self, value: N3String<'_>) -> Self::LiteralValue {
+        value.into_owned()
+    }
+
+    fn simple_literal(&mut self, value: Self::LiteralValue) -> Self::Object {
+        Literal::new_simple_literal(value).into()
+    }
+
+    fn language_tagged_literal(
+        &mut self,
+        value: Self::LiteralValue,
+        language: &str,
+        #[cfg(feature = "rdf-12")] direction: Option<BaseDirection>,
+    ) -> Self::Object {
+        #[cfg(feature = "rdf-12")]
+        if let Some(direction) = direction {
+            return Literal::new_directional_language_tagged_literal_unchecked(
+                value,
+                to_lowercase(language),
+                direction,
+            )
+            .into();
+        }
+        Literal::new_language_tagged_literal_unchecked(value, to_lowercase(language)).into()
+    }
+
+    fn typed_literal(&mut self, value: Self::LiteralValue, datatype: N3String<'_>) -> Self::Object {
+        Literal::new_typed_literal(value, NamedNode::new_unchecked(datatype.into_owned())).into()
+    }
+
+    #[cfg(feature = "rdf-12")]
+    fn triple(
+        &mut self,
+        subject: Self::Subject,
+        predicate: Self::Predicate,
+        object: Self::Object,
+    ) -> Self::Object {
+        Triple {
+            subject,
+            predicate,
+            object,
+        }
+        .into()
+    }
+
+    fn named_graph(&mut self, value: N3String<'_>) -> Self::GraphName {
+        NamedNode::new_unchecked(value.into_owned()).into()
+    }
+
+    fn blank_graph(&mut self, value: &str) -> Self::GraphName {
+        BlankNode::new_unchecked(OxString::new_owned(value)).into()
+    }
+
+    fn default_graph(&mut self) -> Self::GraphName {
+        GraphName::DefaultGraph
+    }
+
+    fn quad(
+        &mut self,
+        subject: Self::Subject,
+        predicate: Self::Predicate,
+        object: Self::Object,
+        graph_name: Self::GraphName,
+    ) -> Self::Output {
+        Quad {
+            subject,
+            predicate,
+            object,
+            graph_name,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct BorrowedNQuadsOutputBuilder {
+    arena: String,
+}
+
+impl BorrowedNQuadsOutputBuilder {
+    #[inline]
+    fn text(&mut self, value: &str) -> TextRange {
+        let start = self.arena.len();
+        self.arena.push_str(value);
+        TextRange {
+            start,
+            end: self.arena.len(),
+        }
+    }
+
+    #[inline]
+    fn lowercase_text(&mut self, value: &str) -> TextRange {
+        let start = self.arena.len();
+        self.arena.extend(
+            value
+                .bytes()
+                .map(|byte| char::from(byte.to_ascii_lowercase())),
+        );
+        TextRange {
+            start,
+            end: self.arena.len(),
+        }
+    }
+}
+
+impl NQuadsOutputBuilder for BorrowedNQuadsOutputBuilder {
+    const BUFFER_OUTPUT_UNTIL_LINE_END: bool = true;
+
+    type Subject = NodeDescriptor;
+    type Predicate = TextRange;
+    type Object = TermDescriptor;
+    type LiteralValue = TextRange;
+    type GraphName = GraphDescriptor;
+    type Output = BorrowedQuad;
+
+    #[inline]
+    fn named_subject(&mut self, value: N3String<'_>) -> Self::Subject {
+        NodeDescriptor::Named(self.text(value.as_str()))
+    }
+
+    #[inline]
+    fn blank_subject(&mut self, value: &str) -> Self::Subject {
+        NodeDescriptor::Blank(self.text(value))
+    }
+
+    #[inline]
+    fn predicate(&mut self, value: N3String<'_>) -> Self::Predicate {
+        self.text(value.as_str())
+    }
+
+    #[inline]
+    fn named_object(&mut self, value: N3String<'_>) -> Self::Object {
+        TermDescriptor::Named(self.text(value.as_str()))
+    }
+
+    #[inline]
+    fn blank_object(&mut self, value: &str) -> Self::Object {
+        TermDescriptor::Blank(self.text(value))
+    }
+
+    #[inline]
+    fn literal_value(&mut self, value: N3String<'_>) -> Self::LiteralValue {
+        self.text(value.as_str())
+    }
+
+    #[inline]
+    fn simple_literal(&mut self, value: Self::LiteralValue) -> Self::Object {
+        TermDescriptor::Simple(value)
+    }
+
+    #[inline]
+    fn language_tagged_literal(
+        &mut self,
+        value: Self::LiteralValue,
+        language: &str,
+        #[cfg(feature = "rdf-12")] direction: Option<BaseDirection>,
+    ) -> Self::Object {
+        let language = self.lowercase_text(language);
+        #[cfg(feature = "rdf-12")]
+        if let Some(direction) = direction {
+            return TermDescriptor::DirectionalLanguageTagged {
+                value,
+                language,
+                direction,
+            };
+        }
+        TermDescriptor::LanguageTagged { value, language }
+    }
+
+    #[inline]
+    fn typed_literal(&mut self, value: Self::LiteralValue, datatype: N3String<'_>) -> Self::Object {
+        let datatype = self.text(datatype.as_str());
+        TermDescriptor::Typed { value, datatype }
+    }
+
+    #[cfg(feature = "rdf-12")]
+    #[inline]
+    fn triple(
+        &mut self,
+        subject: Self::Subject,
+        predicate: Self::Predicate,
+        object: Self::Object,
+    ) -> Self::Object {
+        TermDescriptor::Triple(Box::new(Triple {
+            subject: subject.into_owned(&self.arena),
+            predicate: NamedNodeRef::new_unchecked(predicate.get(&self.arena)).into_owned(),
+            object: object.into_owned(&self.arena),
+        }))
+    }
+
+    #[inline]
+    fn named_graph(&mut self, value: N3String<'_>) -> Self::GraphName {
+        GraphDescriptor::Named(self.text(value.as_str()))
+    }
+
+    #[inline]
+    fn blank_graph(&mut self, value: &str) -> Self::GraphName {
+        GraphDescriptor::Blank(self.text(value))
+    }
+
+    #[inline]
+    fn default_graph(&mut self) -> Self::GraphName {
+        GraphDescriptor::Default
+    }
+
+    #[inline]
+    fn quad(
+        &mut self,
+        subject: Self::Subject,
+        predicate: Self::Predicate,
+        object: Self::Object,
+        graph_name: Self::GraphName,
+    ) -> Self::Output {
+        BorrowedQuad {
+            arena: std::mem::take(&mut self.arena),
+            subject,
+            predicate,
+            object,
+            graph_name,
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.arena.clear();
+    }
+
+    #[inline]
+    fn reuse_output(&mut self, mut output: Self::Output) {
+        output.arena.clear();
+        if output.arena.capacity() > self.arena.capacity() {
+            self.arena = output.arena;
+        }
+    }
+}
+
+pub(crate) struct NQuadsRecognizer<B: NQuadsOutputBuilder = OwnedNQuadsOutputBuilder> {
+    state: NQuadsState<B::LiteralValue>,
+    #[cfg(feature = "rdf-12")]
+    quoted_triples: Vec<QuotedTripleFrame<B::Subject, B::Predicate>>,
+    subject: Option<B::Subject>,
+    predicate: Option<B::Predicate>,
+    object: Option<B::Object>,
+    pending_graph_name: Option<B::GraphName>,
+    output_builder: B,
     lenient: bool,
 }
 
-pub struct NQuadsRecognizerContext {
+pub(crate) type BorrowedNQuadsRecognizer = NQuadsRecognizer<BorrowedNQuadsOutputBuilder>;
+
+pub(crate) struct NQuadsRecognizerContext {
     with_graph_name: bool,
     lexer_options: N3LexerOptions,
 }
 
-enum NQuadsState {
+enum NQuadsState<L> {
     ExpectSubject,
     ExpectPredicate,
     ExpectedObject,
     ExpectPossibleGraphOrEndOfQuotedTriple,
     ExpectDot,
     ExpectLiteralAnnotationOrGraphNameOrDot {
-        value: OxString,
+        value: L,
     },
     ExpectLiteralDatatype {
-        value: OxString,
+        value: L,
     },
     ExpectLineJump,
     RecoverToLineJump,
@@ -40,37 +496,46 @@ enum NQuadsState {
     AfterQuotedTriple,
 }
 
-impl RuleRecognizer for NQuadsRecognizer {
+#[cfg(feature = "rdf-12")]
+struct QuotedTripleFrame<S, P> {
+    subject: S,
+    predicate: P,
+}
+
+impl<B: NQuadsOutputBuilder> RuleRecognizer for NQuadsRecognizer<B> {
     type TokenRecognizer = N3Lexer;
-    type Output = Quad;
+    type Output = B::Output;
     type Context = NQuadsRecognizerContext;
 
     fn set_error_recovery_state(&mut self) {
-        self.stack.clear();
-        self.stack.push(NQuadsState::RecoverToLineJump);
-        self.subjects.clear();
-        self.predicates.clear();
-        self.objects.clear();
+        #[cfg(feature = "rdf-12")]
+        self.quoted_triples.clear();
+        self.state = NQuadsState::RecoverToLineJump;
+        self.subject = None;
+        self.predicate = None;
+        self.object = None;
+        self.pending_graph_name = None;
+        self.output_builder.clear();
     }
 
     fn recognize_next(
         &mut self,
         token: TokenOrLineJump<N3Token<'_>>,
         context: &mut NQuadsRecognizerContext,
-        results: &mut Vec<Quad>,
+        results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
-        match self.stack.pop().unwrap_or(NQuadsState::ExpectSubject) {
+        let state = std::mem::replace(&mut self.state, NQuadsState::RecoverToLineJump);
+        match state {
             NQuadsState::ExpectSubject => match token {
                 TokenOrLineJump::Token(token) => match token {
                     N3Token::IriRef(s) => {
-                        self.subjects.push(NamedNode::new_unchecked(s).into());
-                        self.stack.push(NQuadsState::ExpectPredicate);
+                        self.subject = Some(self.output_builder.named_subject(s));
+                        self.state = NQuadsState::ExpectPredicate;
                     }
                     N3Token::BlankNodeLabel(s) => {
-                        self.subjects
-                            .push(BlankNode::new_unchecked(OxString::new_owned(s)).into());
-                        self.stack.push(NQuadsState::ExpectPredicate);
+                        self.subject = Some(self.output_builder.blank_subject(s));
+                        self.state = NQuadsState::ExpectPredicate;
                     }
                     _ => self.error(
                         context,
@@ -81,7 +546,10 @@ impl RuleRecognizer for NQuadsRecognizer {
                     ),
                 },
                 TokenOrLineJump::LineJump => {
-                    if !self.stack.is_empty() {
+                    #[cfg(feature = "rdf-12")]
+                    if self.quoted_triples.is_empty() {
+                        self.state = NQuadsState::ExpectSubject;
+                    } else {
                         self.error(
                             context,
                             results,
@@ -90,13 +558,17 @@ impl RuleRecognizer for NQuadsRecognizer {
                             "line jumps are not allowed inside of quoted triples",
                         )
                     }
+                    #[cfg(not(feature = "rdf-12"))]
+                    {
+                        self.state = NQuadsState::ExpectSubject;
+                    }
                 }
             },
             NQuadsState::ExpectPredicate => match token {
                 TokenOrLineJump::Token(token) => match token {
                     N3Token::IriRef(p) => {
-                        self.predicates.push(NamedNode::new_unchecked(p));
-                        self.stack.push(NQuadsState::ExpectedObject);
+                        self.predicate = Some(self.output_builder.predicate(p));
+                        self.state = NQuadsState::ExpectedObject;
                     }
                     _ => self.error(
                         context,
@@ -117,24 +589,24 @@ impl RuleRecognizer for NQuadsRecognizer {
             NQuadsState::ExpectedObject => match token {
                 TokenOrLineJump::Token(token) => match token {
                     N3Token::IriRef(o) => {
-                        self.objects.push(NamedNode::new_unchecked(o).into());
-                        self.stack
-                            .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
+                        self.object = Some(self.output_builder.named_object(o));
+                        self.state = NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple;
                     }
                     N3Token::BlankNodeLabel(o) => {
-                        self.objects
-                            .push(BlankNode::new_unchecked(OxString::new_owned(o)).into());
-                        self.stack
-                            .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
+                        self.object = Some(self.output_builder.blank_object(o));
+                        self.state = NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple;
                     }
                     N3Token::String(value) => {
-                        self.stack
-                            .push(NQuadsState::ExpectLiteralAnnotationOrGraphNameOrDot { value });
+                        let value = self.output_builder.literal_value(value);
+                        self.state = NQuadsState::ExpectLiteralAnnotationOrGraphNameOrDot { value };
                     }
                     #[cfg(feature = "rdf-12")]
                     N3Token::Punctuation("<<(") => {
-                        self.stack.push(NQuadsState::AfterQuotedTriple);
-                        self.stack.push(NQuadsState::ExpectSubject);
+                        self.quoted_triples.push(QuotedTripleFrame {
+                            subject: self.subject.take().unwrap(),
+                            predicate: self.predicate.take().unwrap(),
+                        });
+                        self.state = NQuadsState::ExpectSubject;
                     }
                     _ => self.error(
                         context,
@@ -153,67 +625,40 @@ impl RuleRecognizer for NQuadsRecognizer {
                 ),
             },
             NQuadsState::ExpectLiteralAnnotationOrGraphNameOrDot { value } => match token {
-                #[cfg(feature = "rdf-12")]
                 TokenOrLineJump::Token(N3Token::LangTag {
                     language,
+                    #[cfg(feature = "rdf-12")]
                     direction,
                 }) => {
-                    self.objects.push(
-                        if let Some(direction) = direction {
-                            Literal::new_directional_language_tagged_literal_unchecked(
-                                value,
-                                to_lowercase(language),
-                                direction,
-                            )
-                        } else {
-                            Literal::new_language_tagged_literal_unchecked(
-                                value,
-                                to_lowercase(language),
-                            )
-                        }
-                        .into(),
-                    );
-                    self.stack
-                        .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
-                }
-                #[cfg(not(feature = "rdf-12"))]
-                TokenOrLineJump::Token(N3Token::LangTag { language }) => {
-                    self.objects.push(
-                        Literal::new_language_tagged_literal_unchecked(
-                            value,
-                            to_lowercase(language),
-                        )
-                        .into(),
-                    );
-                    self.stack
-                        .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
+                    self.object = Some(self.output_builder.language_tagged_literal(
+                        value,
+                        language,
+                        #[cfg(feature = "rdf-12")]
+                        direction,
+                    ));
+                    self.state = NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple;
                 }
                 TokenOrLineJump::Token(N3Token::Punctuation("^^")) => {
-                    self.stack
-                        .push(NQuadsState::ExpectLiteralDatatype { value });
+                    self.state = NQuadsState::ExpectLiteralDatatype { value };
                 }
                 _ => {
-                    self.objects.push(Literal::new_simple_literal(value).into());
-                    self.stack
-                        .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
+                    self.object = Some(self.output_builder.simple_literal(value));
+                    self.state = NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple;
                     self.recognize_next(token, context, results, errors)
                 }
             },
             NQuadsState::ExpectLiteralDatatype { value } => match token {
                 TokenOrLineJump::Token(token) => match token {
                     N3Token::IriRef(d) => {
-                        if !self.lenient && d == *rdf::LANG_STRING.as_str() {
+                        if !self.lenient && d.as_str() == rdf::LANG_STRING.as_str() {
                             errors.push("The datatype of a literal without a language tag must not be rdf:langString".into());
                         }
                         #[cfg(feature = "rdf-12")]
-                        if !self.lenient && d == *rdf::DIR_LANG_STRING.as_str() {
+                        if !self.lenient && d.as_str() == rdf::DIR_LANG_STRING.as_str() {
                             errors.push("The datatype of a literal without a base direction must not be rdf:dirLangString".into());
                         }
-                        self.objects.push(
-                            Literal::new_typed_literal(value, NamedNode::new_unchecked(d)).into(),
-                        );
-                        self.stack
-                            .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
+                        self.object = Some(self.output_builder.typed_literal(value, d));
+                        self.state = NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple;
                     }
                     _ => self.error(
                         context,
@@ -232,43 +677,53 @@ impl RuleRecognizer for NQuadsRecognizer {
                 ),
             },
             NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple => {
-                if self.stack.is_empty() {
+                #[cfg(feature = "rdf-12")]
+                let inside_quoted_triple = !self.quoted_triples.is_empty();
+                #[cfg(not(feature = "rdf-12"))]
+                let inside_quoted_triple = false;
+                if inside_quoted_triple {
+                    #[cfg(feature = "rdf-12")]
+                    if token == TokenOrLineJump::Token(N3Token::Punctuation(")>>")) {
+                        self.state = NQuadsState::AfterQuotedTriple;
+                    } else {
+                        self.error(
+                            context,
+                            results,
+                            errors,
+                            token,
+                            "Expecting the end of a quoted triple ')>>'",
+                        )
+                    }
+                } else {
                     match token {
                         TokenOrLineJump::Token(N3Token::IriRef(g)) if context.with_graph_name => {
-                            self.emit_quad(results, NamedNode::new_unchecked(g).into());
-                            self.stack.push(NQuadsState::ExpectDot);
+                            let graph_name = self.output_builder.named_graph(g);
+                            self.emit_quad(results, graph_name);
+                            self.state = NQuadsState::ExpectDot;
                         }
                         TokenOrLineJump::Token(N3Token::BlankNodeLabel(g))
                             if context.with_graph_name =>
                         {
-                            self.emit_quad(
-                                results,
-                                BlankNode::new_unchecked(OxString::new_owned(g)).into(),
-                            );
-                            self.stack.push(NQuadsState::ExpectDot);
+                            let graph_name = self.output_builder.blank_graph(g);
+                            self.emit_quad(results, graph_name);
+                            self.state = NQuadsState::ExpectDot;
                         }
                         _ => {
-                            self.emit_quad(results, GraphName::DefaultGraph);
-                            self.stack.push(NQuadsState::ExpectDot);
+                            let graph_name = self.output_builder.default_graph();
+                            self.emit_quad(results, graph_name);
+                            self.state = NQuadsState::ExpectDot;
                             self.recognize_next(token, context, results, errors)
                         }
                     }
-                } else if token != TokenOrLineJump::Token(N3Token::Punctuation(")>>")) {
-                    self.error(
-                        context,
-                        results,
-                        errors,
-                        token,
-                        "Expecting the end of a quoted triple ')>>'",
-                    )
                 }
             }
             NQuadsState::ExpectDot => match token {
                 TokenOrLineJump::Token(token) => {
                     if let N3Token::Punctuation(".") = token {
-                        self.stack.push(NQuadsState::ExpectLineJump);
+                        self.state = NQuadsState::ExpectLineJump;
                     } else {
                         errors.push("Quads must be followed by a dot".into());
+                        self.state = NQuadsState::ExpectSubject;
                         self.recognize_next(TokenOrLineJump::Token(token), context, results, errors)
                     }
                 }
@@ -291,26 +746,38 @@ impl RuleRecognizer for NQuadsRecognizer {
                         )
                         .into(),
                     );
-                    self.recognize_next(TokenOrLineJump::Token(token), context, results, errors)
+                    if B::BUFFER_OUTPUT_UNTIL_LINE_END {
+                        self.set_error_recovery_state();
+                    } else {
+                        self.state = NQuadsState::ExpectSubject;
+                        self.recognize_next(TokenOrLineJump::Token(token), context, results, errors)
+                    }
                 }
-                TokenOrLineJump::LineJump => (),
+                TokenOrLineJump::LineJump => {
+                    self.publish_pending_output(results);
+                    self.state = NQuadsState::ExpectSubject;
+                }
             },
             #[cfg(feature = "rdf-12")]
             NQuadsState::AfterQuotedTriple => {
-                let triple = Triple {
-                    subject: self.subjects.pop().unwrap(),
-                    predicate: self.predicates.pop().unwrap(),
-                    object: self.objects.pop().unwrap(),
-                };
-                self.objects.push(triple.into());
-                self.stack
-                    .push(NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple);
+                let triple = self.output_builder.triple(
+                    self.subject.take().unwrap(),
+                    self.predicate.take().unwrap(),
+                    self.object.take().unwrap(),
+                );
+                let frame = self.quoted_triples.pop().unwrap();
+                self.subject = Some(frame.subject);
+                self.predicate = Some(frame.predicate);
+                self.object = Some(triple);
+                self.state = NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple;
                 self.recognize_next(token, context, results, errors)
             }
             NQuadsState::RecoverToLineJump => {
-                if token != TokenOrLineJump::LineJump {
-                    self.stack.push(NQuadsState::RecoverToLineJump);
-                }
+                self.state = if token == TokenOrLineJump::LineJump {
+                    NQuadsState::ExpectSubject
+                } else {
+                    NQuadsState::RecoverToLineJump
+                };
             }
         }
     }
@@ -318,20 +785,28 @@ impl RuleRecognizer for NQuadsRecognizer {
     fn recognize_end(
         mut self,
         _context: &mut NQuadsRecognizerContext,
-        results: &mut Vec<Quad>,
+        results: &mut Vec<Self::Output>,
         errors: &mut Vec<RuleRecognizerError>,
     ) {
-        match &*self.stack {
-            [NQuadsState::ExpectSubject | NQuadsState::ExpectLineJump] | [] => {}
-            [NQuadsState::ExpectDot] => errors.push("Triples must be followed by a dot".into()),
-            [NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple] => {
-                self.emit_quad(results, GraphName::DefaultGraph);
+        #[cfg(feature = "rdf-12")]
+        if !self.quoted_triples.is_empty() {
+            errors.push("Unexpected end".into()); // TODO
+            return;
+        }
+        let state = std::mem::replace(&mut self.state, NQuadsState::RecoverToLineJump);
+        match state {
+            NQuadsState::ExpectSubject => {}
+            NQuadsState::ExpectLineJump => self.publish_pending_output(results),
+            NQuadsState::ExpectDot => errors.push("Triples must be followed by a dot".into()),
+            NQuadsState::ExpectPossibleGraphOrEndOfQuotedTriple => {
+                let graph_name = self.output_builder.default_graph();
+                self.emit_quad(results, graph_name);
                 errors.push("Triples must be followed by a dot".into())
             }
-            [NQuadsState::ExpectLiteralAnnotationOrGraphNameOrDot { value }] => {
-                self.objects
-                    .push(Literal::new_simple_literal(value.clone()).into());
-                self.emit_quad(results, GraphName::DefaultGraph);
+            NQuadsState::ExpectLiteralAnnotationOrGraphNameOrDot { value } => {
+                self.object = Some(self.output_builder.simple_literal(value));
+                let graph_name = self.output_builder.default_graph();
+                self.emit_quad(results, graph_name);
                 errors.push("Triples must be followed by a dot".into())
             }
             _ => errors.push("Unexpected end".into()), // TODO
@@ -340,6 +815,10 @@ impl RuleRecognizer for NQuadsRecognizer {
 
     fn lexer_options(context: &NQuadsRecognizerContext) -> &N3LexerOptions {
         &context.lexer_options
+    }
+
+    fn reuse_output(&mut self, output: Self::Output) {
+        self.output_builder.reuse_output(output);
     }
 }
 
@@ -351,6 +830,45 @@ impl NQuadsRecognizer {
         lenient: bool,
         max_buffer_size: usize,
     ) -> Parser<B, Self> {
+        Self::new_parser_with_builder(
+            data,
+            is_ending,
+            with_graph_name,
+            lenient,
+            max_buffer_size,
+            OwnedNQuadsOutputBuilder,
+        )
+    }
+}
+
+impl BorrowedNQuadsRecognizer {
+    pub(crate) fn new_borrowed_parser<B>(
+        data: B,
+        is_ending: bool,
+        with_graph_name: bool,
+        lenient: bool,
+        max_buffer_size: usize,
+    ) -> Parser<B, Self> {
+        Self::new_parser_with_builder(
+            data,
+            is_ending,
+            with_graph_name,
+            lenient,
+            max_buffer_size,
+            BorrowedNQuadsOutputBuilder::default(),
+        )
+    }
+}
+
+impl<B: NQuadsOutputBuilder> NQuadsRecognizer<B> {
+    fn new_parser_with_builder<D>(
+        data: D,
+        is_ending: bool,
+        with_graph_name: bool,
+        lenient: bool,
+        max_buffer_size: usize,
+        output_builder: B,
+    ) -> Parser<D, Self> {
         Parser::new(
             Lexer::new(
                 N3Lexer::new(N3LexerMode::NTriples, lenient),
@@ -361,10 +879,14 @@ impl NQuadsRecognizer {
                 Some(b"#"),
             ),
             Self {
-                stack: vec![NQuadsState::ExpectSubject],
-                subjects: Vec::new(),
-                predicates: Vec::new(),
-                objects: Vec::new(),
+                state: NQuadsState::ExpectSubject,
+                #[cfg(feature = "rdf-12")]
+                quoted_triples: Vec::new(),
+                subject: None,
+                predicate: None,
+                object: None,
+                pending_graph_name: None,
+                output_builder,
                 lenient,
             },
             NQuadsRecognizerContext {
@@ -377,7 +899,7 @@ impl NQuadsRecognizer {
     fn error(
         &mut self,
         context: &mut NQuadsRecognizerContext,
-        results: &mut Vec<Quad>,
+        results: &mut Vec<B::Output>,
         errors: &mut Vec<RuleRecognizerError>,
         token: TokenOrLineJump<N3Token<'_>>,
         msg: impl Into<RuleRecognizerError>,
@@ -390,12 +912,31 @@ impl NQuadsRecognizer {
         }
     }
 
-    fn emit_quad(&mut self, results: &mut Vec<Quad>, graph_name: GraphName) {
-        results.push(Quad {
-            subject: self.subjects.pop().unwrap(),
-            predicate: self.predicates.pop().unwrap(),
-            object: self.objects.pop().unwrap(),
-            graph_name,
-        })
+    fn emit_quad(&mut self, results: &mut Vec<B::Output>, graph_name: B::GraphName) {
+        if B::BUFFER_OUTPUT_UNTIL_LINE_END {
+            debug_assert!(
+                self.pending_graph_name.is_none(),
+                "a line parser must publish or discard its previous output before emitting again"
+            );
+            self.pending_graph_name = Some(graph_name);
+        } else {
+            results.push(self.output_builder.quad(
+                self.subject.take().unwrap(),
+                self.predicate.take().unwrap(),
+                self.object.take().unwrap(),
+                graph_name,
+            ));
+        }
+    }
+
+    fn publish_pending_output(&mut self, results: &mut Vec<B::Output>) {
+        if let Some(graph_name) = self.pending_graph_name.take() {
+            results.push(self.output_builder.quad(
+                self.subject.take().unwrap(),
+                self.predicate.take().unwrap(),
+                self.object.take().unwrap(),
+                graph_name,
+            ));
+        }
     }
 }

--- a/lib/oxttl/src/n3.rs
+++ b/lib/oxttl/src/n3.rs
@@ -967,7 +967,8 @@ impl RuleRecognizer for N3Recognizer {
                 }
                 N3State::BaseExpectIri => {
                     if let N3Token::IriRef(iri) = token {
-                        context.lexer_options.base_iri = Some(Iri::parse_unchecked(iri));
+                        context.lexer_options.base_iri =
+                            Some(Iri::parse_unchecked(iri.into_owned()));
                     } else {
                         self.error(errors, "The BASE keyword should be followed by an IRI")
                     }
@@ -989,7 +990,9 @@ impl RuleRecognizer for N3Recognizer {
                 }
                 N3State::PrefixExpectIri { name } => {
                     if let N3Token::IriRef(iri) = token {
-                        context.prefixes.insert(name, Iri::parse_unchecked(iri));
+                        context
+                            .prefixes
+                            .insert(name, Iri::parse_unchecked(iri.into_owned()));
                     } else {
                         self.error(errors, "The PREFIX declaration should be followed by a prefix and its value as an IRI")
                     }
@@ -1167,7 +1170,8 @@ impl RuleRecognizer for N3Recognizer {
                 N3State::PathItem => {
                     match token {
                         N3Token::IriRef(iri) => {
-                            self.terms.push(NamedNode::new_unchecked(iri).into());
+                            self.terms
+                                .push(NamedNode::new_unchecked(iri.into_owned()).into());
                         }
                         N3Token::PrefixedName {
                             prefix,
@@ -1198,7 +1202,9 @@ impl RuleRecognizer for N3Recognizer {
                             self.stack.push(N3State::CollectionBeginning);
                         }
                         N3Token::String(value) | N3Token::LongString(value) => {
-                            self.stack.push(N3State::LiteralPossibleSuffix { value });
+                            self.stack.push(N3State::LiteralPossibleSuffix {
+                                value: value.into_owned(),
+                            });
                         }
                         N3Token::Integer(v) => {
                             self.terms.push(
@@ -1258,7 +1264,8 @@ impl RuleRecognizer for N3Recognizer {
                 N3State::IriPropertyList => {
                     match token {
                         N3Token::IriRef(id) => {
-                            self.terms.push(NamedNode::new_unchecked(id).into());
+                            self.terms
+                                .push(NamedNode::new_unchecked(id.into_owned()).into());
                             self.stack.push(N3State::PropertyListEnd);
                             self.stack.push(N3State::PredicateObjectList);
                         }
@@ -1342,8 +1349,11 @@ impl RuleRecognizer for N3Recognizer {
                 N3State::LiteralExpectDatatype { value } => match token {
                     N3Token::IriRef(datatype) => {
                         self.terms.push(
-                            Literal::new_typed_literal(value, NamedNode::new_unchecked(datatype))
-                                .into(),
+                            Literal::new_typed_literal(
+                                value,
+                                NamedNode::new_unchecked(datatype.into_owned()),
+                            )
+                            .into(),
                         );
                         return;
                     }

--- a/lib/oxttl/src/nquads.rs
+++ b/lib/oxttl/src/nquads.rs
@@ -2,12 +2,12 @@
 //! and a serializer implemented by [`NQuadsSerializer`].
 
 use crate::chunker::{get_ntriples_file_chunks, get_ntriples_slice_chunks};
-use crate::line_formats::NQuadsRecognizer;
+use crate::line_formats::{BorrowedNQuadsRecognizer, NQuadsRecognizer};
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::TokioAsyncReaderIterator;
 use crate::toolkit::{Parser, ReaderIterator, SliceIterator, TurtleParseError, TurtleSyntaxError};
 use crate::{DEFAULT_MAX_BUFFER_SIZE, MIN_PARALLEL_CHUNK_SIZE};
-use oxrdf::{Quad, Triple};
+use oxrdf::{Quad, QuadRef, Triple};
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Take, Write};
 use std::path::Path;
@@ -109,6 +109,65 @@ impl NQuadsParser {
         ReaderNQuadsParser {
             inner: self.low_level().parser.for_reader(reader),
         }
+    }
+
+    /// Parses an N-Quads file from a [`Read`] implementation and calls
+    /// `on_quad` for each parsed quad.
+    ///
+    /// The callback receives a [`QuadRef`] borrowing from reusable parser
+    /// buffers. Its strings are only valid for the duration of the callback
+    /// invocation. Use [`QuadRef::into_owned`] if a quad must be retained.
+    /// This callback API avoids allocating owned RDF terms for every quad.
+    ///
+    /// Count quads without materializing them:
+    /// ```
+    /// use oxttl::{NQuadsParser, TurtleParseError};
+    ///
+    /// let input = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/g> .\n";
+    /// let mut count = 0;
+    /// NQuadsParser::new().parse_reader(input.as_slice(), |quad| {
+    ///     // `quad` and its strings cannot be retained after this call.
+    ///     assert_eq!(quad.graph_name.to_string(), "<http://example.com/g>");
+    ///     count += 1;
+    ///     Ok::<_, TurtleParseError>(())
+    /// })?;
+    /// assert_eq!(count, 1);
+    /// # Result::<_, TurtleParseError>::Ok(())
+    /// ```
+    ///
+    /// Parsing stops at the first syntax, I/O, or callback error. Callback
+    /// errors are returned unchanged. When RDF 1.2 support is enabled, triple
+    /// term subtrees are materialized temporarily because [`QuadRef`] represents
+    /// them using owned [`Triple`] values. Ordinary terms keep the
+    /// allocation-light borrowed representation.
+    ///
+    /// This is a streaming API: if parsing fails late, callbacks for earlier
+    /// statements have already run. Consumers that require atomic ingestion
+    /// should stage their changes and commit only after this method returns
+    /// [`Ok`].
+    pub fn parse_reader<R: Read, E>(
+        self,
+        reader: R,
+        mut on_quad: impl for<'a> FnMut(QuadRef<'a>) -> Result<(), E>,
+    ) -> Result<(), E>
+    where
+        E: From<TurtleParseError>,
+    {
+        let mut parser = BorrowedNQuadsRecognizer::new_borrowed_parser(
+            Vec::new(),
+            false,
+            true,
+            self.lenient,
+            self.max_buffer_size,
+        )
+        .for_reader(reader);
+        while let Some(quad) = parser.next() {
+            let quad = quad.map_err(E::from)?;
+            let result = on_quad(quad.as_ref());
+            parser.parser.reuse_output(quad);
+            result?;
+        }
+        Ok(())
     }
 
     /// Parses a N-Quads file from a [`AsyncRead`] implementation.

--- a/lib/oxttl/src/ntriples.rs
+++ b/lib/oxttl/src/ntriples.rs
@@ -2,12 +2,12 @@
 //! and a serializer implemented by [`NTriplesSerializer`].
 
 use crate::chunker::{get_ntriples_file_chunks, get_ntriples_slice_chunks};
-use crate::line_formats::NQuadsRecognizer;
+use crate::line_formats::{BorrowedNQuadsRecognizer, NQuadsRecognizer};
 #[cfg(feature = "async-tokio")]
 use crate::toolkit::TokioAsyncReaderIterator;
 use crate::toolkit::{Parser, ReaderIterator, SliceIterator, TurtleParseError, TurtleSyntaxError};
 use crate::{DEFAULT_MAX_BUFFER_SIZE, MIN_PARALLEL_CHUNK_SIZE};
-use oxrdf::Triple;
+use oxrdf::{Triple, TripleRef};
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Take, Write};
 use std::path::Path;
@@ -109,6 +109,65 @@ impl NTriplesParser {
         ReaderNTriplesParser {
             inner: self.low_level().parser.for_reader(reader),
         }
+    }
+
+    /// Parses an N-Triples file from a [`Read`] implementation and calls
+    /// `on_triple` for each parsed triple.
+    ///
+    /// The callback receives a [`TripleRef`] borrowing from reusable parser
+    /// buffers. Its strings are only valid for the duration of the callback
+    /// invocation. Use [`TripleRef::into_owned`] if a triple must be retained.
+    /// This callback API avoids allocating owned RDF terms for every triple.
+    ///
+    /// Count triples without materializing them:
+    /// ```
+    /// use oxttl::{NTriplesParser, TurtleParseError};
+    ///
+    /// let input = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .\n";
+    /// let mut count = 0;
+    /// NTriplesParser::new().parse_reader(input.as_slice(), |triple| {
+    ///     // `triple` and its strings cannot be retained after this call.
+    ///     assert_eq!(triple.subject.to_string(), "<http://example.com/s>");
+    ///     count += 1;
+    ///     Ok::<_, TurtleParseError>(())
+    /// })?;
+    /// assert_eq!(count, 1);
+    /// # Result::<_, TurtleParseError>::Ok(())
+    /// ```
+    ///
+    /// Parsing stops at the first syntax, I/O, or callback error. Callback
+    /// errors are returned unchanged. When RDF 1.2 support is enabled, triple
+    /// term subtrees are materialized temporarily because [`TripleRef`]
+    /// represents them using owned [`Triple`] values. Ordinary terms keep the
+    /// allocation-light borrowed representation.
+    ///
+    /// This is a streaming API: if parsing fails late, callbacks for earlier
+    /// statements have already run. Consumers that require atomic ingestion
+    /// should stage their changes and commit only after this method returns
+    /// [`Ok`].
+    pub fn parse_reader<R: Read, E>(
+        self,
+        reader: R,
+        mut on_triple: impl for<'a> FnMut(TripleRef<'a>) -> Result<(), E>,
+    ) -> Result<(), E>
+    where
+        E: From<TurtleParseError>,
+    {
+        let mut parser = BorrowedNQuadsRecognizer::new_borrowed_parser(
+            Vec::new(),
+            false,
+            false,
+            self.lenient,
+            self.max_buffer_size,
+        )
+        .for_reader(reader);
+        while let Some(triple) = parser.next() {
+            let triple = triple.map_err(E::from)?;
+            let result = on_triple(triple.as_ref().into());
+            parser.parser.reuse_output(triple);
+            result?;
+        }
+        Ok(())
     }
 
     /// Parses a N-Triples file from a [`AsyncRead`] implementation.

--- a/lib/oxttl/src/terse.rs
+++ b/lib/oxttl/src/terse.rs
@@ -148,7 +148,8 @@ impl RuleRecognizer for TriGRecognizer {
                 }
                 TriGState::BaseExpectIri => {
                     if let N3Token::IriRef(iri) = token {
-                        context.lexer_options.base_iri = Some(Iri::parse_unchecked(iri));
+                        context.lexer_options.base_iri =
+                            Some(Iri::parse_unchecked(iri.into_owned()));
                     } else {
                         self.error(errors, "The BASE keyword should be followed by an IRI")
                     }
@@ -166,7 +167,9 @@ impl RuleRecognizer for TriGRecognizer {
                 },
                 TriGState::PrefixExpectIri { name } => {
                     if let N3Token::IriRef(iri) = token {
-                        context.prefixes.insert(name, Iri::parse_unchecked(iri));
+                        context
+                            .prefixes
+                            .insert(name, Iri::parse_unchecked(iri.into_owned()));
                     } else {
                         self.error(errors, "The PREFIX declaration should be followed by a prefix and its value as an IRI")
                     }
@@ -183,7 +186,7 @@ impl RuleRecognizer for TriGRecognizer {
                     N3Token::IriRef(iri) => {
                         self.stack
                             .push(TriGState::WrappedGraphOrPredicateObjectList {
-                                term: NamedNode::new_unchecked(iri).into(),
+                                term: NamedNode::new_unchecked(iri.into_owned()).into(),
                             });
                     }
                     N3Token::PrefixedName {
@@ -354,7 +357,8 @@ impl RuleRecognizer for TriGRecognizer {
                             .push(TriGState::TriplesBlankNodePropertyListCurrent);
                     }
                     N3Token::IriRef(iri) => {
-                        self.cur_subject.push(NamedNode::new_unchecked(iri).into());
+                        self.cur_subject
+                            .push(NamedNode::new_unchecked(iri.into_owned()).into());
                         self.stack.push(TriGState::PredicateObjectList);
                     }
                     N3Token::PrefixedName {
@@ -407,7 +411,7 @@ impl RuleRecognizer for TriGRecognizer {
                 // [7]  labelOrSubject  ::=  iri | BlankNode
                 TriGState::GraphName => match token {
                     N3Token::IriRef(iri) => {
-                        self.cur_graph = NamedNode::new_unchecked(iri).into();
+                        self.cur_graph = NamedNode::new_unchecked(iri.into_owned()).into();
                     }
                     N3Token::PrefixedName {
                         prefix,
@@ -562,7 +566,8 @@ impl RuleRecognizer for TriGRecognizer {
                         self.cur_predicate.push(rdf::TYPE);
                     }
                     N3Token::IriRef(iri) => {
-                        self.cur_predicate.push(NamedNode::new_unchecked(iri));
+                        self.cur_predicate
+                            .push(NamedNode::new_unchecked(iri.into_owned()));
                     }
                     N3Token::PrefixedName {
                         prefix,
@@ -594,7 +599,8 @@ impl RuleRecognizer for TriGRecognizer {
                 // [32] BlankNode 	::= 	BLANK_NODE_LABEL | ANON
                 TriGState::Object => match token {
                     N3Token::IriRef(iri) => {
-                        self.cur_object.push(NamedNode::new_unchecked(iri).into());
+                        self.cur_object
+                            .push(NamedNode::new_unchecked(iri.into_owned()).into());
                         self.emit_quad(results);
                     }
                     N3Token::PrefixedName {
@@ -626,8 +632,10 @@ impl RuleRecognizer for TriGRecognizer {
                         self.stack.push(TriGState::ObjectCollectionBeginning);
                     }
                     N3Token::String(value) | N3Token::LongString(value) => {
-                        self.stack
-                            .push(TriGState::LiteralPossibleSuffix { value, emit: true });
+                        self.stack.push(TriGState::LiteralPossibleSuffix {
+                            value: value.into_owned(),
+                            emit: true,
+                        });
                     }
                     N3Token::Integer(v) => {
                         self.cur_object.push(
@@ -786,16 +794,19 @@ impl RuleRecognizer for TriGRecognizer {
                 },
                 TriGState::LiteralExpectDatatype { value, emit } => match token {
                     N3Token::IriRef(datatype) => {
-                        if !self.lenient && datatype == rdf::LANG_STRING.as_str() {
+                        if !self.lenient && datatype.as_str() == rdf::LANG_STRING.as_str() {
                             errors.push("The datatype of a literal without a language tag must not be rdf:langString".into());
                         }
                         #[cfg(feature = "rdf-12")]
-                        if !self.lenient && datatype == rdf::DIR_LANG_STRING.as_str() {
+                        if !self.lenient && datatype.as_str() == rdf::DIR_LANG_STRING.as_str() {
                             errors.push("The datatype of a literal without a base direction must not be rdf:dirLangString".into());
                         }
                         self.cur_object.push(
-                            Literal::new_typed_literal(value, NamedNode::new_unchecked(datatype))
-                                .into(),
+                            Literal::new_typed_literal(
+                                value,
+                                NamedNode::new_unchecked(datatype.into_owned()),
+                            )
+                            .into(),
                         );
                         if emit {
                             self.emit_quad(results);
@@ -901,7 +912,7 @@ impl RuleRecognizer for TriGRecognizer {
                 #[cfg(feature = "rdf-12")]
                 TriGState::Reifier { triple } => match token {
                     N3Token::IriRef(iri) => {
-                        let reifier = NamedNode::new_unchecked(iri);
+                        let reifier = NamedNode::new_unchecked(iri.into_owned());
                         results.push(Quad::new(
                             reifier.clone(),
                             rdf::REIFIES,
@@ -972,7 +983,8 @@ impl RuleRecognizer for TriGRecognizer {
                         self.stack.push(TriGState::QuotedAnonEnd);
                     }
                     N3Token::IriRef(iri) => {
-                        self.cur_subject.push(NamedNode::new_unchecked(iri).into());
+                        self.cur_subject
+                            .push(NamedNode::new_unchecked(iri.into_owned()).into());
                     }
                     N3Token::PrefixedName {
                         prefix,
@@ -1016,7 +1028,8 @@ impl RuleRecognizer for TriGRecognizer {
                         self.stack.push(TriGState::QuotedAnonEnd);
                     }
                     N3Token::IriRef(iri) => {
-                        self.cur_object.push(NamedNode::new_unchecked(iri).into());
+                        self.cur_object
+                            .push(NamedNode::new_unchecked(iri.into_owned()).into());
                     }
                     N3Token::PrefixedName {
                         prefix,
@@ -1038,8 +1051,10 @@ impl RuleRecognizer for TriGRecognizer {
                             .push(BlankNode::new_unchecked(OxString::new_owned(label)).into());
                     }
                     N3Token::String(value) => {
-                        self.stack
-                            .push(TriGState::LiteralPossibleSuffix { value, emit: false });
+                        self.stack.push(TriGState::LiteralPossibleSuffix {
+                            value: value.into_owned(),
+                            emit: false,
+                        });
                     }
                     N3Token::Integer(v) => {
                         self.cur_object.push(

--- a/lib/oxttl/src/toolkit/parser.rs
+++ b/lib/oxttl/src/toolkit/parser.rs
@@ -30,6 +30,8 @@ pub trait RuleRecognizer: Sized {
     fn lexer_options(
         context: &Self::Context,
     ) -> &<Self::TokenRecognizer as TokenRecognizer>::Options;
+
+    fn reuse_output(&mut self, _output: Self::Output) {}
 }
 
 pub struct RuleRecognizerError {
@@ -114,6 +116,12 @@ impl<B: Deref<Target = [u8]>, RR: RuleRecognizer> Parser<B, RR> {
             } else {
                 return None;
             }
+        }
+    }
+
+    pub fn reuse_output(&mut self, output: RR::Output) {
+        if let Some(state) = &mut self.state {
+            state.reuse_output(output);
         }
     }
 }

--- a/lib/oxttl/tests/borrowed_parser.rs
+++ b/lib/oxttl/tests/borrowed_parser.rs
@@ -142,6 +142,25 @@ mod tests {
         assert!(error.to_string().contains("Only a single triple"));
     }
 
+    #[test]
+    fn ntriples_graph_name_is_not_exposed_to_callback() {
+        let input = "<http://example.com/s> <http://example.com/p> <http://example.com/o> <http://example.com/g> .\n";
+        let owned_error = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .find_map(Result::err)
+            .unwrap();
+        let mut calls = 0;
+        let borrowed_error = NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert_eq!(borrowed_error.to_string(), owned_error.to_string());
+    }
+
     struct ErrorAfterData {
         data: Option<&'static [u8]>,
     }
@@ -376,6 +395,26 @@ mod tests {
             assert_eq!(calls, 0, "input: {input:?}");
             assert_eq!(borrowed.to_string(), owned.to_string(), "input: {input:?}");
         }
+    }
+
+    #[cfg(not(feature = "rdf-12"))]
+    #[test]
+    fn rdf_12_triple_terms_are_not_exposed_without_the_feature() {
+        let input = "<http://example.com/s> <http://example.com/p> <<( <http://example.com/qs> <http://example.com/qp> <http://example.com/qo> )>> .\n";
+        let owned_error = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .find_map(Result::err)
+            .unwrap();
+        let mut calls = 0;
+        let borrowed_error = NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert_eq!(borrowed_error.to_string(), owned_error.to_string());
     }
 
     #[test]

--- a/lib/oxttl/tests/borrowed_parser.rs
+++ b/lib/oxttl/tests/borrowed_parser.rs
@@ -1,0 +1,392 @@
+#[cfg(test)]
+mod tests {
+    use oxrdf::Quad;
+    #[cfg(feature = "rdf-12")]
+    use oxrdf::TermRef;
+    use oxttl::{NQuadsParser, NTriplesParser, TurtleParseError};
+    use std::io::{self, Read};
+
+    #[test]
+    fn nquads_borrowed_callback_matches_owned_parser() {
+        let input = concat!(
+            "<http://example.com/s> <http://example.com/p> <http://example.com/o> .\n",
+            "_:subject <http://example.com/p> _:object <http://example.com/g> .\n",
+            "<http://example.com/s> <http://example.com/p> \"simple\" _:graph .\n",
+            "<http://example.com/s> <http://example.com/p> \"language\"@EN-us .\n",
+            "<http://example.com/s> <http://example.com/p> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+            "<http://example.com/\\u0073> <http://example.com/p> \"line\\nκαφέ \\u2615\" . # comment\n",
+        );
+        let expected = NQuadsParser::new()
+            .for_reader(input.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        let mut actual = Vec::new();
+        NQuadsParser::new()
+            .parse_reader(input.as_bytes(), |quad| {
+                actual.push(quad.into_owned());
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn ntriples_borrowed_callback_matches_owned_parser() {
+        let input = concat!(
+            "<http://example.com/s> <http://example.com/p> <http://example.com/o> .\r\n",
+            "_:subject <http://example.com/p> _:object .\n",
+            "<http://example.com/s> <http://example.com/p> \"literal\"@FR .",
+        );
+        let expected = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        let mut actual = Vec::new();
+        NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |triple| {
+                actual.push(triple.into_owned());
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[derive(Debug)]
+    enum CallbackError {
+        Parse,
+        Stop(&'static str),
+    }
+
+    impl From<TurtleParseError> for CallbackError {
+        fn from(_error: TurtleParseError) -> Self {
+            Self::Parse
+        }
+    }
+
+    #[test]
+    fn callback_error_stops_parsing_unchanged() {
+        let input = concat!(
+            "<http://example.com/s1> <http://example.com/p> <http://example.com/o> .\n",
+            "<http://example.com/s2> <http://example.com/p> <http://example.com/o> .\n",
+        );
+        let mut calls = 0;
+        let error = NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Err(CallbackError::Stop("sentinel"))
+            })
+            .unwrap_err();
+
+        let value = match error {
+            CallbackError::Stop(value) => value,
+            CallbackError::Parse => "parser error",
+        };
+        assert_eq!(value, "sentinel");
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn late_parse_error_keeps_streaming_prefix_visible() {
+        let input = concat!(
+            "<http://example.com/s1> <http://example.com/p> <http://example.com/o> .\n",
+            "<http://example.com/s2> <http://example.com/p> <http://example.com/o>\n",
+        );
+        let mut calls = 0;
+        let error = NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 1);
+        assert!(error.to_string().contains("followed by a dot"));
+    }
+
+    #[test]
+    fn invalid_statement_is_not_exposed_to_callback() {
+        let input = "<http://example.com/s> <http://example.com/p> <http://example.com/o>\n";
+        let owned_error = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .find_map(Result::err)
+            .unwrap();
+        let mut calls = 0;
+        let borrowed_error = NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert_eq!(borrowed_error.to_string(), owned_error.to_string());
+    }
+
+    #[test]
+    fn extra_token_after_dot_is_not_exposed_to_callback() {
+        let input =
+            "<http://example.com/s> <http://example.com/p> <http://example.com/o> . trailing\n";
+        let mut calls = 0;
+        let error = NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert!(error.to_string().contains("Only a single triple"));
+    }
+
+    struct ErrorAfterData {
+        data: Option<&'static [u8]>,
+    }
+
+    impl Read for ErrorAfterData {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if let Some(data) = self.data.take() {
+                buf[..data.len()].copy_from_slice(data);
+                Ok(data.len())
+            } else {
+                Err(io::Error::other("reader failed"))
+            }
+        }
+    }
+
+    #[test]
+    fn reader_error_is_returned_after_completed_callbacks() {
+        let reader = ErrorAfterData {
+            data: Some(b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .\n"),
+        };
+        let mut calls = 0;
+        let error = NTriplesParser::new()
+            .parse_reader(reader, |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 1);
+        assert!(matches!(error, TurtleParseError::Io(_)));
+        assert!(error.to_string().contains("reader failed"));
+    }
+
+    #[test]
+    fn reader_error_before_statement_boundary_is_fail_closed() {
+        let reader = ErrorAfterData {
+            data: Some(b"<http://example.com/s> <http://example.com/p> <http://example.com/o> ."),
+        };
+        let mut calls = 0;
+        let error = NTriplesParser::new()
+            .parse_reader(reader, |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert!(matches!(error, TurtleParseError::Io(_)));
+    }
+
+    struct TinyChunks<'a> {
+        data: &'a [u8],
+    }
+
+    impl Read for TinyChunks<'_> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let Some((byte, remaining)) = self.data.split_first() else {
+                return Ok(0);
+            };
+            buf[0] = *byte;
+            self.data = remaining;
+            Ok(1)
+        }
+    }
+
+    #[test]
+    #[expect(
+        clippy::non_ascii_literal,
+        reason = "this test exercises raw Unicode parser input"
+    )]
+    fn tiny_reader_chunks_preserve_escapes_and_unicode() {
+        let input = "<http://example.com/\\u0073> <http://example.com/p> \"καφέ \\u2615\" .\n";
+        let expected = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .next()
+            .unwrap()
+            .unwrap();
+        let mut actual = None;
+        NTriplesParser::new()
+            .parse_reader(
+                TinyChunks {
+                    data: input.as_bytes(),
+                },
+                |triple| {
+                    actual = Some(triple.into_owned());
+                    Ok::<_, TurtleParseError>(())
+                },
+            )
+            .unwrap();
+
+        assert_eq!(actual, Some(expected));
+    }
+
+    #[test]
+    fn maximum_buffer_size_remains_enforced() {
+        let input = format!(
+            "<http://example.com/s> <http://example.com/p> \"{}\" .\n",
+            "a".repeat(5000)
+        );
+        let mut calls = 0;
+        let error = NTriplesParser::new()
+            .with_max_buffer_size(4096)
+            .parse_reader(input.as_bytes(), |_| {
+                calls += 1;
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert!(matches!(error, TurtleParseError::Io(_)));
+    }
+
+    #[test]
+    fn syntax_errors_match_the_owned_parser() {
+        for input in [
+            "<http://example.com/s>\n",
+            "<http://example.com/s> <http://example.com/p>\n",
+            "<http://example.com/s> <http://example.com/p> \"value\"^^\n",
+            "<relative> <http://example.com/p> <http://example.com/o> .\n",
+            "<http://example.com/s> <http://example.com/p> \"bad\\q\" .\n",
+            "<http://example.com/s> <http://example.com/p> <http://example.com/o>\n",
+        ] {
+            let owned = NTriplesParser::new()
+                .for_reader(input.as_bytes())
+                .find_map(Result::err)
+                .unwrap();
+            let borrowed = NTriplesParser::new()
+                .parse_reader(input.as_bytes(), |_| Ok::<_, TurtleParseError>(()))
+                .unwrap_err();
+            assert_eq!(borrowed.to_string(), owned.to_string(), "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn token_debug_output_remains_stable() {
+        let input = "<http://example.com/s> <http://example.com/p> <http://example.com/o> . <http://example.com/extra>\n";
+        let error = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .find_map(Result::err)
+            .unwrap();
+        let message = error.to_string();
+
+        assert!(message.contains("IriRef(\"http://example.com/extra\")"));
+        assert!(!message.contains("Borrowed"));
+        assert!(!message.contains("Owned"));
+    }
+
+    #[cfg(feature = "rdf-12")]
+    #[test]
+    fn rdf_12_directional_literal_is_borrowed() {
+        use oxrdf::BaseDirection;
+
+        let input = "<http://example.com/s> <http://example.com/p> \"value\"@EN--rtl .\n";
+        let mut direction = None;
+        NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |triple| {
+                if let TermRef::Literal(literal) = triple.object {
+                    direction = literal.direction();
+                }
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap();
+
+        assert_eq!(direction, Some(BaseDirection::Rtl));
+    }
+
+    #[cfg(feature = "rdf-12")]
+    #[test]
+    fn rdf_12_triple_terms_match_owned_parser() {
+        let input = "<http://example.com/s> <http://example.com/p> <<( <http://example.com/qs> <http://example.com/qp> <<( <http://example.com/ns> <http://example.com/np> \"nested\"@EN )>> )>> .\n";
+        let owned = NTriplesParser::new()
+            .for_reader(input.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        let mut borrowed = Vec::new();
+        NTriplesParser::new()
+            .parse_reader(input.as_bytes(), |triple| {
+                assert!(
+                    matches!(
+                        triple.object,
+                        TermRef::Triple(triple_term) if triple_term.object.is_triple()
+                    ),
+                    "expected nested RDF 1.2 triple terms"
+                );
+                borrowed.push(triple.into_owned());
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap();
+
+        assert_eq!(borrowed, owned);
+
+        let input = format!(
+            "{} <http://example.com/g> .\n",
+            input.trim_end().trim_end_matches(" .")
+        );
+        let owned = NQuadsParser::new()
+            .for_reader(input.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let mut borrowed = Vec::new();
+        NQuadsParser::new()
+            .parse_reader(input.as_bytes(), |quad| {
+                borrowed.push(quad.into_owned());
+                Ok::<_, TurtleParseError>(())
+            })
+            .unwrap();
+        assert_eq!(borrowed, owned);
+    }
+
+    #[cfg(feature = "rdf-12")]
+    #[test]
+    fn malformed_rdf_12_triple_terms_fail_closed_like_owned_parser() {
+        for input in [
+            "<http://example.com/s> <http://example.com/p> <<( <http://example.com/qs> <http://example.com/qp> <http://example.com/qo> .\n",
+            "<http://example.com/s> <http://example.com/p> <<( <http://example.com/qs> <http://example.com/qp> )>> .\n",
+            "<http://example.com/s> <http://example.com/p> <<( <http://example.com/qs> _:predicate <http://example.com/qo> )>> .\n",
+            "<http://example.com/s> <http://example.com/p> <<( <http://example.com/qs> <http://example.com/qp> <http://example.com/qo>\n)>> .\n",
+        ] {
+            let owned = NTriplesParser::new()
+                .for_reader(input.as_bytes())
+                .find_map(Result::err)
+                .unwrap();
+            let mut calls = 0;
+            let borrowed = NTriplesParser::new()
+                .parse_reader(input.as_bytes(), |_| {
+                    calls += 1;
+                    Ok::<_, TurtleParseError>(())
+                })
+                .unwrap_err();
+
+            assert_eq!(calls, 0, "input: {input:?}");
+            assert_eq!(borrowed.to_string(), owned.to_string(), "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn owned_quad_type_remains_usable() {
+        let quad: Quad = NQuadsParser::new()
+            .for_reader(
+                &b"<http://example.com/s> <http://example.com/p> <http://example.com/o> ."[..],
+            )
+            .next()
+            .unwrap()
+            .unwrap();
+        assert!(quad.graph_name.is_default_graph());
+    }
+}

--- a/testsuite/benches/parser.rs
+++ b/testsuite/benches/parser.rs
@@ -4,6 +4,8 @@ use oxigraph_testsuite::files::read_file;
 use oxigraph_testsuite::manifest::TestManifest;
 use oxrdf::Dataset;
 use oxrdf::dataset::{CanonicalizationAlgorithm, CanonicalizationHashAlgorithm};
+use oxttl::{NTriplesParser, TurtleParseError};
+use std::hint::black_box;
 use std::io::Read;
 
 fn test_data_from_testsuite(manifest_uri: String, include_tests_types: &[&str]) -> Vec<u8> {
@@ -115,6 +117,23 @@ fn bench_parse_ntriples_with_ntriples(c: &mut Criterion) {
     )
 }
 
+fn bench_parse_ntriples_with_borrowed_callback(c: &mut Criterion) {
+    let data = ntriples_test_data();
+    let mut group = c.benchmark_group("oxttl ntriples");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+    group.bench_with_input("borrowed callback", &data, |b, data| {
+        b.iter(|| {
+            NTriplesParser::new()
+                .parse_reader(data.as_slice(), |triple| {
+                    black_box(triple);
+                    Ok::<_, TurtleParseError>(())
+                })
+                .unwrap();
+        })
+    });
+    group.finish();
+}
+
 fn bench_parse_ntriples_with_turtle(c: &mut Criterion) {
     parse_bench(
         c,
@@ -214,6 +233,7 @@ fn canonicalization_bench(c: &mut Criterion) {
 criterion_group!(
     w3c_testsuite,
     bench_parse_ntriples_with_ntriples,
+    bench_parse_ntriples_with_borrowed_callback,
     bench_parse_ntriples_with_turtle,
     bench_parse_turtle_with_turtle,
     bench_parse_jsonld_with_jsonld,


### PR DESCRIPTION
## Summary

- add callback-based `NTriplesParser::parse_reader` and `NQuadsParser::parse_reader` APIs yielding callback-scoped `TripleRef` and `QuadRef` values
- borrow plain lexer strings and reuse a semantic arena between statements instead of materializing owned RDF terms for every callback
- use the same line-format recognizer for the existing owned iterators and the new borrowed callbacks
- support RDF 1.2 triple terms, including nesting, while allocating only their required owned `Triple` subtrees
- preserve the existing owned iterator API, validation, recovery, and error behavior

## Motivation

Streaming consumers often encode or index parsed RDF immediately and do not need to retain an owned intermediate `Triple` or `Quad`. A callback-scoped borrowed API allows those consumers to process validated RDF directly while keeping parser memory bounded.

The higher-ranked callback lifetime prevents references into the parser's reusable buffers from escaping. Consumers that need to retain a statement can call `into_owned` inside the callback.

`TermRef::Triple` contains `&Triple`, so recursively borrowed triple terms cannot be represented by the existing `oxrdf` reference model. The borrowed line parser therefore keeps ordinary term strings in its reusable arena and temporarily owns only quoted-triple subtrees. This avoids an `oxrdf` API break and keeps the common path allocation-light.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p oxttl --all-targets --all-features -- -D warnings`
- `cargo clippy -p oxttl --all-targets --no-default-features -- -D warnings`
- `cargo test -p oxttl --all-features`
- `cargo test -p oxttl --no-default-features`
- `cargo test -p oxigraph-testsuite`
- one-minute `nquads`, `trig`, and `n3` fuzz runs
- `cargo doc -p oxttl --all-features --no-deps`
- borrowed callback and existing owned parser benchmarks

On the same development machine and N-Triples corpus, the shared borrowed callback path parses at roughly 405 MiB/s versus roughly 269 MiB/s for the owned iterator.
