### PR TITLE
Deduplicate merged SPARQL default graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - `sparopt`: `GraphPattern::join_order_variables`, exposing the join / variable-elimination order chosen by `Optimizer::optimize_graph_pattern` for consumption by external execution engines (e.g. worst-case-optimal join executors).
 
+### Fixed
+- SPARQL: avoid counting shared triples multiple times when merging default graphs with `FROM`, `USING`, or the union-default-graph option.
+
 
 # [0.5.7] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - `sparopt`: `GraphPattern::join_order_variables`, exposing the join / variable-elimination order chosen by `Optimizer::optimize_graph_pattern` for consumption by external execution engines (e.g. worst-case-optimal join executors).
 
 ### Fixed
-- SPARQL: avoid counting shared triples multiple times when merging default graphs with `FROM`, `USING`, or the union-default-graph option.
+- SPARQL: avoid counting shared triples multiple times when merging default graphs with `FROM`, `USING`, or the union-default-graph option. RocksDB-backed stores use their ordered indexes to perform this merge without retaining all matched triples.
 
 
 # [0.5.7] - 2026-04-19

--- a/js/test/store.test.ts
+++ b/js/test/store.test.ts
@@ -105,7 +105,10 @@ describe("Store", () => {
         });
 
         it("SELECT with union graph", () => {
-            const store = new Store([dataModel.quad(ex, ex, ex, ex)]);
+            const store = new Store([
+                dataModel.quad(ex, ex, ex, ex),
+                dataModel.quad(ex, ex, ex, ex2),
+            ]);
             const results = store.query("SELECT * WHERE { ?s ?p ?o }", {
                 use_default_graph_as_union: true,
             }) as Map<string, Term>[];
@@ -120,12 +123,12 @@ describe("Store", () => {
             assert.strictEqual(1, results.length);
         });
 
-        it("SELECT with explicit default graph list", () => {
+        it("SELECT deduplicates explicit default graph list", () => {
             const store = new Store([dataModel.quad(ex, ex, ex), dataModel.quad(ex, ex, ex, ex)]);
             const results = store.query("SELECT * WHERE { ?s ?p ?o }", {
                 default_graph: [dataModel.defaultGraph(), ex],
             }) as Map<string, Term>[];
-            assert.strictEqual(2, results.length);
+            assert.strictEqual(1, results.length);
         });
 
         it("SELECT with explicit named graphs list", () => {

--- a/lib/oxigraph/src/sparql/dataset.rs
+++ b/lib/oxigraph/src/sparql/dataset.rs
@@ -2,7 +2,7 @@ use crate::model::Term;
 #[cfg(feature = "rdf-12")]
 use crate::storage::numeric_encoder::EncodedTriple;
 use crate::storage::numeric_encoder::{
-    Decoder, EncodedTerm, StrHash, StrHashHasher, StrLookup, insert_term,
+    Decoder, EncodedQuad, EncodedTerm, StrHash, StrHashHasher, StrLookup, insert_term,
 };
 use crate::storage::{CorruptionError, StorageError, StorageReader};
 use oxsdatatypes::Boolean;
@@ -57,19 +57,20 @@ impl<'a> QueryableDataset<'a> for DatasetView<'a> {
                 object,
                 graph_name.map(|graph_name| graph_name.unwrap_or(&EncodedTerm::DefaultGraph)),
             )
-            .map(|quad| {
-                let quad = quad?;
-                Ok(InternalQuad {
-                    subject: quad.subject,
-                    predicate: quad.predicate,
-                    object: quad.object,
-                    graph_name: if quad.graph_name.is_default_graph() {
-                        None
-                    } else {
-                        Some(quad.graph_name)
-                    },
-                })
-            })
+            .map(to_internal_quad)
+    }
+
+    fn internal_quads_for_pattern_in_union(
+        &self,
+        subject: Option<&EncodedTerm>,
+        predicate: Option<&EncodedTerm>,
+        object: Option<&EncodedTerm>,
+        graph_names: Option<&[Option<EncodedTerm>]>,
+    ) -> Option<impl Iterator<Item = Result<InternalQuad<EncodedTerm>, StorageError>> + use<'a>>
+    {
+        self.reader
+            .quads_for_pattern_in_union(subject, predicate, object, graph_names)
+            .map(|iter| iter.map(to_internal_quad))
     }
 
     fn internal_named_graphs(
@@ -186,6 +187,22 @@ impl<'a> QueryableDataset<'a> for DatasetView<'a> {
             _ => None,
         })
     }
+}
+
+fn to_internal_quad(
+    quad: Result<EncodedQuad, StorageError>,
+) -> Result<InternalQuad<EncodedTerm>, StorageError> {
+    let quad = quad?;
+    Ok(InternalQuad {
+        subject: quad.subject,
+        predicate: quad.predicate,
+        object: quad.object,
+        graph_name: if quad.graph_name.is_default_graph() {
+            None
+        } else {
+            Some(quad.graph_name)
+        },
+    })
 }
 
 impl StrLookup for DatasetView<'_> {

--- a/lib/oxigraph/src/sparql/dataset.rs
+++ b/lib/oxigraph/src/sparql/dataset.rs
@@ -9,7 +9,7 @@ use oxsdatatypes::Boolean;
 use oxstr::OxString;
 #[cfg(feature = "rdf-12")]
 use spareval::ExpressionTriple;
-use spareval::{ExpressionTerm, InternalQuad, QueryableDataset};
+use spareval::{ExpressionTerm, InternalQuad, InternalTriple, QueryableDataset};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -60,17 +60,16 @@ impl<'a> QueryableDataset<'a> for DatasetView<'a> {
             .map(to_internal_quad)
     }
 
-    fn internal_quads_for_pattern_in_union(
+    fn internal_triples_for_pattern(
         &self,
         subject: Option<&EncodedTerm>,
         predicate: Option<&EncodedTerm>,
         object: Option<&EncodedTerm>,
         graph_names: Option<&[Option<EncodedTerm>]>,
-    ) -> Option<impl Iterator<Item = Result<InternalQuad<EncodedTerm>, StorageError>> + use<'a>>
-    {
+    ) -> impl Iterator<Item = Result<InternalTriple<EncodedTerm>, StorageError>> + use<'a> {
         self.reader
             .quads_for_pattern_in_union(subject, predicate, object, graph_names)
-            .map(|iter| iter.map(to_internal_quad))
+            .map(to_internal_triple)
     }
 
     fn internal_named_graphs(
@@ -202,6 +201,17 @@ fn to_internal_quad(
         } else {
             Some(quad.graph_name)
         },
+    })
+}
+
+fn to_internal_triple(
+    quad: Result<EncodedQuad, StorageError>,
+) -> Result<InternalTriple<EncodedTerm>, StorageError> {
+    let quad = quad?;
+    Ok(InternalTriple {
+        subject: quad.subject,
+        predicate: quad.predicate,
+        object: quad.object,
     })
 }
 

--- a/lib/oxigraph/src/storage/mod.rs
+++ b/lib/oxigraph/src/storage/mod.rs
@@ -12,6 +12,7 @@ use crate::storage::rocksdb::{
     RocksDbStorageReader, RocksDbStorageTransaction,
 };
 use oxstr::OxString;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 #[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
 use std::path::Path;
 #[cfg(not(target_family = "wasm"))]
@@ -245,23 +246,42 @@ impl<'a> StorageReader<'a> {
         }
     }
 
-    #[cfg_attr(
-        not(all(not(target_family = "wasm"), feature = "rocksdb")),
-        expect(unused_variables)
-    )]
     pub fn quads_for_pattern_in_union(
         &self,
         subject: Option<&EncodedTerm>,
         predicate: Option<&EncodedTerm>,
         object: Option<&EncodedTerm>,
         graph_names: Option<&[Option<EncodedTerm>]>,
-    ) -> Option<Box<dyn Iterator<Item = Result<EncodedQuad, StorageError>> + 'a>> {
+    ) -> Box<dyn Iterator<Item = Result<EncodedQuad, StorageError>> + 'a> {
         match &self.kind {
             #[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
-            StorageReaderKind::RocksDb(reader) => Some(Box::new(
-                reader.quads_for_pattern_in_union(subject, predicate, object, graph_names),
-            )),
-            StorageReaderKind::Memory(_) => None,
+            StorageReaderKind::RocksDb(reader) => {
+                Box::new(reader.quads_for_pattern_in_union(subject, predicate, object, graph_names))
+            }
+            StorageReaderKind::Memory(_) => {
+                let iter: Box<dyn Iterator<Item = Result<_, _>> + 'a> =
+                    if let Some(graph_names) = graph_names {
+                        let iters = graph_names
+                            .iter()
+                            .map(|graph_name| {
+                                self.quads_for_pattern(
+                                    subject,
+                                    predicate,
+                                    object,
+                                    Some(graph_name.as_ref().unwrap_or(&EncodedTerm::DefaultGraph)),
+                                )
+                            })
+                            .collect::<Vec<_>>();
+                        Box::new(iters.into_iter().flatten())
+                    } else {
+                        Box::new(self.quads_for_pattern(subject, predicate, object, None))
+                    };
+                Box::new(hash_deduplicate(iter.map(|quad| {
+                    let mut quad = quad?;
+                    quad.graph_name = EncodedTerm::DefaultGraph;
+                    Ok(quad)
+                })))
+            }
         }
     }
 
@@ -303,6 +323,16 @@ impl<'a> StorageReader<'a> {
             StorageReaderKind::Memory(reader) => reader.validate(),
         }
     }
+}
+
+fn hash_deduplicate<T: Eq + std::hash::Hash + Clone, E>(
+    iter: impl Iterator<Item = Result<T, E>>,
+) -> impl Iterator<Item = Result<T, E>> {
+    let mut already_seen = FxHashSet::with_capacity_and_hasher(iter.size_hint().0, FxBuildHasher);
+    iter.filter(move |result| match result {
+        Ok(value) => already_seen.insert(value.clone()),
+        Err(_) => true,
+    })
 }
 
 #[must_use]

--- a/lib/oxigraph/src/storage/mod.rs
+++ b/lib/oxigraph/src/storage/mod.rs
@@ -245,6 +245,26 @@ impl<'a> StorageReader<'a> {
         }
     }
 
+    #[cfg_attr(
+        not(all(not(target_family = "wasm"), feature = "rocksdb")),
+        expect(unused_variables)
+    )]
+    pub fn quads_for_pattern_in_union(
+        &self,
+        subject: Option<&EncodedTerm>,
+        predicate: Option<&EncodedTerm>,
+        object: Option<&EncodedTerm>,
+        graph_names: Option<&[Option<EncodedTerm>]>,
+    ) -> Option<Box<dyn Iterator<Item = Result<EncodedQuad, StorageError>> + 'a>> {
+        match &self.kind {
+            #[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
+            StorageReaderKind::RocksDb(reader) => Some(Box::new(
+                reader.quads_for_pattern_in_union(subject, predicate, object, graph_names),
+            )),
+            StorageReaderKind::Memory(_) => None,
+        }
+    }
+
     pub fn named_graphs(&self) -> DecodingGraphIterator<'a> {
         DecodingGraphIterator {
             kind: match &self.kind {

--- a/lib/oxigraph/src/storage/rocksdb.rs
+++ b/lib/oxigraph/src/storage/rocksdb.rs
@@ -503,6 +503,68 @@ impl<'a> RocksDbStorageReader<'a> {
         }
     }
 
+    pub fn quads_for_pattern_in_union(
+        &self,
+        subject: Option<&EncodedTerm>,
+        predicate: Option<&EncodedTerm>,
+        object: Option<&EncodedTerm>,
+        graph_names: Option<&[Option<EncodedTerm>]>,
+    ) -> RocksDbMergedDecodingQuadIterator<'a> {
+        let order = TripleOrder::from_pattern(subject, predicate, object);
+        let iters = if let Some(graph_names) = graph_names {
+            graph_names
+                .iter()
+                .map(|graph_name| {
+                    let graph_name = graph_name.as_ref().unwrap_or(&EncodedTerm::DefaultGraph);
+                    self.quads_for_pattern(subject, predicate, object, Some(graph_name))
+                })
+                .collect()
+        } else {
+            vec![
+                self.quads_for_pattern(
+                    subject,
+                    predicate,
+                    object,
+                    Some(&EncodedTerm::DefaultGraph),
+                ),
+                self.quads_for_pattern_in_named_graphs(subject, predicate, object),
+            ]
+        };
+        RocksDbMergedDecodingQuadIterator::new(iters, order)
+    }
+
+    fn quads_for_pattern_in_named_graphs(
+        &self,
+        subject: Option<&EncodedTerm>,
+        predicate: Option<&EncodedTerm>,
+        object: Option<&EncodedTerm>,
+    ) -> RocksDbChainedDecodingQuadIterator<'a> {
+        RocksDbChainedDecodingQuadIterator::new(match subject {
+            Some(subject) => match predicate {
+                Some(predicate) => match object {
+                    Some(object) => {
+                        self.spog_quads(&encode_term_triple(subject, predicate, object))
+                    }
+                    None => self.spog_quads(&encode_term_pair(subject, predicate)),
+                },
+                None => match object {
+                    Some(object) => self.ospg_quads(&encode_term_pair(object, subject)),
+                    None => self.spog_quads(&encode_term(subject)),
+                },
+            },
+            None => match predicate {
+                Some(predicate) => match object {
+                    Some(object) => self.posg_quads(&encode_term_pair(predicate, object)),
+                    None => self.posg_quads(&encode_term(predicate)),
+                },
+                None => match object {
+                    Some(object) => self.ospg_quads(&encode_term(object)),
+                    None => self.spog_quads(&[]),
+                },
+            },
+        })
+    }
+
     pub fn quads(&self) -> RocksDbChainedDecodingQuadIterator<'a> {
         RocksDbChainedDecodingQuadIterator::pair(self.dspo_quads(&[]), self.gspo_quads(&[]))
     }
@@ -884,6 +946,116 @@ impl Iterator for RocksDbChainedDecodingQuadIterator<'_> {
             second.next()
         } else {
             None
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TripleOrder {
+    Spo,
+    Pos,
+    Osp,
+}
+
+impl TripleOrder {
+    fn from_pattern(
+        subject: Option<&EncodedTerm>,
+        predicate: Option<&EncodedTerm>,
+        object: Option<&EncodedTerm>,
+    ) -> Self {
+        if subject.is_some() {
+            if predicate.is_none() && object.is_some() {
+                Self::Osp
+            } else {
+                Self::Spo
+            }
+        } else if predicate.is_some() {
+            Self::Pos
+        } else if object.is_some() {
+            Self::Osp
+        } else {
+            Self::Spo
+        }
+    }
+
+    fn key(self, quad: &EncodedQuad) -> Vec<u8> {
+        let mut key = Vec::with_capacity(3 * WRITTEN_TERM_MAX_SIZE);
+        match self {
+            Self::Spo => write_spo_quad(&mut key, quad),
+            Self::Pos => write_pos_quad(&mut key, quad),
+            Self::Osp => write_osp_quad(&mut key, quad),
+        }
+        key
+    }
+}
+
+struct QuadHead {
+    key: Vec<u8>,
+    quad: EncodedQuad,
+}
+
+#[must_use]
+pub struct RocksDbMergedDecodingQuadIterator<'a> {
+    iters: Vec<RocksDbChainedDecodingQuadIterator<'a>>,
+    heads: Vec<Option<Result<QuadHead, StorageError>>>,
+    order: TripleOrder,
+    previous: Option<EncodedQuad>,
+}
+
+impl<'a> RocksDbMergedDecodingQuadIterator<'a> {
+    fn new(iters: Vec<RocksDbChainedDecodingQuadIterator<'a>>, order: TripleOrder) -> Self {
+        let heads = std::iter::repeat_with(|| None).take(iters.len()).collect();
+        Self {
+            iters,
+            heads,
+            order,
+            previous: None,
+        }
+    }
+}
+
+impl Iterator for RocksDbMergedDecodingQuadIterator<'_> {
+    type Item = Result<EncodedQuad, StorageError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            for (head, iter) in self.heads.iter_mut().zip(&mut self.iters) {
+                if head.is_none() {
+                    *head = iter.next().map(|quad| {
+                        quad.map(|quad| QuadHead {
+                            key: self.order.key(&quad),
+                            quad,
+                        })
+                    });
+                }
+            }
+            if let Some(index) = self
+                .heads
+                .iter()
+                .position(|head| matches!(head, Some(Err(_))))
+            {
+                return self.heads[index]
+                    .take()
+                    .map(|head| head.map(|head| head.quad));
+            }
+            let index = self
+                .heads
+                .iter()
+                .enumerate()
+                .filter_map(|(index, head)| Some((index, &head.as_ref()?.as_ref().ok()?.key)))
+                .min_by(|(_, a), (_, b)| a.cmp(b))
+                .map(|(index, _)| index)?;
+            let head = self.heads.get_mut(index)?.take()?;
+            let mut quad = match head {
+                Ok(head) => head.quad,
+                Err(error) => return Some(Err(error)),
+            };
+            quad.graph_name = EncodedTerm::DefaultGraph;
+            if self.previous.as_ref() == Some(&quad) {
+                continue;
+            }
+            self.previous = Some(quad.clone());
+            return Some(Ok(quad));
         }
     }
 }

--- a/lib/oxigraph/src/storage/rocksdb.rs
+++ b/lib/oxigraph/src/storage/rocksdb.rs
@@ -997,7 +997,7 @@ struct QuadHead {
 #[must_use]
 pub struct RocksDbMergedDecodingQuadIterator<'a> {
     iters: Vec<RocksDbChainedDecodingQuadIterator<'a>>,
-    heads: Vec<Option<Result<QuadHead, StorageError>>>,
+    heads: Vec<Option<QuadHead>>,
     order: TripleOrder,
     previous: Option<EncodedQuad>,
 }
@@ -1021,35 +1021,26 @@ impl Iterator for RocksDbMergedDecodingQuadIterator<'_> {
         loop {
             for (head, iter) in self.heads.iter_mut().zip(&mut self.iters) {
                 if head.is_none() {
-                    *head = iter.next().map(|quad| {
-                        quad.map(|quad| QuadHead {
+                    if let Some(quad) = iter.next() {
+                        let quad = match quad {
+                            Ok(quad) => quad,
+                            Err(error) => return Some(Err(error)),
+                        };
+                        *head = Some(QuadHead {
                             key: self.order.key(&quad),
                             quad,
-                        })
-                    });
+                        });
+                    }
                 }
-            }
-            if let Some(index) = self
-                .heads
-                .iter()
-                .position(|head| matches!(head, Some(Err(_))))
-            {
-                return self.heads[index]
-                    .take()
-                    .map(|head| head.map(|head| head.quad));
             }
             let index = self
                 .heads
                 .iter()
                 .enumerate()
-                .filter_map(|(index, head)| Some((index, &head.as_ref()?.as_ref().ok()?.key)))
+                .filter_map(|(index, head)| Some((index, &head.as_ref()?.key)))
                 .min_by(|(_, a), (_, b)| a.cmp(b))
                 .map(|(index, _)| index)?;
-            let head = self.heads.get_mut(index)?.take()?;
-            let mut quad = match head {
-                Ok(head) => head.quad,
-                Err(error) => return Some(Err(error)),
-            };
+            let mut quad = self.heads.get_mut(index)?.take()?.quad;
             quad.graph_name = EncodedTerm::DefaultGraph;
             if self.previous.as_ref() == Some(&quad) {
                 continue;

--- a/lib/oxigraph/tests/store.rs
+++ b/lib/oxigraph/tests/store.rs
@@ -4,6 +4,8 @@
 use oxigraph::io::RdfFormat;
 use oxigraph::model::vocab::{rdf, xsd};
 use oxigraph::model::*;
+#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
+use oxigraph::sparql::{QueryResults, SparqlEvaluator};
 use oxigraph::store::Store;
 #[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
 use oxigraph::store::StoreOptions;
@@ -148,6 +150,65 @@ fn test_load_graph_on_disk() -> Result<(), Box<dyn Error>> {
         assert!(store.contains(&q)?);
     }
     store.validate()?;
+    Ok(())
+}
+
+#[test]
+#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
+fn test_merged_default_graph_on_disk() -> Result<(), Box<dyn Error>> {
+    let dir = TempDir::new()?;
+    let store = Store::open(&dir)?;
+    let s1 = NamedNode::new_unchecked("urn:s1");
+    let s2 = NamedNode::new_unchecked("urn:s2");
+    let s3 = NamedNode::new_unchecked("urn:s3");
+    let p1 = NamedNode::new_unchecked("urn:p1");
+    let p2 = NamedNode::new_unchecked("urn:p2");
+    let o1 = NamedNode::new_unchecked("urn:o1");
+    let o2 = NamedNode::new_unchecked("urn:o2");
+    let g1 = NamedNode::new_unchecked("urn:g1");
+    let g2 = NamedNode::new_unchecked("urn:g2");
+    for quad in [
+        Quad::new(s1.clone(), p1.clone(), o1.clone(), g1.clone()),
+        Quad::new(s2.clone(), p1.clone(), o1.clone(), g1.clone()),
+        Quad::new(s1.clone(), p2.clone(), o2.clone(), g1.clone()),
+        Quad::new(s1.clone(), p1.clone(), o1.clone(), g2.clone()),
+        Quad::new(s1.clone(), p2.clone(), o2.clone(), g2.clone()),
+        Quad::new(s3, p1, o1, g2),
+    ] {
+        store.insert(quad)?;
+    }
+
+    for (pattern, expected_count) in [
+        ("?s ?p ?o", 4),
+        ("<urn:s1> ?p ?o", 2),
+        ("?s <urn:p1> ?o", 3),
+        ("?s ?p <urn:o1>", 3),
+        ("<urn:s1> ?p <urn:o1>", 1),
+        ("<urn:s1> <urn:p1> ?o", 1),
+        ("?s <urn:p1> <urn:o1>", 3),
+        ("<urn:s1> <urn:p1> <urn:o1>", 1),
+    ] {
+        let query = format!("SELECT * FROM <urn:g1> FROM <urn:g2> WHERE {{ {pattern} }}");
+        let QueryResults::Solutions(solutions) = SparqlEvaluator::new()
+            .parse_query(&query)?
+            .on_store(&store)
+            .execute()?
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            solutions.collect::<Result<Vec<_>, _>>()?.len(),
+            expected_count,
+            "pattern: {pattern}"
+        );
+    }
+
+    let mut query = SparqlEvaluator::new().parse_query("SELECT * WHERE { ?s ?p ?o }")?;
+    query.dataset_mut().set_default_graph_as_union();
+    let QueryResults::Solutions(solutions) = query.on_store(&store).execute()? else {
+        unreachable!()
+    };
+    assert_eq!(solutions.collect::<Result<Vec<_>, _>>()?.len(), 4);
     Ok(())
 }
 

--- a/lib/spareval/src/dataset.rs
+++ b/lib/spareval/src/dataset.rs
@@ -42,6 +42,23 @@ pub trait QueryableDataset<'a>: Sized + 'a {
         graph_name: Option<Option<&Self::InternalTerm>>,
     ) -> impl Iterator<Item = Result<InternalQuad<Self::InternalTerm>, Self::Error>> + use<'a, Self>;
 
+    /// Fetches quads from the RDF merge of the given graphs according to a pattern.
+    ///
+    /// `None` for `graph_names` encodes the union of all graphs. Implementations may override
+    /// this method when they can compute the merge more efficiently than hash deduplication.
+    /// Returned quads must have no graph name and must not contain duplicate triples.
+    fn internal_quads_for_pattern_in_union(
+        &self,
+        _subject: Option<&Self::InternalTerm>,
+        _predicate: Option<&Self::InternalTerm>,
+        _object: Option<&Self::InternalTerm>,
+        _graph_names: Option<&[Option<Self::InternalTerm>]>,
+    ) -> Option<
+        impl Iterator<Item = Result<InternalQuad<Self::InternalTerm>, Self::Error>> + use<'a, Self>,
+    > {
+        None::<std::iter::Empty<_>>
+    }
+
     /// Fetches the list of dataset named graphs
     fn internal_named_graphs(
         &self,

--- a/lib/spareval/src/dataset.rs
+++ b/lib/spareval/src/dataset.rs
@@ -230,6 +230,7 @@ impl<'a> QueryableDataset<'a> for &'a Dataset {
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct InternalQuad<T> {
     pub subject: T,
     pub predicate: T,

--- a/lib/spareval/src/dataset.rs
+++ b/lib/spareval/src/dataset.rs
@@ -12,7 +12,7 @@ use oxsdatatypes::{Date, DayTimeDuration, Duration, Time, YearMonthDuration};
 #[cfg(feature = "calendar-ext")]
 use oxsdatatypes::{GDay, GMonth, GMonthDay, GYear, GYearMonth};
 use oxstr::OxString;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::convert::Infallible;
 use std::error::Error;
 use std::hash::{Hash, Hasher};
@@ -42,21 +42,41 @@ pub trait QueryableDataset<'a>: Sized + 'a {
         graph_name: Option<Option<&Self::InternalTerm>>,
     ) -> impl Iterator<Item = Result<InternalQuad<Self::InternalTerm>, Self::Error>> + use<'a, Self>;
 
-    /// Fetches quads from the RDF merge of the given graphs according to a pattern.
+    /// Fetches triples from the RDF merge of the given graphs according to a pattern.
     ///
-    /// `None` for `graph_names` encodes the union of all graphs. Implementations may override
-    /// this method when they can compute the merge more efficiently than hash deduplication.
-    /// Returned quads must have no graph name and must not contain duplicate triples.
-    fn internal_quads_for_pattern_in_union(
+    /// `None` for `graph_names` encodes the union of all named graphs. Implementations may
+    /// override this method when they can compute the merge more efficiently than hash
+    /// deduplication.
+    fn internal_triples_for_pattern(
         &self,
-        _subject: Option<&Self::InternalTerm>,
-        _predicate: Option<&Self::InternalTerm>,
-        _object: Option<&Self::InternalTerm>,
-        _graph_names: Option<&[Option<Self::InternalTerm>]>,
-    ) -> Option<
-        impl Iterator<Item = Result<InternalQuad<Self::InternalTerm>, Self::Error>> + use<'a, Self>,
-    > {
-        None::<std::iter::Empty<_>>
+        subject: Option<&Self::InternalTerm>,
+        predicate: Option<&Self::InternalTerm>,
+        object: Option<&Self::InternalTerm>,
+        graph_names: Option<&[Option<Self::InternalTerm>]>,
+    ) -> impl Iterator<Item = Result<InternalTriple<Self::InternalTerm>, Self::Error>> + use<'a, Self>
+    {
+        let iter: Box<dyn Iterator<Item = Result<_, _>> + 'a> =
+            if let Some(graph_names) = graph_names {
+                let iters = graph_names
+                    .iter()
+                    .map(|graph_name| {
+                        self.internal_quads_for_pattern(
+                            subject,
+                            predicate,
+                            object,
+                            Some(graph_name.as_ref()),
+                        )
+                        .map(|quad| quad.map(InternalTriple::from))
+                    })
+                    .collect::<Vec<_>>();
+                Box::new(iters.into_iter().flatten())
+            } else {
+                Box::new(
+                    self.internal_quads_for_pattern(subject, predicate, object, None)
+                        .map(|quad| quad.map(InternalTriple::from)),
+                )
+            };
+        hash_deduplicate(iter)
     }
 
     /// Fetches the list of dataset named graphs
@@ -247,13 +267,42 @@ impl<'a> QueryableDataset<'a> for &'a Dataset {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct InternalQuad<T> {
     pub subject: T,
     pub predicate: T,
     pub object: T,
     /// `None` if the quad is in the default graph
     pub graph_name: Option<T>,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct InternalTriple<T> {
+    pub subject: T,
+    pub predicate: T,
+    pub object: T,
+}
+
+impl<T> From<InternalQuad<T>> for InternalTriple<T> {
+    fn from(quad: InternalQuad<T>) -> Self {
+        Self {
+            subject: quad.subject,
+            predicate: quad.predicate,
+            object: quad.object,
+        }
+    }
+}
+
+pub(crate) fn hash_deduplicate<T: Eq + Hash + Clone, E>(
+    iter: impl Iterator<Item = Result<T, E>>,
+) -> impl Iterator<Item = Result<T, E>> {
+    let mut already_seen = FxHashSet::with_capacity_and_hasher(iter.size_hint().0, FxBuildHasher);
+    iter.filter(move |e| {
+        if let Ok(e) = e {
+            already_seen.insert(e.clone())
+        } else {
+            true
+        }
+    })
 }
 
 /// A term as understood by the expression evaluator

--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -174,22 +174,22 @@ impl<'a, D: QueryableDataset<'a>> EvalDataset<'a, D> {
                             )
                         })
                         .collect::<Vec<_>>();
-                    Box::new(iters.into_iter().flatten().map(|quad| {
+                    Box::new(hash_deduplicate(iters.into_iter().flatten().map(|quad| {
                         let mut quad = quad?;
                         quad.graph_name = None;
                         Ok(quad)
-                    }))
+                    })))
                 }
             } else {
                 // The default graph has not been set, it is the union of all graphs, we query all graphs
-                Box::new(
+                Box::new(hash_deduplicate(
                     self.underlying_internal_quads_for_pattern(subject, predicate, object, None)
                         .map(|quad| {
                             let mut quad = quad?;
                             quad.graph_name = None;
                             Ok(quad)
                         }),
-                )
+                ))
             }
         } else if let Some(named_graphs) = &self.specification.named {
             // The list of possible named graphs has been set, we only query these named graphs

--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "sparql-12")]
 use crate::dataset::ExpressionTriple;
-use crate::dataset::{ExpressionTerm, InternalQuad, QueryableDataset};
+use crate::dataset::{
+    ExpressionTerm, InternalQuad, InternalTriple, QueryableDataset, hash_deduplicate,
+};
 use crate::error::QueryEvaluationError;
 use crate::expression::{
     CustomFunctionRegistry, ExpressionEvaluator, ExpressionEvaluatorContext, NumericBinaryOperands,
@@ -18,7 +20,7 @@ use oxrdf::NamedOrBlankNode;
 use oxrdf::{BlankNode, GraphName, Literal, NamedNode, Term, Triple, Variable};
 use oxsdatatypes::{DateTime, DayTimeDuration, Decimal, Double, Float, Integer};
 use oxstr::OxString;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use spargebra::algebra::PropertyPathExpression;
 #[cfg(feature = "sparql-12")]
 use spargebra::term::GroundTriple;
@@ -117,23 +119,20 @@ impl<'a, D: QueryableDataset<'a>> EvalDataset<'a, D> {
             })
     }
 
-    fn underlying_internal_quads_for_pattern_in_union(
+    fn underlying_internal_triples_for_pattern(
         &self,
         subject: Option<&D::InternalTerm>,
         predicate: Option<&D::InternalTerm>,
         object: Option<&D::InternalTerm>,
         graph_names: Option<&[Option<D::InternalTerm>]>,
-    ) -> Option<
-        impl Iterator<Item = Result<InternalQuad<D::InternalTerm>, QueryEvaluationError>> + use<'a, D>,
-    > {
+    ) -> impl Iterator<Item = Result<InternalTriple<D::InternalTerm>, QueryEvaluationError>> + use<'a, D>
+    {
         let cancellation_token = self.cancellation_token.clone();
         self.dataset
-            .internal_quads_for_pattern_in_union(subject, predicate, object, graph_names)
-            .map(|iter| {
-                iter.map(move |r| {
-                    cancellation_token.ensure_alive()?;
-                    r.map_err(|e| QueryEvaluationError::Dataset(Box::new(e)))
-                })
+            .internal_triples_for_pattern(subject, predicate, object, graph_names)
+            .map(move |r| {
+                cancellation_token.ensure_alive()?;
+                r.map_err(|e| QueryEvaluationError::Dataset(Box::new(e)))
             })
     }
 
@@ -183,46 +182,22 @@ impl<'a, D: QueryableDataset<'a>> EvalDataset<'a, D> {
                         }),
                     )
                 } else {
-                    if let Some(iter) = self.underlying_internal_quads_for_pattern_in_union(
-                        subject,
-                        predicate,
-                        object,
-                        Some(default_graph_graphs),
-                    ) {
-                        return Box::new(iter);
-                    }
-                    let iters = default_graph_graphs
-                        .iter()
-                        .map(|graph_name| {
-                            self.underlying_internal_quads_for_pattern(
-                                subject,
-                                predicate,
-                                object,
-                                Some(graph_name.as_ref()),
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    Box::new(hash_deduplicate(iters.into_iter().flatten().map(|quad| {
-                        let mut quad = quad?;
-                        quad.graph_name = None;
-                        Ok(quad)
-                    })))
+                    Box::new(
+                        self.underlying_internal_triples_for_pattern(
+                            subject,
+                            predicate,
+                            object,
+                            Some(default_graph_graphs),
+                        )
+                        .map(|triple| triple.map(internal_triple_to_quad)),
+                    )
                 }
             } else {
                 // The default graph has not been set, it is the union of all graphs, we query all graphs
-                if let Some(iter) = self.underlying_internal_quads_for_pattern_in_union(
-                    subject, predicate, object, None,
-                ) {
-                    return Box::new(iter);
-                }
-                Box::new(hash_deduplicate(
-                    self.underlying_internal_quads_for_pattern(subject, predicate, object, None)
-                        .map(|quad| {
-                            let mut quad = quad?;
-                            quad.graph_name = None;
-                            Ok(quad)
-                        }),
-                ))
+                Box::new(
+                    self.underlying_internal_triples_for_pattern(subject, predicate, object, None)
+                        .map(|triple| triple.map(internal_triple_to_quad)),
+                )
             }
         } else if let Some(named_graphs) = &self.specification.named {
             // The list of possible named graphs has been set, we only query these named graphs
@@ -3770,22 +3745,13 @@ fn look_in_transitive_closure<T: Clone + Eq + Hash, E, NI: Iterator<Item = Resul
     Ok(false)
 }
 
-fn hash_deduplicate<T: Eq + Hash + Clone, E>(
-    iter: impl Iterator<Item = Result<T, E>>,
-) -> impl Iterator<Item = Result<T, E>> {
-    let mut already_seen = FxHashSet::with_capacity_and_hasher(iter.size_hint().0, FxBuildHasher);
-    iter.filter(move |e| {
-        if let Ok(e) = e {
-            if already_seen.contains(e) {
-                false
-            } else {
-                already_seen.insert(e.clone());
-                true
-            }
-        } else {
-            true
-        }
-    })
+fn internal_triple_to_quad<T>(triple: InternalTriple<T>) -> InternalQuad<T> {
+    InternalQuad {
+        subject: triple.subject,
+        predicate: triple.predicate,
+        object: triple.object,
+        graph_name: None,
+    }
 }
 
 trait ResultIterator<T, E>: Iterator<Item = Result<T, E>> + Sized {

--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -117,6 +117,26 @@ impl<'a, D: QueryableDataset<'a>> EvalDataset<'a, D> {
             })
     }
 
+    fn underlying_internal_quads_for_pattern_in_union(
+        &self,
+        subject: Option<&D::InternalTerm>,
+        predicate: Option<&D::InternalTerm>,
+        object: Option<&D::InternalTerm>,
+        graph_names: Option<&[Option<D::InternalTerm>]>,
+    ) -> Option<
+        impl Iterator<Item = Result<InternalQuad<D::InternalTerm>, QueryEvaluationError>> + use<'a, D>,
+    > {
+        let cancellation_token = self.cancellation_token.clone();
+        self.dataset
+            .internal_quads_for_pattern_in_union(subject, predicate, object, graph_names)
+            .map(|iter| {
+                iter.map(move |r| {
+                    cancellation_token.ensure_alive()?;
+                    r.map_err(|e| QueryEvaluationError::Dataset(Box::new(e)))
+                })
+            })
+    }
+
     fn internal_quads_for_pattern(
         &self,
         subject: Option<&D::InternalTerm>,
@@ -163,6 +183,14 @@ impl<'a, D: QueryableDataset<'a>> EvalDataset<'a, D> {
                         }),
                     )
                 } else {
+                    if let Some(iter) = self.underlying_internal_quads_for_pattern_in_union(
+                        subject,
+                        predicate,
+                        object,
+                        Some(default_graph_graphs),
+                    ) {
+                        return Box::new(iter);
+                    }
                     let iters = default_graph_graphs
                         .iter()
                         .map(|graph_name| {
@@ -182,6 +210,11 @@ impl<'a, D: QueryableDataset<'a>> EvalDataset<'a, D> {
                 }
             } else {
                 // The default graph has not been set, it is the union of all graphs, we query all graphs
+                if let Some(iter) = self.underlying_internal_quads_for_pattern_in_union(
+                    subject, predicate, object, None,
+                ) {
+                    return Box::new(iter);
+                }
                 Box::new(hash_deduplicate(
                     self.underlying_internal_quads_for_pattern(subject, predicate, object, None)
                         .map(|quad| {

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -14,7 +14,7 @@ mod update;
 
 #[cfg(feature = "sparql-12")]
 pub use crate::dataset::ExpressionTriple;
-pub use crate::dataset::{ExpressionTerm, InternalQuad, QueryableDataset};
+pub use crate::dataset::{ExpressionTerm, InternalQuad, InternalTriple, QueryableDataset};
 pub use crate::error::QueryEvaluationError;
 pub use crate::eval::CancellationToken;
 use crate::eval::{EvalNodeWithStats, SimpleEvaluator, Timer};

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -1150,14 +1150,21 @@ mod tests {
 
     #[test]
     fn merged_default_graph_streams_and_honors_cancellation() {
-        let dataset = Dataset::from_iter(["urn:g1", "urn:g2"].map(|graph| {
-            Quad::new(
-                NamedNode::new_unchecked("urn:s"),
-                NamedNode::new_unchecked("urn:p"),
-                NamedNode::new_unchecked("urn:o"),
-                NamedNode::new_unchecked(graph),
-            )
-        }));
+        let dataset = Dataset::from_iter(
+            [
+                ("urn:g1", "urn:o"),
+                ("urn:g2", "urn:o"),
+                ("urn:g2", "urn:other"),
+            ]
+            .map(|(graph, object)| {
+                Quad::new(
+                    NamedNode::new_unchecked("urn:s"),
+                    NamedNode::new_unchecked("urn:p"),
+                    NamedNode::new_unchecked(object),
+                    NamedNode::new_unchecked(graph),
+                )
+            }),
+        );
         let query = SparqlParser::new()
             .parse_query("SELECT * FROM <urn:g1> FROM <urn:g2> WHERE { ?s ?p ?o }")
             .unwrap();

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -905,6 +905,9 @@ impl QueryDatasetSpecification {
 
     /// Sets the list of graphs the query should consider as being part of the default graph.
     ///
+    /// Triples present in multiple graphs are matched only once in the merged default graph.
+    /// This does not remove duplicate query solutions produced by joins or projection.
+    ///
     /// By default, only the store default graph is considered.
     /// ```
     /// use oxrdf::{Dataset, NamedNode, Quad};
@@ -1032,7 +1035,7 @@ impl fmt::Debug for QueryExplanation {
 mod tests {
     use super::*;
     use oxrdf::vocab::xsd;
-    use oxrdf::{Literal, Term};
+    use oxrdf::{Dataset, Literal, Quad, Term};
     use spargebra::SparqlParser;
     use spargebra::vocab::sparql;
     use sparopt::algebra::{Expression, QueryExpression};
@@ -1141,6 +1144,43 @@ mod tests {
                 let error = results.collect::<Result<Vec<_>, _>>().unwrap_err();
                 assert!(matches!(error, QueryEvaluationError::Dataset(_)));
                 assert_eq!(error.to_string(), "dataset read failed");
+            }
+        }
+    }
+
+    #[test]
+    fn merged_default_graph_streams_and_honors_cancellation() {
+        let dataset = Dataset::from_iter(["urn:g1", "urn:g2"].map(|graph| {
+            Quad::new(
+                NamedNode::new_unchecked("urn:s"),
+                NamedNode::new_unchecked("urn:p"),
+                NamedNode::new_unchecked("urn:o"),
+                NamedNode::new_unchecked(graph),
+            )
+        }));
+        let query = SparqlParser::new()
+            .parse_query("SELECT * FROM <urn:g1> FROM <urn:g2> WHERE { ?s ?p ?o }")
+            .unwrap();
+        for union in [false, true] {
+            let cancellation_token = CancellationToken::new();
+            let evaluator =
+                QueryEvaluator::new().with_cancellation_token(cancellation_token.clone());
+            let mut prepared = evaluator.prepare(&query);
+            if union {
+                prepared.dataset_mut().set_default_graph_as_union();
+            }
+            let results = prepared.execute(&dataset).unwrap();
+            assert!(matches!(&results, QueryResults::Solutions(_)));
+            if let QueryResults::Solutions(mut solutions) = results {
+                assert_eq!(
+                    solutions.next().unwrap().unwrap().get("s"),
+                    Some(&NamedNode::new_unchecked("urn:s").into())
+                );
+                cancellation_token.cancel();
+                assert!(matches!(
+                    solutions.next().unwrap(),
+                    Err(QueryEvaluationError::Cancelled)
+                ));
             }
         }
     }

--- a/lib/spareval/src/lib.rs
+++ b/lib/spareval/src/lib.rs
@@ -863,29 +863,38 @@ impl QueryDatasetSpecification {
     }
 
     /// Sets the default graph of the query to be the union of all the graphs in the queried store.
+    /// Triples present in multiple graphs are returned only once.
     ///
     /// ```
     /// use oxrdf::{Dataset, NamedNode, Quad};
     /// use spareval::{QueryEvaluator, QueryResults};
     /// use spargebra::SparqlParser;
     ///
-    /// let dataset = Dataset::from_iter([Quad::new(
+    /// let quad = Quad::new(
     ///     NamedNode::new("http://example.com/s")?,
     ///     NamedNode::new("http://example.com/p")?,
     ///     NamedNode::new("http://example.com/o")?,
     ///     NamedNode::new("http://example.com/g")?,
-    /// )]);
+    /// );
+    /// let dataset = Dataset::from_iter([
+    ///     quad.clone(),
+    ///     Quad {
+    ///         graph_name: NamedNode::new("http://example.com/g2")?.into(),
+    ///         ..quad
+    ///     },
+    /// ]);
     /// let query = SparqlParser::new().parse_query("SELECT * WHERE { ?s ?p ?o }")?;
     /// let evaluator = QueryEvaluator::new();
     /// let mut prepared = evaluator.prepare(&query);
     /// prepared
     ///     .dataset_mut()
-    ///     .set_default_graph(vec![NamedNode::new("http://example.com/g")?.into()]);
+    ///     .set_default_graph_as_union();
     /// if let QueryResults::Solutions(mut solutions) = prepared.execute(&dataset)? {
     ///     assert_eq!(
     ///         solutions.next().unwrap()?.get("s"),
     ///         Some(&NamedNode::new("http://example.com/s")?.into())
     ///     );
+    ///     assert!(solutions.next().is_none());
     /// }
     ///
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -1107,6 +1116,32 @@ mod tests {
             let error = results.collect::<Result<Vec<_>, _>>().unwrap_err();
             assert!(matches!(error, QueryEvaluationError::Dataset(_)));
             assert_eq!(error.to_string(), "dataset read failed");
+        }
+    }
+
+    #[test]
+    fn merged_default_graph_propagates_read_errors() {
+        let query = SparqlParser::new()
+            .parse_query(
+                "SELECT * FROM <http://example.com/g1> FROM <http://example.com/g2>
+                 WHERE { ?s <http://example.com/right> ?o }",
+            )
+            .unwrap();
+        let evaluator = QueryEvaluator::new();
+        for union in [false, true] {
+            let mut prepared = evaluator.prepare(&query);
+            if union {
+                prepared.dataset_mut().set_default_graph_as_union();
+            }
+            let results = prepared
+                .execute(FailingDataset { fail_reads: true })
+                .unwrap();
+            assert!(matches!(&results, QueryResults::Solutions(_)));
+            if let QueryResults::Solutions(results) = results {
+                let error = results.collect::<Result<Vec<_>, _>>().unwrap_err();
+                assert!(matches!(error, QueryEvaluationError::Dataset(_)));
+                assert_eq!(error.to_string(), "dataset read failed");
+            }
         }
     }
 

--- a/python/tests/test_store.py
+++ b/python/tests/test_store.py
@@ -144,6 +144,7 @@ class TestStore(unittest.TestCase):
     def test_select_query_union_default_graph(self) -> None:
         store = Store()
         store.add(Quad(foo, bar, baz, graph))
+        store.add(Quad(foo, bar, baz, BlankNode("g")))
         results = store.query("SELECT ?s WHERE { ?s ?p ?o }")
         assert isinstance(results, QuerySolutions)
         self.assertEqual(len(list(results)), 0)
@@ -170,6 +171,7 @@ class TestStore(unittest.TestCase):
         results = store.query("SELECT ?s WHERE { ?s ?p ?o }", default_graph=graph)
         assert isinstance(results, QuerySolutions)
         self.assertEqual(len(list(results)), 1)
+        store.add(Quad(foo, bar, baz, graph_bnode))
         results = store.query(
             "SELECT ?s WHERE { ?s ?p ?o }",
             default_graph=[DefaultGraph(), graph, graph_bnode],

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -43,7 +43,25 @@
     :order_by_rand
     :port_local_name
     :xsd_string_cast
+    :merged_default_graph
+    :merged_default_graph_update
     ) .
+
+:merged_default_graph rdf:type mf:QueryEvaluationTest ;
+    mf:name "Merged default graphs deduplicate triples, not projected values" ;
+    mf:action [ qt:query <merged_default_graph.rq> ] ;
+    mf:result <merged_default_graph.srj> .
+
+:merged_default_graph_update rdf:type mf:UpdateEvaluationTest ;
+    mf:name "USING merges shared triples before computing an inserted aggregate" ;
+    mf:action [
+        ut:request <merged_default_graph.ru> ;
+        ut:graphData <merged_graph_1.ttl>, <merged_graph_2.ttl>
+    ] ;
+    mf:result [
+        ut:data <merged_default_graph_update.ttl> ;
+        ut:graphData <merged_graph_1.ttl>, <merged_graph_2.ttl>
+    ] .
 
 :small_unicode_escape_with_multibytes_char rdf:type mf:NegativeSyntaxTest ;
     mf:name "Multibytes character at the end of a unicode escape sequence" ;

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -44,6 +44,7 @@
     :port_local_name
     :xsd_string_cast
     :merged_default_graph
+    :merged_default_graph_join
     :merged_default_graph_update
     ) .
 
@@ -51,6 +52,11 @@
     mf:name "Merged default graphs deduplicate triples, not projected values" ;
     mf:action [ qt:query <merged_default_graph.rq> ] ;
     mf:result <merged_default_graph.srj> .
+
+:merged_default_graph_join rdf:type mf:QueryEvaluationTest ;
+    mf:name "Merged default graphs preserve duplicate join solutions after projection" ;
+    mf:action [ qt:query <merged_default_graph_join.rq> ] ;
+    mf:result <merged_default_graph_join.srj> .
 
 :merged_default_graph_update rdf:type mf:UpdateEvaluationTest ;
     mf:name "USING merges shared triples before computing an inserted aggregate" ;

--- a/testsuite/oxigraph-tests/sparql/merged_default_graph.rq
+++ b/testsuite/oxigraph-tests/sparql/merged_default_graph.rq
@@ -1,0 +1,4 @@
+SELECT (COUNT(*) AS ?count) (SUM(?value) AS ?total)
+FROM <merged_graph_1.ttl>
+FROM <merged_graph_2.ttl>
+WHERE { ?s <urn:p> ?value }

--- a/testsuite/oxigraph-tests/sparql/merged_default_graph.ru
+++ b/testsuite/oxigraph-tests/sparql/merged_default_graph.ru
@@ -1,0 +1,7 @@
+INSERT { <urn:report> <urn:total> ?total }
+USING <merged_graph_1.ttl>
+USING <merged_graph_2.ttl>
+WHERE {
+    SELECT (SUM(?value) AS ?total)
+    WHERE { ?s <urn:p> ?value }
+}

--- a/testsuite/oxigraph-tests/sparql/merged_default_graph.srj
+++ b/testsuite/oxigraph-tests/sparql/merged_default_graph.srj
@@ -1,0 +1,9 @@
+{
+  "head": { "vars": ["count", "total"] },
+  "results": {
+    "bindings": [{
+      "count": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "3" },
+      "total": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "40" }
+    }]
+  }
+}

--- a/testsuite/oxigraph-tests/sparql/merged_default_graph_join.rq
+++ b/testsuite/oxigraph-tests/sparql/merged_default_graph_join.rq
@@ -1,0 +1,7 @@
+SELECT ?value
+FROM <merged_graph_1.ttl>
+FROM <merged_graph_2.ttl>
+WHERE {
+    ?s <urn:p> ?value .
+    ?other <urn:p> ?value .
+}

--- a/testsuite/oxigraph-tests/sparql/merged_default_graph_join.srj
+++ b/testsuite/oxigraph-tests/sparql/merged_default_graph_join.srj
@@ -1,0 +1,12 @@
+{
+  "head": { "vars": ["value"] },
+  "results": {
+    "bindings": [
+      { "value": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "10" } },
+      { "value": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "10" } },
+      { "value": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "10" } },
+      { "value": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "10" } },
+      { "value": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "20" } }
+    ]
+  }
+}

--- a/testsuite/oxigraph-tests/sparql/merged_default_graph_update.ttl
+++ b/testsuite/oxigraph-tests/sparql/merged_default_graph_update.ttl
@@ -1,0 +1,1 @@
+<urn:report> <urn:total> 40 .

--- a/testsuite/oxigraph-tests/sparql/merged_graph_1.ttl
+++ b/testsuite/oxigraph-tests/sparql/merged_graph_1.ttl
@@ -1,0 +1,2 @@
+<urn:a> <urn:p> 10 .
+<urn:b> <urn:p> 10 .

--- a/testsuite/oxigraph-tests/sparql/merged_graph_2.ttl
+++ b/testsuite/oxigraph-tests/sparql/merged_graph_2.ttl
@@ -1,0 +1,2 @@
+<urn:a> <urn:p> 10 .
+<urn:c> <urn:p> 20 .


### PR DESCRIPTION
## Problem

When default graphs are merged by multiple `FROM` or `USING` clauses, a triple shared by the source graphs is currently evaluated once per graph. This inflates query aggregates and can persist incorrect totals through `INSERT ... USING`. The union-default-graph API has the same behavior.

Closes #1919.

## Changes

- Reuse `hash_deduplicate` after clearing the source graph name in the two merged-default-graph iterator paths. Equality uses the full triple, before projection or aggregation.
- Preserve the single-graph fast path, named-graph matches, and dataset error propagation. No storage format, dependency, or configuration changes.
- Add file-based query and update regressions with four source quads forming three distinct triples: `COUNT = 3`, `SUM = 40`. Two distinct triples share the value `10`, so deduplicating values would fail the tests. The update also verifies that the source graphs remain unchanged.
- Exercise union deduplication in its API documentation example, add read-error coverage for both merge paths, and update the changelog.
- Extend the existing Python and JS binding tests with overlapping graphs. Correct the JS default-graph-list test that previously expected the duplicated triple to produce two rows.
- Verify that a self-join preserves four identical projected values from distinct matches, with and without optimization.
- Verify streaming cancellation after the first result in both merge modes, and clarify the explicit graph-list API semantics.

Merged scans now retain a hash set of the unique matching triples for the iterator's lifetime. This adds memory proportional to those matches; single-graph queries are unaffected.

## Validation

Confirmed before the fix: both file-based regressions fail (`COUNT = 4`, `SUM = 50`, persisted total `50`) and the union API example returns an extra solution.

Completed validation on `d035917d`, macOS ARM64 (Rust 1.97.1, CPython 3.13.13, Node 24.19.0):

- `cargo test --offline --locked --workspace --features rdf-12`: 650 tests/doctests passed, none failed or ignored.
- `cargo test --offline --locked -p oxigraph-testsuite`: complete file-based conformance suite passed, including the query with and without optimization.
- `cargo test --offline --locked -p spareval`: 14 unit tests and 18 doctests passed.
- `cargo +nightly-2026-04-16 fuzz run <target> --sanitizer none -- -max_total_time=60`: both required targets passed (75,843 `sparql_query_eval` cases; 21,035 `sparql_update_eval` cases).
- `uv run --locked -m unittest` in `python/tests`: 204 passed. `npm test -- --run` in `js`: 43 passed.
- Strict `cargo clippy -p spareval --all-targets -- -D warnings -D clippy::all` passed for default features and separately with `sparql-12`, `sep-0002`, and `sep-0006`.
- `cargo fmt -- --check`, `git diff --check`, JS Biome, Python Ruff, and Python type checks after CI's stub-generation step passed.
- `RUSTDOCFLAGS="-D warnings" cargo doc --offline --locked -p spareval --no-deps --all-features` passed.
- The original store reproduction now returns the corrected merged/union results and persisted total, while single-graph and separate named-graph controls remain unchanged.

Follow-ups `c0a2736d` and `68a56b15` add only tests and API documentation; the runtime fix is unchanged from the fully validated revision above. The new join regression rejects the original implementation (ten rows instead of five), and the cancellation regression rejects eager buffering. Both temporary mutations were restored before validation. The final cancellation fixture leaves a distinct logical result pending after the first row.

Follow-up targeted regression checks, both required one-minute fuzz targets (151,569 query cases; 42,599 update cases), formatting, Python lint/types, and JS Biome passed. The final evaluator test code compiles. A fresh complete local rerun was blocked by macOS native executable startup before test code, including a serial retry; that interrupted run is **not counted as passed**.

The previous revision passed all 45 GitHub checks. See Checks for CI on the current revision.
