### PR TITLE
spargebra: drop blank nodes in the query expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,6 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxstr",
- "rand",
  "thiserror 2.0.18",
 ]
 

--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -24,9 +24,7 @@ use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use spargebra::algebra::PropertyPathExpression;
 #[cfg(feature = "sparql-12")]
 use spargebra::term::GroundTriple;
-use spargebra::term::{
-    GroundTerm, GroundTermPattern, NamedNodePattern, TermPattern, TriplePattern,
-};
+use spargebra::term::{GroundTerm, NamedNodePattern, TermPattern, TermTemplate, TripleTemplate};
 use spargebra::vocab::sparql;
 use sparopt::algebra::{
     AggregateExpression, Expression, JoinAlgorithm, LeftJoinAlgorithm, MinusAlgorithm,
@@ -523,7 +521,7 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
     pub fn evaluate_construct(
         &self,
         expression: &QueryExpression,
-        template: &[TriplePattern],
+        template: &[TripleTemplate],
         substitutions: impl IntoIterator<Item = (Variable, Term)>,
     ) -> (
         Result<QueryTripleIter<'a>, QueryEvaluationError>,
@@ -539,17 +537,17 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
         let template = template
             .iter()
             .filter_map(|t| {
-                Some(TripleTemplate {
-                    subject: TripleTemplateValue::from_term_or_variable(
+                Some(TripleTemplateValue {
+                    subject: TermTemplateValue::from_term_or_variable(
                         &t.subject,
                         &mut variables,
                         &mut bnodes,
                     )?,
-                    predicate: TripleTemplateValue::from_named_node_or_variable(
+                    predicate: TermTemplateValue::from_named_node_or_variable(
                         &t.predicate,
                         &mut variables,
                     ),
-                    object: TripleTemplateValue::from_term_or_variable(
+                    object: TermTemplateValue::from_term_or_variable(
                         &t.object,
                         &mut variables,
                         &mut bnodes,
@@ -809,18 +807,18 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
 
     fn quad_pattern_evaluator(
         &self,
-        subject: &GroundTermPattern,
+        subject: &TermPattern,
         predicate: &NamedNodePattern,
-        object: &GroundTermPattern,
+        object: &TermPattern,
         graph_name: Option<&NamedNodePattern>,
         encoded_variables: &mut Vec<Variable>,
     ) -> Result<InternalTupleEvaluator<'a, D::InternalTerm>, QueryEvaluationError> {
         let subject_selector =
-            TupleSelector::from_ground_term_pattern(subject, encoded_variables, &self.dataset)?;
+            TupleSelector::from_term_pattern(subject, encoded_variables, &self.dataset)?;
         let predicate_selector =
             TupleSelector::from_named_node_pattern(predicate, encoded_variables, &self.dataset)?;
         let object_selector =
-            TupleSelector::from_ground_term_pattern(object, encoded_variables, &self.dataset)?;
+            TupleSelector::from_term_pattern(object, encoded_variables, &self.dataset)?;
         let graph_name_selector = if let Some(graph_name) = graph_name {
             Some(TupleSelector::from_named_node_pattern(
                 graph_name,
@@ -935,16 +933,16 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
 
     fn path_evaluator(
         &self,
-        subject: &GroundTermPattern,
+        subject: &TermPattern,
         path: &PropertyPathExpression,
-        object: &GroundTermPattern,
+        object: &TermPattern,
         encoded_variables: &mut Vec<Variable>,
     ) -> Result<InternalTupleEvaluator<'a, D::InternalTerm>, QueryEvaluationError> {
         let subject_selector =
-            TupleSelector::from_ground_term_pattern(subject, encoded_variables, &self.dataset)?;
+            TupleSelector::from_term_pattern(subject, encoded_variables, &self.dataset)?;
         let path = self.encode_property_path(path)?;
         let object_selector =
-            TupleSelector::from_ground_term_pattern(object, encoded_variables, &self.dataset)?;
+            TupleSelector::from_term_pattern(object, encoded_variables, &self.dataset)?;
         let dataset = self.dataset.clone();
         Ok(Rc::new(move |from| {
             let input_subject = match subject_selector.get_pattern_value(
@@ -2698,27 +2696,25 @@ enum TupleSelector<T> {
 }
 
 impl<T> TupleSelector<T> {
-    fn from_ground_term_pattern<'a>(
-        term_pattern: &GroundTermPattern,
+    fn from_term_pattern<'a>(
+        term_pattern: &TermPattern,
         variables: &mut Vec<Variable>,
         dataset: &EvalDataset<'a, impl QueryableDataset<'a, InternalTerm = T>>,
     ) -> Result<Self, QueryEvaluationError> {
         Ok(match term_pattern {
-            GroundTermPattern::Variable(variable) => {
-                Self::Variable(encode_variable(variables, variable))
-            }
-            GroundTermPattern::NamedNode(term) => {
+            TermPattern::Variable(variable) => Self::Variable(encode_variable(variables, variable)),
+            TermPattern::NamedNode(term) => {
                 Self::Constant(dataset.internalize_term(term.as_ref().into())?)
             }
-            GroundTermPattern::Literal(term) => {
+            TermPattern::Literal(term) => {
                 Self::Constant(dataset.internalize_term(term.as_ref().into())?)
             }
             #[cfg(feature = "sparql-12")]
-            GroundTermPattern::Triple(triple) => {
+            TermPattern::Triple(triple) => {
                 match (
-                    Self::from_ground_term_pattern(&triple.subject, variables, dataset)?,
+                    Self::from_term_pattern(&triple.subject, variables, dataset)?,
                     Self::from_named_node_pattern(&triple.predicate, variables, dataset)?,
-                    Self::from_ground_term_pattern(&triple.object, variables, dataset)?,
+                    Self::from_term_pattern(&triple.object, variables, dataset)?,
                 ) {
                     (
                         Self::Constant(subject),
@@ -3433,7 +3429,7 @@ impl<T: Eq> Iterator for ConsecutiveDeduplication<'_, T> {
 struct ConstructIterator<'a, D: QueryableDataset<'a>> {
     eval: SimpleEvaluator<'a, D>,
     iter: InternalTuplesIterator<'a, D::InternalTerm>,
-    template: Vec<TripleTemplate>,
+    template: Vec<TripleTemplateValue>,
     buffered_results: Vec<Result<Triple, QueryEvaluationError>>,
     already_emitted_results: FxHashSet<Triple>,
     bnodes: Vec<BlankNode>,
@@ -3523,34 +3519,36 @@ impl<'a, D: QueryableDataset<'a>> Iterator for ConstructIterator<'a, D> {
     }
 }
 
-pub struct TripleTemplate {
-    pub subject: TripleTemplateValue,
-    pub predicate: TripleTemplateValue,
-    pub object: TripleTemplateValue,
+pub struct TripleTemplateValue {
+    pub subject: TermTemplateValue,
+    pub predicate: TermTemplateValue,
+    pub object: TermTemplateValue,
 }
 
-pub enum TripleTemplateValue {
+pub enum TermTemplateValue {
     Constant(Term),
     BlankNode(usize),
     Variable(usize),
     #[cfg(feature = "sparql-12")]
-    Triple(Box<TripleTemplate>),
+    Triple(Box<TripleTemplateValue>),
 }
 
-impl TripleTemplateValue {
+impl TermTemplateValue {
     #[cfg_attr(not(feature = "sparql-12"), expect(clippy::unnecessary_wraps))]
     fn from_term_or_variable(
-        term_or_variable: &TermPattern,
+        term_or_variable: &TermTemplate,
         variables: &mut Vec<Variable>,
         bnodes: &mut Vec<BlankNode>,
     ) -> Option<Self> {
         Some(match term_or_variable {
-            TermPattern::Variable(variable) => Self::Variable(encode_variable(variables, variable)),
-            TermPattern::NamedNode(node) => Self::Constant(node.clone().into()),
-            TermPattern::BlankNode(bnode) => Self::BlankNode(bnode_key(bnodes, bnode)),
-            TermPattern::Literal(literal) => Self::Constant(literal.clone().into()),
+            TermTemplate::Variable(variable) => {
+                Self::Variable(encode_variable(variables, variable))
+            }
+            TermTemplate::NamedNode(node) => Self::Constant(node.clone().into()),
+            TermTemplate::BlankNode(bnode) => Self::BlankNode(bnode_key(bnodes, bnode)),
+            TermTemplate::Literal(literal) => Self::Constant(literal.clone().into()),
             #[cfg(feature = "sparql-12")]
-            TermPattern::Triple(triple) => {
+            TermTemplate::Triple(triple) => {
                 match (
                     Self::from_term_or_variable(&triple.subject, variables, bnodes)?,
                     Self::from_named_node_or_variable(&triple.predicate, variables),
@@ -3569,7 +3567,7 @@ impl TripleTemplateValue {
                         .into(),
                     ),
                     (subject, predicate, object) => {
-                        TripleTemplateValue::Triple(Box::new(TripleTemplate {
+                        TermTemplateValue::Triple(Box::new(TripleTemplateValue {
                             subject,
                             predicate,
                             object,
@@ -3583,7 +3581,7 @@ impl TripleTemplateValue {
     fn from_named_node_or_variable(
         named_node_or_variable: &NamedNodePattern,
         variables: &mut Vec<Variable>,
-    ) -> TripleTemplateValue {
+    ) -> TermTemplateValue {
         match named_node_or_variable {
             NamedNodePattern::Variable(variable) => {
                 Self::Variable(encode_variable(variables, variable))
@@ -3594,25 +3592,25 @@ impl TripleTemplateValue {
 }
 
 fn get_triple_template_value<'a, D: QueryableDataset<'a>>(
-    selector: &TripleTemplateValue,
+    selector: &TermTemplateValue,
     tuple: &InternalTuple<D::InternalTerm>,
     bnodes: &mut Vec<BlankNode>,
     dataset: &EvalDataset<'a, D>,
 ) -> Result<Option<Term>, QueryEvaluationError> {
     match selector {
-        TripleTemplateValue::Constant(term) => Ok(Some(term.clone())),
-        TripleTemplateValue::Variable(v) => tuple
+        TermTemplateValue::Constant(term) => Ok(Some(term.clone())),
+        TermTemplateValue::Variable(v) => tuple
             .get(*v)
             .map(|t| dataset.externalize_term(t.clone()))
             .transpose(),
-        TripleTemplateValue::BlankNode(bnode) => {
+        TermTemplateValue::BlankNode(bnode) => {
             if *bnode >= bnodes.len() {
                 bnodes.resize_with(*bnode + 1, BlankNode::default)
             }
             Ok(Some(bnodes[*bnode].clone().into()))
         }
         #[cfg(feature = "sparql-12")]
-        TripleTemplateValue::Triple(triple) => {
+        TermTemplateValue::Triple(triple) => {
             let (Some(subject), Some(predicate), Some(object)) = (
                 get_triple_template_value(&triple.subject, tuple, bnodes, dataset)?,
                 get_triple_template_value(&triple.predicate, tuple, bnodes, dataset)?,

--- a/lib/spareval/src/update.rs
+++ b/lib/spareval/src/update.rs
@@ -5,11 +5,10 @@ use oxrdf::{BlankNode, GraphName, NamedNode, Quad, Term};
 use rustc_hash::FxHashMap;
 use sparesults::QuerySolution;
 use spargebra::term::{
-    GraphNamePattern, GroundQuadPattern, GroundTermPattern, NamedNodePattern, QuadPattern,
-    TermPattern,
+    GraphNamePattern, NamedNodePattern, QuadPattern, QuadTemplate, TermPattern, TermTemplate,
 };
 #[cfg(feature = "sparql-12")]
-use spargebra::term::{GroundTriplePattern, TriplePattern};
+use spargebra::term::{TriplePattern, TripleTemplate};
 use std::collections::VecDeque;
 use std::mem::take;
 
@@ -24,9 +23,9 @@ pub enum DeleteInsertQuad {
 pub struct DeleteInsertIter<'a, 'b> {
     solutions: QuerySolutionIter<'a>,
     ground_delete: Vec<Quad>,
-    variable_delete: Vec<&'b GroundQuadPattern>,
+    variable_delete: Vec<&'b QuadPattern>,
     ground_insert: Vec<Quad>,
-    variable_insert: Vec<&'b QuadPattern>,
+    variable_insert: Vec<&'b QuadTemplate>,
     buffer: VecDeque<DeleteInsertQuad>,
     bnodes: FxHashMap<BlankNode, BlankNode>,
 }
@@ -34,8 +33,8 @@ pub struct DeleteInsertIter<'a, 'b> {
 impl<'a, 'b> DeleteInsertIter<'a, 'b> {
     pub(crate) fn new(
         solutions: QuerySolutionIter<'a>,
-        delete: &'b [GroundQuadPattern],
-        insert: &'b [QuadPattern],
+        delete: &'b [QuadPattern],
+        insert: &'b [QuadTemplate],
         without_optimizations: bool,
     ) -> Self {
         let mut ground_delete = Vec::new();
@@ -119,7 +118,7 @@ impl Iterator for DeleteInsertIter<'_, '_> {
 }
 
 fn fill_quad_pattern(
-    quad: &QuadPattern,
+    quad: &QuadTemplate,
     solution: &QuerySolution,
     bnodes: &mut FxHashMap<BlankNode, BlankNode>,
 ) -> Option<Quad> {
@@ -138,17 +137,17 @@ fn fill_quad_pattern(
 }
 
 fn fill_term_or_var(
-    term: &TermPattern,
+    term: &TermTemplate,
     solution: &QuerySolution,
     bnodes: &mut FxHashMap<BlankNode, BlankNode>,
 ) -> Option<Term> {
     Some(match term {
-        TermPattern::NamedNode(term) => term.clone().into(),
-        TermPattern::BlankNode(bnode) => convert_blank_node(bnode, bnodes).into(),
-        TermPattern::Literal(term) => term.clone().into(),
+        TermTemplate::NamedNode(term) => term.clone().into(),
+        TermTemplate::BlankNode(bnode) => convert_blank_node(bnode, bnodes).into(),
+        TermTemplate::Literal(term) => term.clone().into(),
         #[cfg(feature = "sparql-12")]
-        TermPattern::Triple(triple) => fill_triple_pattern(triple, solution, bnodes)?.into(),
-        TermPattern::Variable(v) => solution.get(v)?.clone(),
+        TermTemplate::Triple(triple) => fill_triple_pattern(triple, solution, bnodes)?.into(),
+        TermTemplate::Variable(v) => solution.get(v)?.clone(),
     })
 }
 
@@ -181,7 +180,7 @@ fn fill_graph_name_or_var(term: &GraphNamePattern, solution: &QuerySolution) -> 
 
 #[cfg(feature = "sparql-12")]
 fn fill_triple_pattern(
-    triple: &TriplePattern,
+    triple: &TripleTemplate,
     solution: &QuerySolution,
     bnodes: &mut FxHashMap<BlankNode, BlankNode>,
 ) -> Option<Triple> {
@@ -197,7 +196,7 @@ fn fill_triple_pattern(
         object: fill_term_or_var(&triple.object, solution, bnodes)?,
     })
 }
-fn fill_ground_quad_pattern(quad: &GroundQuadPattern, solution: &QuerySolution) -> Option<Quad> {
+fn fill_ground_quad_pattern(quad: &QuadPattern, solution: &QuerySolution) -> Option<Quad> {
     Some(Quad {
         subject: match fill_ground_term_or_var(&quad.subject, solution)? {
             Term::NamedNode(node) => node.into(),
@@ -212,21 +211,18 @@ fn fill_ground_quad_pattern(quad: &GroundQuadPattern, solution: &QuerySolution) 
     })
 }
 
-fn fill_ground_term_or_var(term: &GroundTermPattern, solution: &QuerySolution) -> Option<Term> {
+fn fill_ground_term_or_var(term: &TermPattern, solution: &QuerySolution) -> Option<Term> {
     Some(match term {
-        GroundTermPattern::NamedNode(term) => term.clone().into(),
-        GroundTermPattern::Literal(term) => term.clone().into(),
+        TermPattern::NamedNode(term) => term.clone().into(),
+        TermPattern::Literal(term) => term.clone().into(),
         #[cfg(feature = "sparql-12")]
-        GroundTermPattern::Triple(triple) => fill_ground_triple_pattern(triple, solution)?.into(),
-        GroundTermPattern::Variable(v) => solution.get(v)?.clone(),
+        TermPattern::Triple(triple) => fill_ground_triple_pattern(triple, solution)?.into(),
+        TermPattern::Variable(v) => solution.get(v)?.clone(),
     })
 }
 
 #[cfg(feature = "sparql-12")]
-fn fill_ground_triple_pattern(
-    triple: &GroundTriplePattern,
-    solution: &QuerySolution,
-) -> Option<Triple> {
+fn fill_ground_triple_pattern(triple: &TriplePattern, solution: &QuerySolution) -> Option<Triple> {
     Some(Triple {
         subject: match fill_ground_term_or_var(&triple.subject, solution)? {
             Term::NamedNode(node) => node.into(),

--- a/lib/spargebra/Cargo.toml
+++ b/lib/spargebra/Cargo.toml
@@ -23,7 +23,6 @@ logos.workspace = true
 oxiri.workspace = true
 oxrdf.workspace = true
 oxstr.workspace = true
-rand.workspace = true
 thiserror.workspace = true
 
 [lints]

--- a/lib/spargebra/src/algebra_builder.rs
+++ b/lib/spargebra/src/algebra_builder.rs
@@ -8,8 +8,8 @@ use crate::query::{AskQuery, ConstructQuery, DescribeQuery, Query, SelectQuery};
 #[cfg(feature = "sparql-12")]
 use crate::term::GroundTriple;
 use crate::term::{
-    GraphName, GraphNamePattern, GroundQuad, GroundQuadPattern, GroundTerm, NamedNodePattern, Quad,
-    QuadPattern, TermPattern, TriplePattern,
+    GraphName, GraphNamePattern, GroundQuad, GroundTerm, NamedNodePattern, Quad, QuadPattern,
+    QuadTemplate, TermPattern, TermTemplate, TriplePattern, TripleTemplate,
 };
 use crate::update::{
     ClearOperation, CreateOperation, DeleteDataOperation, DeleteInsertOperation, DropOperation,
@@ -23,7 +23,6 @@ use oxrdf::BaseDirection;
 use oxrdf::vocab::{rdf, xsd};
 use oxrdf::{BlankNode, Literal, NamedNode, Variable};
 use oxstr::OxString;
-use rand::random;
 use std::borrow::Cow;
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -35,6 +34,8 @@ pub struct AlgebraBuilder<'a> {
     prefixes: HashMap<OxString, Iri<OxString>>,
     custom_aggregate_functions: &'a HashSet<NamedNode>,
     buffer: String,
+    variable_allocator: FreshVariableAllocator<'a>,
+    blank_node_allocator: FreshBlankNodeAllocator<'a>,
 }
 
 impl<'a> AlgebraBuilder<'a> {
@@ -48,10 +49,14 @@ impl<'a> AlgebraBuilder<'a> {
             prefixes,
             custom_aggregate_functions,
             buffer: String::new(),
+            variable_allocator: FreshVariableAllocator::default(),
+            blank_node_allocator: FreshBlankNodeAllocator::default(),
         }
     }
 
     pub fn build_query(mut self, query: ast::Query<'a>) -> Result<Query, AlgebraBuilderError> {
+        self.variable_allocator.reset_with_query(&query);
+        self.blank_node_allocator.reset_with_query(&query);
         self.apply_prologue(query.prologue)?;
         Ok(match query.variant {
             ast::QueryQuery::Select(select) => {
@@ -354,7 +359,7 @@ impl<'a> AlgebraBuilder<'a> {
                     variables.push(variable);
                 } else {
                     // We have to introduce an intermediate variable
-                    let variable = random_variable();
+                    let variable = self.variable_allocator.fresh_variable("g");
                     p = QueryExpression::Extend {
                         inner: Box::new(p),
                         variable: variable.clone(),
@@ -440,7 +445,12 @@ impl<'a> AlgebraBuilder<'a> {
             }
             // TODO: is it really useful to always do a projection?
             p.on_in_scope_variable(|v| {
-                if !projection_variables.contains(v) {
+                if !projection_variables.contains(v)
+                    && !self
+                        .variable_allocator
+                        .allocated_variable_names
+                        .contains(v.as_str())
+                {
                     projection_variables.push(v.clone());
                 }
             });
@@ -502,7 +512,7 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_triple_template(
         &mut self,
         template: Vec<(ast::GraphNode<'a>, ast::PropertyList<'a>)>,
-    ) -> Result<Vec<TriplePattern>, AlgebraBuilderError> {
+    ) -> Result<Vec<TripleTemplate>, AlgebraBuilderError> {
         let mut patterns = Vec::new();
         for (subject, property_list) in template {
             let subject = self.build_graph_node(subject, &mut patterns)?;
@@ -1006,7 +1016,7 @@ impl<'a> AlgebraBuilder<'a> {
             ast::Expression::Bound(v) => Expression::Bound(Self::build_variable(v)),
             ast::Expression::Aggregate(aggregate) => {
                 let aggregate = self.build_aggregate(expression.span.make_wrapped(aggregate))?;
-                register_aggregate(aggregate, aggregates).into()
+                self.register_aggregate(aggregate, aggregates).into()
             }
             ast::Expression::Iri(n) => Expression::NamedNode(self.build_named_node(n)?),
             ast::Expression::Literal(l) => Expression::Literal(self.build_literal(l)?),
@@ -1139,16 +1149,17 @@ impl<'a> AlgebraBuilder<'a> {
                         args.args.into_iter().next().unwrap(),
                         "Aggregated expressions cannot be nested",
                     )?;
-                    return Ok(register_aggregate(
-                        AggregateExpression::FunctionCall {
-                            name,
-                            expr,
-                            distinct: args.distinct,
-                            scalarvals: BTreeMap::new(),
-                        },
-                        aggregates,
-                    )
-                    .into());
+                    return Ok(self
+                        .register_aggregate(
+                            AggregateExpression::FunctionCall {
+                                name,
+                                expr,
+                                distinct: args.distinct,
+                                scalarvals: BTreeMap::new(),
+                            },
+                            aggregates,
+                        )
+                        .into());
                 }
                 if args.distinct {
                     return Err(AlgebraBuilderError::new(
@@ -1201,9 +1212,9 @@ impl<'a> AlgebraBuilder<'a> {
 
     fn build_property_list(
         &mut self,
-        subject: &TermPattern,
+        subject: &TermTemplate,
         property_list: ast::PropertyList<'a>,
-        patterns: &mut Vec<TriplePattern>,
+        patterns: &mut Vec<TripleTemplate>,
     ) -> Result<(), AlgebraBuilderError> {
         for (predicate, objects) in property_list {
             let predicate = self.build_verb(predicate)?;
@@ -1216,7 +1227,7 @@ impl<'a> AlgebraBuilder<'a> {
                     object,
                     patterns,
                 )?;
-                patterns.push(TriplePattern::new(
+                patterns.push(TripleTemplate::new(
                     subject.clone(),
                     predicate.clone(),
                     object,
@@ -1248,7 +1259,7 @@ impl<'a> AlgebraBuilder<'a> {
                         TriplePattern::new(subject.clone(), predicate, object),
                     )),
                     VarOrPath::Path(path) => {
-                        add_path_to_patterns(subject.clone(), path, object, patterns)
+                        self.add_path_to_patterns(subject.clone(), path, object, patterns)
                     }
                 }
             }
@@ -1258,11 +1269,11 @@ impl<'a> AlgebraBuilder<'a> {
 
     fn build_object(
         &mut self,
-        #[cfg(feature = "sparql-12")] subject: &TermPattern,
+        #[cfg(feature = "sparql-12")] subject: &TermTemplate,
         #[cfg(feature = "sparql-12")] predicate: &NamedNodePattern,
         object: ast::Object<'a>,
-        patterns: &mut Vec<TriplePattern>,
-    ) -> Result<TermPattern, AlgebraBuilderError> {
+        patterns: &mut Vec<TripleTemplate>,
+    ) -> Result<TermTemplate, AlgebraBuilderError> {
         let object_pattern = self.build_graph_node(object.graph_node, patterns)?;
         #[cfg(feature = "sparql-12")]
         {
@@ -1274,22 +1285,23 @@ impl<'a> AlgebraBuilder<'a> {
                         current_reifier = Some(if let Some(r) = r {
                             self.build_reifier_id(r)?
                         } else {
-                            BlankNode::default().into()
+                            self.blank_node_allocator.fresh_blank_node("r").into()
                         });
                         reifier_to_emit
                     }
                     ast::Annotation::AnnotationBlock(a) => {
-                        let reifier_to_emit = take(&mut current_reifier)
-                            .unwrap_or_else(|| BlankNode::default().into());
+                        let reifier_to_emit = take(&mut current_reifier).unwrap_or_else(|| {
+                            self.blank_node_allocator.fresh_blank_node("r").into()
+                        });
                         self.build_property_list(&reifier_to_emit, a, patterns)?;
                         Some(reifier_to_emit)
                     }
                 };
                 if let Some(reifier) = reifier_to_emit {
-                    patterns.push(TriplePattern::new(
+                    patterns.push(TripleTemplate::new(
                         reifier,
                         rdf::REIFIES,
-                        TriplePattern::new(
+                        TripleTemplate::new(
                             subject.clone(),
                             predicate.clone(),
                             object_pattern.clone(),
@@ -1317,15 +1329,17 @@ impl<'a> AlgebraBuilder<'a> {
                     ast::AnnotationPath::Reifier(r) => {
                         let reifier_to_emit = current_reifier;
                         current_reifier = Some(annotation.span.make_wrapped(if let Some(r) = r {
-                            self.build_reifier_id(r)?
+                            self.build_reifier_id_path(r)?
                         } else {
-                            BlankNode::default().into()
+                            self.variable_allocator.fresh_variable("r").into()
                         }));
                         reifier_to_emit
                     }
                     ast::AnnotationPath::AnnotationBlock(a) => {
                         let reifier_to_emit = take(&mut current_reifier).unwrap_or_else(|| {
-                            annotation.span.make_wrapped(BlankNode::default().into())
+                            annotation
+                                .span
+                                .make_wrapped(self.variable_allocator.fresh_variable("r").into())
                         });
                         self.build_property_list_path(&reifier_to_emit.inner, a, patterns)?;
                         Some(reifier_to_emit)
@@ -1359,32 +1373,45 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_reifier_id(
         &mut self,
         var_or_reifier_id: ast::VarOrReifierId<'a>,
+    ) -> Result<TermTemplate, AlgebraBuilderError> {
+        Ok(match var_or_reifier_id {
+            ast::VarOrReifierId::Var(v) => Self::build_variable(v).into(),
+            ast::VarOrReifierId::Iri(n) => self.build_named_node(n)?.into(),
+            ast::VarOrReifierId::BlankNode(n) => self.build_blank_node(n).into(),
+        })
+    }
+
+    #[cfg(feature = "sparql-12")]
+    fn build_reifier_id_path(
+        &mut self,
+        var_or_reifier_id: ast::VarOrReifierId<'a>,
     ) -> Result<TermPattern, AlgebraBuilderError> {
         Ok(match var_or_reifier_id {
             ast::VarOrReifierId::Var(v) => Self::build_variable(v).into(),
             ast::VarOrReifierId::Iri(n) => self.build_named_node(n)?.into(),
-            ast::VarOrReifierId::BlankNode(n) => Self::build_blank_node(n).into(),
+            ast::VarOrReifierId::BlankNode(n) => self.build_blank_node_path(n).into(),
         })
     }
 
     fn build_graph_node(
         &mut self,
         graph_node: ast::GraphNode<'a>,
-        patterns: &mut Vec<TriplePattern>,
-    ) -> Result<TermPattern, AlgebraBuilderError> {
+        patterns: &mut Vec<TripleTemplate>,
+    ) -> Result<TermTemplate, AlgebraBuilderError> {
         match graph_node {
             ast::GraphNode::VarOrTerm(var_or_term) => self.build_term_pattern(var_or_term),
             ast::GraphNode::Collection(elements) => {
-                let mut current_list_node = TermPattern::from(rdf::NIL);
+                let mut current_list_node = TermTemplate::from(rdf::NIL);
                 for element in elements.inner.into_iter().rev() {
                     let element = self.build_graph_node(element, patterns)?;
-                    let new_blank_node = TermPattern::from(BlankNode::default());
-                    patterns.push(TriplePattern::new(
+                    let new_blank_node =
+                        TermTemplate::from(self.blank_node_allocator.fresh_blank_node("c"));
+                    patterns.push(TripleTemplate::new(
                         new_blank_node.clone(),
                         rdf::FIRST,
                         element.clone(),
                     ));
-                    patterns.push(TriplePattern::new(
+                    patterns.push(TripleTemplate::new(
                         new_blank_node.clone(),
                         rdf::REST,
                         current_list_node,
@@ -1394,7 +1421,7 @@ impl<'a> AlgebraBuilder<'a> {
                 Ok(current_list_node)
             }
             ast::GraphNode::BlankNodePropertyList(property_list) => {
-                let subject = TermPattern::from(BlankNode::default());
+                let subject = TermTemplate::from(self.blank_node_allocator.fresh_blank_node("b"));
                 self.build_property_list(&subject, property_list.inner, patterns)?;
                 Ok(subject)
             }
@@ -1409,12 +1436,13 @@ impl<'a> AlgebraBuilder<'a> {
         patterns: &mut Vec<TripleOrPathPattern>,
     ) -> Result<TermPattern, AlgebraBuilderError> {
         match graph_node_path {
-            ast::GraphNodePath::VarOrTerm(var_or_term) => self.build_term_pattern(var_or_term),
+            ast::GraphNodePath::VarOrTerm(var_or_term) => self.build_term_pattern_path(var_or_term),
             ast::GraphNodePath::Collection(elements) => {
                 let mut current_list_node = TermPattern::from(rdf::NIL);
                 for element in elements.inner.into_iter().rev() {
                     let element = self.build_graph_node_path(element, patterns)?;
-                    let new_blank_node = TermPattern::from(BlankNode::default());
+                    let new_blank_node =
+                        TermPattern::from(self.variable_allocator.fresh_variable("c"));
                     patterns.push(TripleOrPathPattern::Triple(TriplePattern::new(
                         new_blank_node.clone(),
                         rdf::FIRST,
@@ -1430,14 +1458,14 @@ impl<'a> AlgebraBuilder<'a> {
                 Ok(current_list_node)
             }
             ast::GraphNodePath::BlankNodePropertyList(property_list) => {
-                let subject = TermPattern::from(BlankNode::default());
+                let subject = TermPattern::from(self.variable_allocator.fresh_variable("b"));
                 self.build_property_list_path(&subject, property_list.inner, patterns)?;
                 Ok(subject)
             }
             #[cfg(feature = "sparql-12")]
             ast::GraphNodePath::ReifiedTriple(t) => {
                 let mut extra_patterns = Vec::new();
-                let term = self.build_reified_triple(t, &mut extra_patterns)?;
+                let term = self.build_reified_triple_path(t, &mut extra_patterns)?;
                 patterns.extend(extra_patterns.into_iter().map(TripleOrPathPattern::Triple));
                 Ok(term)
             }
@@ -1519,16 +1547,33 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_term_pattern(
         &mut self,
         var_or_term: ast::VarOrTerm<'a>,
-    ) -> Result<TermPattern, AlgebraBuilderError> {
+    ) -> Result<TermTemplate, AlgebraBuilderError> {
         Ok(match var_or_term {
             ast::VarOrTerm::Var(v) => Self::build_variable(v).into(),
             ast::VarOrTerm::Iri(n) => self.build_named_node(n)?.into(),
-            ast::VarOrTerm::BlankNode(n) => Self::build_blank_node(n).into(),
+            ast::VarOrTerm::BlankNode(n) => self.build_blank_node(n).into(),
             ast::VarOrTerm::Literal(l) => self.build_literal(l)?.into(),
             ast::VarOrTerm::Nil => rdf::NIL.into(),
             #[cfg(feature = "sparql-12")]
             ast::VarOrTerm::TripleTerm(t) => {
-                TermPattern::Triple(Box::new(self.build_triple_term(*t)?))
+                TermTemplate::Triple(Box::new(self.build_triple_term(*t)?))
+            }
+        })
+    }
+
+    fn build_term_pattern_path(
+        &mut self,
+        var_or_term: ast::VarOrTerm<'a>,
+    ) -> Result<TermPattern, AlgebraBuilderError> {
+        Ok(match var_or_term {
+            ast::VarOrTerm::Var(v) => Self::build_variable(v).into(),
+            ast::VarOrTerm::Iri(n) => self.build_named_node(n)?.into(),
+            ast::VarOrTerm::BlankNode(n) => self.build_blank_node_path(n).into(),
+            ast::VarOrTerm::Literal(l) => self.build_literal(l)?.into(),
+            ast::VarOrTerm::Nil => rdf::NIL.into(),
+            #[cfg(feature = "sparql-12")]
+            ast::VarOrTerm::TripleTerm(t) => {
+                TermPattern::Triple(Box::new(self.build_triple_term_path(*t)?))
             }
         })
     }
@@ -1537,8 +1582,8 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_triple_term(
         &mut self,
         triple_term: ast::TripleTerm<'a>,
-    ) -> Result<TriplePattern, AlgebraBuilderError> {
-        Ok(TriplePattern::new(
+    ) -> Result<TripleTemplate, AlgebraBuilderError> {
+        Ok(TripleTemplate::new(
             self.build_term_pattern(triple_term.subject)?,
             self.build_verb(triple_term.predicate)?,
             self.build_term_pattern(triple_term.object)?,
@@ -1546,20 +1591,52 @@ impl<'a> AlgebraBuilder<'a> {
     }
 
     #[cfg(feature = "sparql-12")]
+    fn build_triple_term_path(
+        &mut self,
+        triple_term: ast::TripleTerm<'a>,
+    ) -> Result<TriplePattern, AlgebraBuilderError> {
+        Ok(TriplePattern::new(
+            self.build_term_pattern_path(triple_term.subject)?,
+            self.build_verb(triple_term.predicate)?,
+            self.build_term_pattern_path(triple_term.object)?,
+        ))
+    }
+
+    #[cfg(feature = "sparql-12")]
     fn build_reified_triple(
+        &mut self,
+        triple: ast::ReifiedTriple<'a>,
+        patterns: &mut Vec<TripleTemplate>,
+    ) -> Result<TermTemplate, AlgebraBuilderError> {
+        let reifier = triple
+            .reifier
+            .map(|r| self.build_reifier_id(r))
+            .transpose()?
+            .unwrap_or_else(|| self.blank_node_allocator.fresh_blank_node("r").into());
+        let triple = TripleTemplate::new(
+            self.build_reified_triple_subject_or_object(triple.subject, patterns)?,
+            self.build_verb(triple.predicate)?,
+            self.build_reified_triple_subject_or_object(triple.object, patterns)?,
+        );
+        patterns.push(TripleTemplate::new(reifier.clone(), rdf::REIFIES, triple));
+        Ok(reifier)
+    }
+
+    #[cfg(feature = "sparql-12")]
+    fn build_reified_triple_path(
         &mut self,
         triple: ast::ReifiedTriple<'a>,
         patterns: &mut Vec<TriplePattern>,
     ) -> Result<TermPattern, AlgebraBuilderError> {
         let reifier = triple
             .reifier
-            .map(|r| self.build_reifier_id(r))
+            .map(|r| self.build_reifier_id_path(r))
             .transpose()?
-            .unwrap_or_else(|| BlankNode::default().into());
+            .unwrap_or_else(|| self.variable_allocator.fresh_variable("r").into());
         let triple = TriplePattern::new(
-            self.build_reified_triple_subject_or_object(triple.subject, patterns)?,
+            self.build_reified_triple_subject_or_object_path(triple.subject, patterns)?,
             self.build_verb(triple.predicate)?,
-            self.build_reified_triple_subject_or_object(triple.object, patterns)?,
+            self.build_reified_triple_subject_or_object_path(triple.object, patterns)?,
         );
         patterns.push(TriplePattern::new(reifier.clone(), rdf::REIFIES, triple));
         Ok(reifier)
@@ -1569,18 +1646,38 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_reified_triple_subject_or_object(
         &mut self,
         triple_term: ast::ReifiedTripleSubjectOrObject<'a>,
-        patterns: &mut Vec<TriplePattern>,
-    ) -> Result<TermPattern, AlgebraBuilderError> {
+        patterns: &mut Vec<TripleTemplate>,
+    ) -> Result<TermTemplate, AlgebraBuilderError> {
         Ok(match triple_term {
             ast::ReifiedTripleSubjectOrObject::Var(v) => Self::build_variable(v).into(),
             ast::ReifiedTripleSubjectOrObject::Iri(n) => self.build_named_node(n)?.into(),
-            ast::ReifiedTripleSubjectOrObject::BlankNode(n) => Self::build_blank_node(n).into(),
+            ast::ReifiedTripleSubjectOrObject::BlankNode(n) => self.build_blank_node(n).into(),
             ast::ReifiedTripleSubjectOrObject::Literal(l) => self.build_literal(l)?.into(),
             ast::ReifiedTripleSubjectOrObject::ReifiedTriple(t) => {
                 self.build_reified_triple(*t, patterns)?
             }
             ast::ReifiedTripleSubjectOrObject::TripleTerm(t) => {
-                TermPattern::Triple(Box::new(self.build_triple_term(*t)?))
+                TermTemplate::Triple(Box::new(self.build_triple_term(*t)?))
+            }
+        })
+    }
+
+    #[cfg(feature = "sparql-12")]
+    fn build_reified_triple_subject_or_object_path(
+        &mut self,
+        triple_term: ast::ReifiedTripleSubjectOrObject<'a>,
+        patterns: &mut Vec<TriplePattern>,
+    ) -> Result<TermPattern, AlgebraBuilderError> {
+        Ok(match triple_term {
+            ast::ReifiedTripleSubjectOrObject::Var(v) => Self::build_variable(v).into(),
+            ast::ReifiedTripleSubjectOrObject::Iri(n) => self.build_named_node(n)?.into(),
+            ast::ReifiedTripleSubjectOrObject::BlankNode(n) => self.build_blank_node_path(n).into(),
+            ast::ReifiedTripleSubjectOrObject::Literal(l) => self.build_literal(l)?.into(),
+            ast::ReifiedTripleSubjectOrObject::ReifiedTriple(t) => {
+                self.build_reified_triple_path(*t, patterns)?
+            }
+            ast::ReifiedTripleSubjectOrObject::TripleTerm(t) => {
+                TermPattern::Triple(Box::new(self.build_triple_term_path(*t)?))
             }
         })
     }
@@ -1651,11 +1748,19 @@ impl<'a> AlgebraBuilder<'a> {
         })
     }
 
-    fn build_blank_node(blank_node: Spanned<ast::BlankNode<'a>>) -> BlankNode {
+    fn build_blank_node(&mut self, blank_node: Spanned<ast::BlankNode<'a>>) -> BlankNode {
         if let Some(id) = blank_node.inner.0 {
             BlankNode::new_unchecked(OxString::new_owned(id))
         } else {
-            BlankNode::default()
+            self.blank_node_allocator.fresh_blank_node("a")
+        }
+    }
+
+    fn build_blank_node_path(&mut self, blank_node: Spanned<ast::BlankNode<'a>>) -> Variable {
+        if let Some(id) = blank_node.inner.0 {
+            self.variable_allocator.map_blank_node_id(id)
+        } else {
+            self.variable_allocator.fresh_variable("bn")
         }
     }
 
@@ -1726,9 +1831,11 @@ impl<'a> AlgebraBuilder<'a> {
 
     pub fn build_update(mut self, update: ast::Update<'a>) -> Result<Update, AlgebraBuilderError> {
         valid_update_operation_blank_node_id_syntax_restrictions(&update)?;
+        self.blank_node_allocator.reset_with_update(&update);
 
         let mut operations = Vec::new();
         for (prologue, update1) in update.operations {
+            self.variable_allocator.reset_with_update1(&update1);
             self.apply_prologue(prologue)?;
             match update1 {
                 ast::Update1::Load { silent, from, to } => operations.push(
@@ -1822,9 +1929,9 @@ impl<'a> AlgebraBuilder<'a> {
                         }
                         current_graph_name = &pattern.graph_name;
                         current_bgp.push(TriplePattern {
-                            subject: pattern.subject.clone().into(),
+                            subject: pattern.subject.clone(),
                             predicate: pattern.predicate.clone(),
-                            object: pattern.object.clone().into(),
+                            object: pattern.object.clone(),
                         });
                     }
                     graph_pattern = new_join(
@@ -1908,8 +2015,8 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_ground_quad_patterns(
         &mut self,
         quads: ast::QuadPatterns<'a>,
-    ) -> Result<Vec<GroundQuadPattern>, AlgebraBuilderError> {
-        let mut visitor = FindBlankNodeOrVariable::default();
+    ) -> Result<Vec<QuadPattern>, AlgebraBuilderError> {
+        let mut visitor = FindAnyBlankNode::default();
         visitor.visit_quads(&quads);
         if let Some(blank_node) = visitor.blank_node {
             return Err(AlgebraBuilderError::new(
@@ -1928,7 +2035,7 @@ impl<'a> AlgebraBuilder<'a> {
         &mut self,
         quads: ast::QuadPatterns<'a>,
     ) -> Result<Vec<Quad>, AlgebraBuilderError> {
-        let mut visitor = FindBlankNodeOrVariable::default();
+        let mut visitor = FindAnyVariable::default();
         visitor.visit_quads(&quads);
         if let Some(variable) = visitor.variable {
             return Err(AlgebraBuilderError::new(
@@ -1947,7 +2054,7 @@ impl<'a> AlgebraBuilder<'a> {
         &mut self,
         quads: ast::QuadPatterns<'a>,
     ) -> Result<Vec<GroundQuad>, AlgebraBuilderError> {
-        let mut visitor = FindBlankNodeOrVariable::default();
+        let mut visitor = FindAnyVariable::default();
         visitor.visit_quads(&quads);
         if let Some(variable) = visitor.variable {
             return Err(AlgebraBuilderError::new(
@@ -1955,6 +2062,8 @@ impl<'a> AlgebraBuilder<'a> {
                 "Variables are not allowed in DELETE DATA",
             ));
         }
+        let mut visitor = FindAnyBlankNode::default();
+        visitor.visit_quads(&quads);
         if let Some(blank_node) = visitor.blank_node {
             return Err(AlgebraBuilderError::new(
                 blank_node.span,
@@ -1971,7 +2080,7 @@ impl<'a> AlgebraBuilder<'a> {
     fn build_quad_patterns(
         &mut self,
         quads: ast::QuadPatterns<'a>,
-    ) -> Result<Vec<QuadPattern>, AlgebraBuilderError> {
+    ) -> Result<Vec<QuadTemplate>, AlgebraBuilderError> {
         let mut patterns = Vec::new();
         for (graph_name, triples) in quads {
             let graph_name = if let Some(graph_name) = graph_name {
@@ -1980,7 +2089,7 @@ impl<'a> AlgebraBuilder<'a> {
                 GraphNamePattern::DefaultGraph
             };
             for triple in self.build_triple_template(triples)? {
-                patterns.push(QuadPattern {
+                patterns.push(QuadTemplate {
                     subject: triple.subject,
                     predicate: triple.predicate,
                     object: triple.object,
@@ -2012,25 +2121,49 @@ impl<'a> AlgebraBuilder<'a> {
             ast::GraphRefAll::All => GraphTarget::AllGraphs,
         })
     }
-}
 
-fn register_aggregate(
-    agg: AggregateExpression,
-    aggregates: &mut Vec<(Variable, AggregateExpression)>,
-) -> Variable {
-    aggregates
-        .iter()
-        .find_map(|(v, a)| (*a == agg).then_some(v))
-        .cloned()
-        .unwrap_or_else(|| {
-            let new_var = random_variable();
-            aggregates.push((new_var.clone(), agg));
-            new_var
-        })
-}
+    fn register_aggregate(
+        &mut self,
+        agg: AggregateExpression,
+        aggregates: &mut Vec<(Variable, AggregateExpression)>,
+    ) -> Variable {
+        aggregates
+            .iter()
+            .find_map(|(v, a)| (*a == agg).then_some(v))
+            .cloned()
+            .unwrap_or_else(|| {
+                let new_var = self.variable_allocator.fresh_variable("agg");
+                aggregates.push((new_var.clone(), agg));
+                new_var
+            })
+    }
 
-fn random_variable() -> Variable {
-    Variable::new_unchecked(OxString::new_owned(&format!("{:x}", random::<u128>())))
+    fn add_path_to_patterns(
+        &mut self,
+        subject: TermPattern,
+        path: PropertyPathExpression,
+        object: TermPattern,
+        patterns: &mut Vec<TripleOrPathPattern>,
+    ) {
+        match path {
+            PropertyPathExpression::Link(predicate) => patterns.push(TripleOrPathPattern::Triple(
+                TriplePattern::new(subject, predicate, object),
+            )),
+            PropertyPathExpression::Inv(path) => {
+                self.add_path_to_patterns(object, *path, subject, patterns)
+            }
+            PropertyPathExpression::Seq(path1, path2) => {
+                let middle = self.variable_allocator.fresh_variable("m");
+                self.add_path_to_patterns(subject, *path1, middle.clone().into(), patterns);
+                self.add_path_to_patterns(middle.into(), *path2, object, patterns)
+            }
+            _ => patterns.push(TripleOrPathPattern::Path {
+                subject,
+                path,
+                object,
+            }),
+        }
+    }
 }
 
 fn find_unbound_variable<'a>(
@@ -2184,30 +2317,6 @@ enum TripleOrPathPattern {
 enum VarOrPath {
     Var(Variable),
     Path(PropertyPathExpression),
-}
-
-fn add_path_to_patterns(
-    subject: TermPattern,
-    path: PropertyPathExpression,
-    object: TermPattern,
-    patterns: &mut Vec<TripleOrPathPattern>,
-) {
-    match path {
-        PropertyPathExpression::Link(predicate) => patterns.push(TripleOrPathPattern::Triple(
-            TriplePattern::new(subject, predicate, object),
-        )),
-        PropertyPathExpression::Inv(path) => add_path_to_patterns(object, *path, subject, patterns),
-        PropertyPathExpression::Seq(path1, path2) => {
-            let middle = BlankNode::default();
-            add_path_to_patterns(subject, *path1, middle.clone().into(), patterns);
-            add_path_to_patterns(middle.into(), *path2, object, patterns)
-        }
-        _ => patterns.push(TripleOrPathPattern::Path {
-            subject,
-            path,
-            object,
-        }),
-    }
 }
 
 /// Called on every variable defined using "AS" or "VALUES"
@@ -2476,12 +2585,7 @@ fn find_update_operation_blank_node_ids_and_validate_syntax_restrictions<'a>(
         | ast::Update1::InsertData { quads }
         | ast::Update1::DeleteData { quads } => {
             let mut blank_nodes = HashMap::new();
-            for (_, triples) in quads {
-                for (subject, property_list) in triples {
-                    blank_nodes.visit_graph_node(subject);
-                    blank_nodes.visit_property_list(property_list);
-                }
-            }
+            blank_nodes.visit_quads(quads);
             Ok(blank_nodes)
         }
     }
@@ -2593,6 +2697,248 @@ fn extend_blank_node_ids_if_not_overlapping<'a>(
 trait TermVisitor<'a> {
     fn on_blank_node(&mut self, _blank_node: &Spanned<ast::BlankNode<'a>>) {}
     fn on_variable(&mut self, _variable: &Spanned<ast::Var<'a>>) {}
+
+    fn visit_query(&mut self, query: &ast::Query<'a>) {
+        match &query.variant {
+            ast::QueryQuery::Select(query) => {
+                self.visit_select_clause(&query.select_clause);
+                self.visit_graph_pattern(&query.where_clause);
+                self.visit_solution_modifier(&query.solution_modifier);
+            }
+            ast::QueryQuery::Construct(query) => {
+                for (subject, property_list) in &query.template.inner {
+                    self.visit_graph_node(subject);
+                    self.visit_property_list(property_list);
+                }
+                if let Some(where_clause) = &query.where_clause {
+                    self.visit_graph_pattern(where_clause);
+                }
+                self.visit_solution_modifier(&query.solution_modifier);
+            }
+            ast::QueryQuery::Describe(query) => {
+                if let ast::DescribeTargets::Explicit(targets) = &query.targets.inner {
+                    for target in targets {
+                        self.visit_var_or_iri(&target.inner);
+                    }
+                }
+                if let Some(where_clause) = &query.where_clause {
+                    self.visit_graph_pattern(where_clause);
+                }
+                self.visit_solution_modifier(&query.solution_modifier);
+            }
+            ast::QueryQuery::Ask(query) => {
+                self.visit_graph_pattern(&query.where_clause);
+                self.visit_solution_modifier(&query.solution_modifier);
+            }
+        }
+        if let Some(values_clause) = &query.values_clause {
+            self.visit_values_clause(values_clause);
+        }
+    }
+
+    fn visit_update(&mut self, update: &ast::Update<'a>) {
+        for (_, update) in &update.operations {
+            self.visit_update1(update);
+        }
+    }
+
+    fn visit_update1(&mut self, update: &ast::Update1<'a>) {
+        match update {
+            ast::Update1::DeleteWhere { pattern }
+            | ast::Update1::InsertData { quads: pattern }
+            | ast::Update1::DeleteData { quads: pattern } => self.visit_quads(pattern),
+            ast::Update1::Modify {
+                delete,
+                insert,
+                r#where,
+                ..
+            } => {
+                self.visit_quads(delete);
+                self.visit_quads(insert);
+                self.visit_graph_pattern(r#where);
+            }
+            ast::Update1::Load { .. }
+            | ast::Update1::Clear { .. }
+            | ast::Update1::Drop { .. }
+            | ast::Update1::Create { .. }
+            | ast::Update1::Add { .. }
+            | ast::Update1::Move { .. }
+            | ast::Update1::Copy { .. } => {}
+        }
+    }
+
+    fn visit_select_clause(&mut self, select_clause: &ast::SelectClause<'a>) {
+        if let ast::SelectVariables::Explicit(bindings) = &select_clause.bindings.inner {
+            for binding in bindings {
+                let (expression, variable) = &binding.inner;
+                if let Some(expression) = expression {
+                    self.visit_expression(&expression.inner);
+                }
+                self.on_variable(variable);
+            }
+        }
+    }
+
+    fn visit_solution_modifier(&mut self, solution_modifier: &ast::SolutionModifier<'a>) {
+        for (expression, variable) in &solution_modifier.group_clause {
+            self.visit_expression(&expression.inner);
+            if let Some(variable) = variable {
+                self.on_variable(variable);
+            }
+        }
+        for expression in &solution_modifier.having_clause {
+            self.visit_expression(&expression.inner);
+        }
+        for condition in &solution_modifier.order_clause {
+            match condition {
+                ast::OrderCondition::Asc(expression) | ast::OrderCondition::Desc(expression) => {
+                    self.visit_expression(&expression.inner);
+                }
+            }
+        }
+    }
+
+    fn visit_values_clause(&mut self, values_clause: &ast::ValuesClause<'a>) {
+        for variable in &values_clause.variables {
+            self.on_variable(variable);
+        }
+    }
+
+    fn visit_graph_pattern(&mut self, graph_pattern: &ast::GraphPattern<'a>) {
+        match graph_pattern {
+            ast::GraphPattern::Group(elements) => {
+                for element in elements {
+                    match &element.inner {
+                        ast::GraphPatternElement::Filter(expression) => {
+                            self.visit_expression(&expression.inner);
+                        }
+                        ast::GraphPatternElement::Union(patterns) => {
+                            for pattern in patterns {
+                                self.visit_graph_pattern(pattern);
+                            }
+                        }
+                        ast::GraphPatternElement::Minus(pattern)
+                        | ast::GraphPatternElement::Optional(pattern) => {
+                            self.visit_graph_pattern(pattern);
+                        }
+                        ast::GraphPatternElement::Values(values_clause) => {
+                            self.visit_values_clause(values_clause);
+                        }
+                        ast::GraphPatternElement::Bind(expression, variable) => {
+                            self.visit_expression(&expression.inner);
+                            self.on_variable(variable);
+                        }
+                        ast::GraphPatternElement::Service { name, pattern, .. }
+                        | ast::GraphPatternElement::Graph { name, pattern } => {
+                            self.visit_var_or_iri(name);
+                            self.visit_graph_pattern(pattern);
+                        }
+                        ast::GraphPatternElement::Triples(triples) => {
+                            for (subject, property_list) in triples {
+                                self.visit_graph_node_path(subject);
+                                self.visit_property_list_path(property_list);
+                            }
+                        }
+                        #[cfg(feature = "sep-0006")]
+                        ast::GraphPatternElement::Lateral(pattern) => {
+                            self.visit_graph_pattern(pattern);
+                        }
+                    }
+                }
+            }
+            ast::GraphPattern::SubSelect(select) => {
+                self.visit_select_clause(&select.select_clause);
+                self.visit_graph_pattern(&select.where_clause);
+                self.visit_solution_modifier(&select.solution_modifier);
+                if let Some(values_clause) = &select.values_clause {
+                    self.visit_values_clause(values_clause);
+                }
+            }
+        }
+    }
+
+    fn visit_expression(&mut self, expression: &ast::Expression<'a>) {
+        match expression {
+            ast::Expression::Or(left, right)
+            | ast::Expression::And(left, right)
+            | ast::Expression::Equal(left, right)
+            | ast::Expression::NotEqual(left, right)
+            | ast::Expression::Less(left, right)
+            | ast::Expression::LessOrEqual(left, right)
+            | ast::Expression::Greater(left, right)
+            | ast::Expression::GreaterOrEqual(left, right)
+            | ast::Expression::Add(left, right)
+            | ast::Expression::Subtract(left, right)
+            | ast::Expression::Multiply(left, right)
+            | ast::Expression::Divide(left, right) => {
+                self.visit_expression(&left.inner);
+                self.visit_expression(&right.inner);
+            }
+            ast::Expression::In(expression, expressions)
+            | ast::Expression::NotIn(expression, expressions) => {
+                self.visit_expression(&expression.inner);
+                for expression in expressions {
+                    self.visit_expression(&expression.inner);
+                }
+            }
+            ast::Expression::UnaryPlus(expression)
+            | ast::Expression::UnaryMinus(expression)
+            | ast::Expression::Not(expression) => self.visit_expression(&expression.inner),
+            ast::Expression::Bound(variable) | ast::Expression::Var(variable) => {
+                self.on_variable(variable);
+            }
+            ast::Expression::Aggregate(aggregate) => self.visit_aggregate(aggregate),
+            ast::Expression::BuiltIn(_, arguments) => {
+                for argument in arguments {
+                    self.visit_expression(&argument.inner);
+                }
+            }
+            ast::Expression::Function(_, arguments) => {
+                for argument in &arguments.args {
+                    self.visit_expression(&argument.inner);
+                }
+            }
+            ast::Expression::Exists(pattern) | ast::Expression::NotExists(pattern) => {
+                self.visit_graph_pattern(pattern);
+            }
+            ast::Expression::Iri(_) | ast::Expression::Literal(_) => {}
+            #[cfg(feature = "sparql-12")]
+            ast::Expression::TripleTerm(triple) => self.visit_expression_triple_term(triple),
+        }
+    }
+
+    fn visit_aggregate(&mut self, aggregate: &ast::Aggregate<'a>) {
+        match aggregate {
+            ast::Aggregate::Count(_, expression) => {
+                if let Some(expression) = expression {
+                    self.visit_expression(&expression.inner);
+                }
+            }
+            ast::Aggregate::Sum(_, expression)
+            | ast::Aggregate::Min(_, expression)
+            | ast::Aggregate::Max(_, expression)
+            | ast::Aggregate::Avg(_, expression)
+            | ast::Aggregate::Sample(_, expression)
+            | ast::Aggregate::GroupConcat(_, expression, _) => {
+                self.visit_expression(&expression.inner);
+            }
+        }
+    }
+
+    #[cfg(feature = "sparql-12")]
+    fn visit_expression_triple_term(&mut self, triple: &ast::ExprTripleTerm<'a>) {
+        if let ast::ExprTripleTermSubject::Var(variable) = &triple.subject {
+            self.on_variable(variable);
+        }
+        self.visit_verb(&triple.predicate);
+        match &triple.object {
+            ast::ExprTripleTermObject::Var(variable) => self.on_variable(variable),
+            ast::ExprTripleTermObject::TripleTerm(triple) => {
+                self.visit_expression_triple_term(triple);
+            }
+            ast::ExprTripleTermObject::Iri(_) | ast::ExprTripleTermObject::Literal(_) => {}
+        }
+    }
 
     fn visit_quads(&mut self, quads: &ast::QuadPatterns<'a>) {
         for (graph_name, triples) in quads {
@@ -2737,6 +3083,9 @@ trait TermVisitor<'a> {
         self.visit_reified_triple_term_subject_or_object(&reified_triple.subject);
         self.visit_verb(&reified_triple.predicate);
         self.visit_reified_triple_term_subject_or_object(&reified_triple.object);
+        if let Some(reifier) = &reified_triple.reifier {
+            self.visit_var_or_reifier_id(reifier);
+        }
     }
 
     #[cfg(feature = "sparql-12")]
@@ -2805,18 +3154,156 @@ impl<'a> TermVisitor<'a> for HashMap<&'a str, SimpleSpan> {
 }
 
 #[derive(Default)]
-struct FindBlankNodeOrVariable<'a> {
+struct FindAnyBlankNode<'a> {
     blank_node: Option<Spanned<ast::BlankNode<'a>>>,
-    variable: Option<Spanned<ast::Var<'a>>>,
 }
 
-impl<'a> TermVisitor<'a> for FindBlankNodeOrVariable<'a> {
+impl<'a> TermVisitor<'a> for FindAnyBlankNode<'a> {
     fn on_blank_node(&mut self, blank_node: &Spanned<ast::BlankNode<'a>>) {
         self.blank_node.get_or_insert(*blank_node);
     }
+}
 
+#[derive(Default)]
+struct FindAnyVariable<'a> {
+    variable: Option<Spanned<ast::Var<'a>>>,
+}
+
+impl<'a> TermVisitor<'a> for FindAnyVariable<'a> {
     fn on_variable(&mut self, variable: &Spanned<ast::Var<'a>>) {
         self.variable.get_or_insert(*variable);
+    }
+}
+
+struct FindAllVariables<'a, 'b> {
+    variables: &'b mut HashSet<&'a str>,
+}
+
+impl<'a> TermVisitor<'a> for FindAllVariables<'a, '_> {
+    fn on_variable(&mut self, variable: &Spanned<ast::Var<'a>>) {
+        self.variables.insert(variable.inner.0);
+    }
+}
+
+#[derive(Default)]
+struct FreshVariableAllocator<'a> {
+    used_variable_names: HashSet<&'a str>,
+    allocated_variable_names: HashSet<OxString>,
+    blank_node_mapping: HashMap<&'a str, Variable>,
+    counter_per_prefix: HashMap<&'a str, usize>,
+}
+
+impl<'a> FreshVariableAllocator<'a> {
+    fn reset_with_query(&mut self, query: &ast::Query<'a>) {
+        self.reset();
+        let mut visitor = FindAllVariables {
+            variables: &mut self.used_variable_names,
+        };
+        visitor.visit_query(query);
+    }
+
+    fn reset_with_update1(&mut self, update1: &ast::Update1<'a>) {
+        self.reset();
+        let mut visitor = FindAllVariables {
+            variables: &mut self.used_variable_names,
+        };
+        visitor.visit_update1(update1);
+    }
+
+    fn reset(&mut self) {
+        self.used_variable_names.clear();
+        self.allocated_variable_names.clear();
+        self.blank_node_mapping.clear();
+        self.counter_per_prefix.clear();
+    }
+
+    fn fresh_variable(&mut self, prefix: &'a str) -> Variable {
+        let counter = self.counter_per_prefix.entry(prefix).or_default();
+        loop {
+            *counter += 1;
+            let name = format!("{prefix}{}", *counter);
+            if !self.used_variable_names.contains(name.as_str())
+                && !self.allocated_variable_names.contains(name.as_str())
+            {
+                // Not used, we can emit
+                return self.emit_fresh_variable(name);
+            }
+        }
+    }
+
+    fn map_blank_node_id(&mut self, name: &'a str) -> Variable {
+        if let Some(var) = self.blank_node_mapping.get(name) {
+            return var.clone();
+        }
+        let var = if !self.used_variable_names.contains(name)
+            && !self.allocated_variable_names.contains(name)
+        {
+            // Not used, we can emit
+            self.emit_fresh_variable(OxString::new_owned(name))
+        } else {
+            self.fresh_variable(name)
+        };
+        self.blank_node_mapping.insert(name, var.clone());
+        var
+    }
+
+    fn emit_fresh_variable(&mut self, name: impl Into<OxString>) -> Variable {
+        let name = name.into();
+        self.allocated_variable_names.insert(name.clone());
+        Variable::new_unchecked(name)
+    }
+}
+
+struct FindAllBlankNodes<'a, 'b> {
+    ids: &'b mut HashSet<&'a str>,
+}
+
+impl<'a> TermVisitor<'a> for FindAllBlankNodes<'a, '_> {
+    fn on_blank_node(&mut self, blank_node: &Spanned<ast::BlankNode<'a>>) {
+        if let Some(id) = blank_node.inner.0 {
+            self.ids.insert(id);
+        }
+    }
+}
+
+#[derive(Default)]
+struct FreshBlankNodeAllocator<'a> {
+    used_blank_node_ids: HashSet<&'a str>,
+    counter_per_prefix: HashMap<&'a str, usize>,
+}
+
+impl<'a> FreshBlankNodeAllocator<'a> {
+    fn reset_with_query(&mut self, query: &ast::Query<'a>) {
+        self.reset();
+        let mut visitor = FindAllBlankNodes {
+            ids: &mut self.used_blank_node_ids,
+        };
+        visitor.visit_query(query);
+    }
+
+    fn reset_with_update(&mut self, update: &ast::Update<'a>) {
+        self.reset();
+        let mut visitor = FindAllBlankNodes {
+            ids: &mut self.used_blank_node_ids,
+        };
+        visitor.visit_update(update);
+    }
+
+    fn reset(&mut self) {
+        self.used_blank_node_ids.clear();
+        self.counter_per_prefix.clear();
+    }
+
+    fn fresh_blank_node(&mut self, prefix: &'a str) -> BlankNode {
+        let counter = self.counter_per_prefix.entry(prefix).or_default();
+        loop {
+            *counter += 1;
+            let id = format!("{prefix}{}", *counter);
+            if !self.used_blank_node_ids.contains(id.as_str()) {
+                // Not used, we can emit
+                return BlankNode::new_unchecked(id);
+            }
+        }
     }
 }
 
@@ -2833,7 +3320,7 @@ fn copy_graph(
     };
     DeleteInsertOperation {
         delete: Vec::new(),
-        insert: vec![QuadPattern::new(
+        insert: vec![QuadTemplate::new(
             Variable::new_unchecked("s"),
             Variable::new_unchecked("p"),
             Variable::new_unchecked("o"),

--- a/lib/spargebra/src/query.rs
+++ b/lib/spargebra/src/query.rs
@@ -179,7 +179,7 @@ impl From<SelectQuery> for Query {
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct ConstructQuery {
     /// The query construction template.
-    pub template: Vec<TriplePattern>,
+    pub template: Vec<TripleTemplate>,
     /// The [query dataset specification](https://www.w3.org/TR/sparql11-query/#specifyingDataset).
     pub dataset: Option<QueryDatasetSpecification>,
     /// The query selection expression.

--- a/lib/spargebra/src/term.rs
+++ b/lib/spargebra/src/term.rs
@@ -251,11 +251,11 @@ impl fmt::Display for Quad {
     }
 }
 
-impl TryFrom<QuadPattern> for Quad {
+impl TryFrom<QuadTemplate> for Quad {
     type Error = ();
 
     #[inline]
-    fn try_from(quad: QuadPattern) -> Result<Self, Self::Error> {
+    fn try_from(quad: QuadTemplate) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: quad.subject.try_into()?,
             predicate: quad.predicate.try_into()?,
@@ -397,15 +397,14 @@ impl TryFrom<NamedNodePattern> for NamedNode {
     }
 }
 
-/// The union of [terms](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term) and [variables](https://www.w3.org/TR/sparql11-query/#sparqlQueryVariables).
+/// The union of [terms](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term) and [variables](https://www.w3.org/TR/sparql11-query/#sparqlQueryVariables) without blank nodes.
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub enum TermPattern {
     NamedNode(NamedNode),
-    BlankNode(BlankNode),
     Literal(Literal),
+    Variable(Variable),
     #[cfg(feature = "sparql-12")]
     Triple(Box<TriplePattern>),
-    Variable(Variable),
 }
 
 impl TermPattern {
@@ -413,11 +412,10 @@ impl TermPattern {
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         match self {
             Self::NamedNode(term) => write!(f, "{term}"),
-            Self::BlankNode(term) => write!(f, "{term}"),
             Self::Literal(term) => write!(f, "{term}"),
+            Self::Variable(var) => write!(f, "{var}"),
             #[cfg(feature = "sparql-12")]
             Self::Triple(triple) => triple.fmt_sse(f),
-            Self::Variable(var) => write!(f, "{var}"),
         }
     }
 }
@@ -427,11 +425,10 @@ impl fmt::Display for TermPattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NamedNode(term) => term.fmt(f),
-            Self::BlankNode(term) => term.fmt(f),
             Self::Literal(term) => term.fmt(f),
+            Self::Variable(var) => var.fmt(f),
             #[cfg(feature = "sparql-12")]
             Self::Triple(triple) => write!(f, "<<( {triple} )>>"),
-            Self::Variable(var) => var.fmt(f),
         }
     }
 }
@@ -440,13 +437,6 @@ impl From<NamedNode> for TermPattern {
     #[inline]
     fn from(node: NamedNode) -> Self {
         Self::NamedNode(node)
-    }
-}
-
-impl From<BlankNode> for TermPattern {
-    #[inline]
-    fn from(node: BlankNode) -> Self {
-        Self::BlankNode(node)
     }
 }
 
@@ -466,30 +456,20 @@ impl From<TriplePattern> for TermPattern {
 }
 
 impl From<Variable> for TermPattern {
+    #[inline]
     fn from(var: Variable) -> Self {
         Self::Variable(var)
     }
 }
 
-impl From<NamedOrBlankNode> for TermPattern {
+impl From<GroundTerm> for TermPattern {
     #[inline]
-    fn from(subject: NamedOrBlankNode) -> Self {
-        match subject {
-            NamedOrBlankNode::NamedNode(node) => node.into(),
-            NamedOrBlankNode::BlankNode(node) => node.into(),
-        }
-    }
-}
-
-impl From<Term> for TermPattern {
-    #[inline]
-    fn from(term: Term) -> Self {
+    fn from(term: GroundTerm) -> Self {
         match term {
-            Term::NamedNode(node) => node.into(),
-            Term::BlankNode(node) => node.into(),
-            Term::Literal(literal) => literal.into(),
+            GroundTerm::NamedNode(node) => node.into(),
+            GroundTerm::Literal(literal) => literal.into(),
             #[cfg(feature = "sparql-12")]
-            Term::Triple(t) => TriplePattern::from(*t).into(),
+            GroundTerm::Triple(triple) => TriplePattern::from(*triple).into(),
         }
     }
 }
@@ -504,93 +484,78 @@ impl From<NamedNodePattern> for TermPattern {
     }
 }
 
-impl From<GroundTermPattern> for TermPattern {
-    #[inline]
-    fn from(element: GroundTermPattern) -> Self {
-        match element {
-            GroundTermPattern::NamedNode(node) => node.into(),
-            GroundTermPattern::Literal(literal) => literal.into(),
-            #[cfg(feature = "sparql-12")]
-            GroundTermPattern::Triple(t) => TriplePattern::from(*t).into(),
-            GroundTermPattern::Variable(variable) => variable.into(),
-        }
-    }
-}
-
-impl TryFrom<TermPattern> for NamedOrBlankNode {
+impl TryFrom<TermTemplate> for TermPattern {
     type Error = ();
 
     #[inline]
-    fn try_from(term: TermPattern) -> Result<Self, Self::Error> {
-        match term {
-            TermPattern::NamedNode(t) => Ok(t.into()),
-            TermPattern::BlankNode(t) => Ok(t.into()),
+    fn try_from(pattern: TermTemplate) -> Result<Self, Self::Error> {
+        Ok(match pattern {
+            TermTemplate::NamedNode(named_node) => named_node.into(),
+            TermTemplate::BlankNode(_) => return Err(()),
+            TermTemplate::Literal(literal) => literal.into(),
             #[cfg(feature = "sparql-12")]
-            TermPattern::Triple(_) => Err(()),
-            TermPattern::Literal(_) | TermPattern::Variable(_) => Err(()),
-        }
+            TermTemplate::Triple(triple) => TriplePattern::try_from(*triple)?.into(),
+            TermTemplate::Variable(variable) => variable.into(),
+        })
     }
 }
 
-impl TryFrom<TermPattern> for Term {
-    type Error = ();
-
-    #[inline]
-    fn try_from(pattern: TermPattern) -> Result<Self, Self::Error> {
-        match pattern {
-            TermPattern::NamedNode(t) => Ok(t.into()),
-            TermPattern::BlankNode(t) => Ok(t.into()),
-            TermPattern::Literal(t) => Ok(t.into()),
-            #[cfg(feature = "sparql-12")]
-            TermPattern::Triple(t) => Ok(Triple::try_from(*t)?.into()),
-            TermPattern::Variable(_) => Err(()),
-        }
-    }
-}
-/// The union of [terms](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term) and [variables](https://www.w3.org/TR/sparql11-query/#sparqlQueryVariables) without blank nodes.
+/// The union of [terms](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term) and [variables](https://www.w3.org/TR/sparql11-query/#sparqlQueryVariables).
+///
+/// It is used in [`ConstructQuery`](crate::query::ConstructQuery).
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
-pub enum GroundTermPattern {
+pub enum TermTemplate {
     NamedNode(NamedNode),
+    BlankNode(BlankNode),
     Literal(Literal),
-    Variable(Variable),
     #[cfg(feature = "sparql-12")]
-    Triple(Box<GroundTriplePattern>),
+    Triple(Box<TripleTemplate>),
+    Variable(Variable),
 }
 
-impl GroundTermPattern {
+impl TermTemplate {
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         match self {
             Self::NamedNode(term) => write!(f, "{term}"),
+            Self::BlankNode(term) => write!(f, "{term}"),
             Self::Literal(term) => write!(f, "{term}"),
-            Self::Variable(var) => write!(f, "{var}"),
             #[cfg(feature = "sparql-12")]
             Self::Triple(triple) => triple.fmt_sse(f),
+            Self::Variable(var) => write!(f, "{var}"),
         }
     }
 }
 
-impl fmt::Display for GroundTermPattern {
+impl fmt::Display for TermTemplate {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NamedNode(term) => term.fmt(f),
+            Self::BlankNode(term) => term.fmt(f),
             Self::Literal(term) => term.fmt(f),
-            Self::Variable(var) => var.fmt(f),
             #[cfg(feature = "sparql-12")]
             Self::Triple(triple) => write!(f, "<<( {triple} )>>"),
+            Self::Variable(var) => var.fmt(f),
         }
     }
 }
 
-impl From<NamedNode> for GroundTermPattern {
+impl From<NamedNode> for TermTemplate {
     #[inline]
     fn from(node: NamedNode) -> Self {
         Self::NamedNode(node)
     }
 }
 
-impl From<Literal> for GroundTermPattern {
+impl From<BlankNode> for TermTemplate {
+    #[inline]
+    fn from(node: BlankNode) -> Self {
+        Self::BlankNode(node)
+    }
+}
+
+impl From<Literal> for TermTemplate {
     #[inline]
     fn from(literal: Literal) -> Self {
         Self::Literal(literal)
@@ -598,33 +563,43 @@ impl From<Literal> for GroundTermPattern {
 }
 
 #[cfg(feature = "sparql-12")]
-impl From<GroundTriplePattern> for GroundTermPattern {
+impl From<TripleTemplate> for TermTemplate {
     #[inline]
-    fn from(triple: GroundTriplePattern) -> Self {
+    fn from(triple: TripleTemplate) -> Self {
         Self::Triple(Box::new(triple))
     }
 }
 
-impl From<Variable> for GroundTermPattern {
-    #[inline]
+impl From<Variable> for TermTemplate {
     fn from(var: Variable) -> Self {
         Self::Variable(var)
     }
 }
 
-impl From<GroundTerm> for GroundTermPattern {
+impl From<NamedOrBlankNode> for TermTemplate {
     #[inline]
-    fn from(term: GroundTerm) -> Self {
-        match term {
-            GroundTerm::NamedNode(node) => node.into(),
-            GroundTerm::Literal(literal) => literal.into(),
-            #[cfg(feature = "sparql-12")]
-            GroundTerm::Triple(triple) => GroundTriplePattern::from(*triple).into(),
+    fn from(subject: NamedOrBlankNode) -> Self {
+        match subject {
+            NamedOrBlankNode::NamedNode(node) => node.into(),
+            NamedOrBlankNode::BlankNode(node) => node.into(),
         }
     }
 }
 
-impl From<NamedNodePattern> for GroundTermPattern {
+impl From<Term> for TermTemplate {
+    #[inline]
+    fn from(term: Term) -> Self {
+        match term {
+            Term::NamedNode(node) => node.into(),
+            Term::BlankNode(node) => node.into(),
+            Term::Literal(literal) => literal.into(),
+            #[cfg(feature = "sparql-12")]
+            Term::Triple(t) => TripleTemplate::from(*t).into(),
+        }
+    }
+}
+
+impl From<NamedNodePattern> for TermTemplate {
     #[inline]
     fn from(element: NamedNodePattern) -> Self {
         match element {
@@ -634,19 +609,47 @@ impl From<NamedNodePattern> for GroundTermPattern {
     }
 }
 
-impl TryFrom<TermPattern> for GroundTermPattern {
+impl From<TermPattern> for TermTemplate {
+    #[inline]
+    fn from(element: TermPattern) -> Self {
+        match element {
+            TermPattern::NamedNode(node) => node.into(),
+            TermPattern::Literal(literal) => literal.into(),
+            #[cfg(feature = "sparql-12")]
+            TermPattern::Triple(t) => TripleTemplate::from(*t).into(),
+            TermPattern::Variable(variable) => variable.into(),
+        }
+    }
+}
+
+impl TryFrom<TermTemplate> for NamedOrBlankNode {
     type Error = ();
 
     #[inline]
-    fn try_from(pattern: TermPattern) -> Result<Self, Self::Error> {
-        Ok(match pattern {
-            TermPattern::NamedNode(named_node) => named_node.into(),
-            TermPattern::BlankNode(_) => return Err(()),
-            TermPattern::Literal(literal) => literal.into(),
+    fn try_from(term: TermTemplate) -> Result<Self, Self::Error> {
+        match term {
+            TermTemplate::NamedNode(t) => Ok(t.into()),
+            TermTemplate::BlankNode(t) => Ok(t.into()),
             #[cfg(feature = "sparql-12")]
-            TermPattern::Triple(triple) => GroundTriplePattern::try_from(*triple)?.into(),
-            TermPattern::Variable(variable) => variable.into(),
-        })
+            TermTemplate::Triple(_) => Err(()),
+            TermTemplate::Literal(_) | TermTemplate::Variable(_) => Err(()),
+        }
+    }
+}
+
+impl TryFrom<TermTemplate> for Term {
+    type Error = ();
+
+    #[inline]
+    fn try_from(pattern: TermTemplate) -> Result<Self, Self::Error> {
+        match pattern {
+            TermTemplate::NamedNode(t) => Ok(t.into()),
+            TermTemplate::BlankNode(t) => Ok(t.into()),
+            TermTemplate::Literal(t) => Ok(t.into()),
+            #[cfg(feature = "sparql-12")]
+            TermTemplate::Triple(t) => Ok(Triple::try_from(*t)?.into()),
+            TermTemplate::Variable(_) => Err(()),
+        }
     }
 }
 
@@ -714,7 +717,9 @@ impl From<NamedNodePattern> for GraphNamePattern {
     }
 }
 
-/// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern)
+/// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern).
+///
+/// Note that `spargebra` follows SPARQL 1.2 and converts blank node to variables in patterns.
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct TriplePattern {
     pub subject: TermPattern,
@@ -754,76 +759,8 @@ impl fmt::Display for TriplePattern {
     }
 }
 
-impl From<Triple> for TriplePattern {
-    #[inline]
-    fn from(triple: Triple) -> Self {
-        Self {
-            subject: triple.subject.into(),
-            predicate: triple.predicate.into(),
-            object: triple.object.into(),
-        }
-    }
-}
-
 #[cfg(feature = "sparql-12")]
-impl From<GroundTriplePattern> for TriplePattern {
-    #[inline]
-    fn from(triple: GroundTriplePattern) -> Self {
-        Self {
-            subject: triple.subject.into(),
-            predicate: triple.predicate,
-            object: triple.object.into(),
-        }
-    }
-}
-
-impl TryFrom<TriplePattern> for Triple {
-    type Error = ();
-
-    #[inline]
-    fn try_from(triple: TriplePattern) -> Result<Self, Self::Error> {
-        Ok(Self {
-            subject: triple.subject.try_into()?,
-            predicate: triple.predicate.try_into()?,
-            object: triple.object.try_into()?,
-        })
-    }
-}
-
-/// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern) without blank nodes.
-#[cfg(feature = "sparql-12")]
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-pub struct GroundTriplePattern {
-    pub subject: GroundTermPattern,
-    pub predicate: NamedNodePattern,
-    pub object: GroundTermPattern,
-}
-
-#[cfg(feature = "sparql-12")]
-impl GroundTriplePattern {
-    /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
-    #[cfg(feature = "sparql-12")]
-    pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
-        f.write_str("(triple ")?;
-        self.subject.fmt_sse(f)?;
-        f.write_str(" ")?;
-        self.predicate.fmt_sse(f)?;
-        f.write_str(" ")?;
-        self.object.fmt_sse(f)?;
-        f.write_str(")")
-    }
-}
-
-#[cfg(feature = "sparql-12")]
-impl fmt::Display for GroundTriplePattern {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}", self.subject, self.predicate, self.object)
-    }
-}
-
-#[cfg(feature = "sparql-12")]
-impl From<GroundTriple> for GroundTriplePattern {
+impl From<GroundTriple> for TriplePattern {
     #[inline]
     fn from(triple: GroundTriple) -> Self {
         Self {
@@ -835,11 +772,11 @@ impl From<GroundTriple> for GroundTriplePattern {
 }
 
 #[cfg(feature = "sparql-12")]
-impl TryFrom<TriplePattern> for GroundTriplePattern {
+impl TryFrom<TripleTemplate> for TriplePattern {
     type Error = ();
 
     #[inline]
-    fn try_from(triple: TriplePattern) -> Result<Self, Self::Error> {
+    fn try_from(triple: TripleTemplate) -> Result<Self, Self::Error> {
         Ok(Self {
             subject: triple.subject.try_into()?,
             predicate: triple.predicate,
@@ -848,7 +785,85 @@ impl TryFrom<TriplePattern> for GroundTriplePattern {
     }
 }
 
-/// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern) in a specific graph
+/// A triple with variables.
+///
+/// It is used in [`ConstructQuery`](crate::query::ConstructQuery).
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+pub struct TripleTemplate {
+    pub subject: TermTemplate,
+    pub predicate: NamedNodePattern,
+    pub object: TermTemplate,
+}
+
+impl TripleTemplate {
+    pub(crate) fn new(
+        subject: impl Into<TermTemplate>,
+        predicate: impl Into<NamedNodePattern>,
+        object: impl Into<TermTemplate>,
+    ) -> Self {
+        Self {
+            subject: subject.into(),
+            predicate: predicate.into(),
+            object: object.into(),
+        }
+    }
+
+    /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
+    pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
+        f.write_str("(triple ")?;
+        self.subject.fmt_sse(f)?;
+        f.write_str(" ")?;
+        self.predicate.fmt_sse(f)?;
+        f.write_str(" ")?;
+        self.object.fmt_sse(f)?;
+        f.write_str(")")
+    }
+}
+
+impl fmt::Display for TripleTemplate {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {}", self.subject, self.predicate, self.object)
+    }
+}
+
+impl From<Triple> for TripleTemplate {
+    #[inline]
+    fn from(triple: Triple) -> Self {
+        Self {
+            subject: triple.subject.into(),
+            predicate: triple.predicate.into(),
+            object: triple.object.into(),
+        }
+    }
+}
+
+#[cfg(feature = "sparql-12")]
+impl From<TriplePattern> for TripleTemplate {
+    #[inline]
+    fn from(triple: TriplePattern) -> Self {
+        Self {
+            subject: triple.subject.into(),
+            predicate: triple.predicate,
+            object: triple.object.into(),
+        }
+    }
+}
+
+impl TryFrom<TripleTemplate> for Triple {
+    type Error = ();
+
+    #[inline]
+    fn try_from(triple: TripleTemplate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            subject: triple.subject.try_into()?,
+            predicate: triple.predicate.try_into()?,
+            object: triple.object.try_into()?,
+        })
+    }
+}
+
+/// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern) in a specific graph.
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct QuadPattern {
     pub subject: TermPattern,
@@ -858,20 +873,6 @@ pub struct QuadPattern {
 }
 
 impl QuadPattern {
-    pub(crate) fn new(
-        subject: impl Into<TermPattern>,
-        predicate: impl Into<NamedNodePattern>,
-        object: impl Into<TermPattern>,
-        graph_name: impl Into<GraphNamePattern>,
-    ) -> Self {
-        Self {
-            subject: subject.into(),
-            predicate: predicate.into(),
-            object: object.into(),
-            graph_name: graph_name.into(),
-        }
-    }
-
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         if self.graph_name != GraphNamePattern::DefaultGraph {
@@ -908,16 +909,44 @@ impl fmt::Display for QuadPattern {
     }
 }
 
-/// A [triple pattern](https://www.w3.org/TR/sparql11-query/#defn_TriplePattern) in a specific graph without blank nodes.
+impl TryFrom<QuadTemplate> for QuadPattern {
+    type Error = ();
+
+    #[inline]
+    fn try_from(pattern: QuadTemplate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            subject: pattern.subject.try_into()?,
+            predicate: pattern.predicate,
+            object: pattern.object.try_into()?,
+            graph_name: pattern.graph_name,
+        })
+    }
+}
+
+/// A [`TripleTemplate`] in a specific graph
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
-pub struct GroundQuadPattern {
-    pub subject: GroundTermPattern,
+pub struct QuadTemplate {
+    pub subject: TermTemplate,
     pub predicate: NamedNodePattern,
-    pub object: GroundTermPattern,
+    pub object: TermTemplate,
     pub graph_name: GraphNamePattern,
 }
 
-impl GroundQuadPattern {
+impl QuadTemplate {
+    pub(crate) fn new(
+        subject: impl Into<TermTemplate>,
+        predicate: impl Into<NamedNodePattern>,
+        object: impl Into<TermTemplate>,
+        graph_name: impl Into<GraphNamePattern>,
+    ) -> Self {
+        Self {
+            subject: subject.into(),
+            predicate: predicate.into(),
+            object: object.into(),
+            graph_name: graph_name.into(),
+        }
+    }
+
     /// Formats using the [SPARQL S-Expression syntax](https://jena.apache.org/documentation/notes/sse.html).
     pub(crate) fn fmt_sse(&self, f: &mut impl Write) -> fmt::Result {
         if self.graph_name != GraphNamePattern::DefaultGraph {
@@ -939,7 +968,7 @@ impl GroundQuadPattern {
     }
 }
 
-impl fmt::Display for GroundQuadPattern {
+impl fmt::Display for QuadTemplate {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.graph_name == GraphNamePattern::DefaultGraph {
@@ -951,19 +980,5 @@ impl fmt::Display for GroundQuadPattern {
                 self.graph_name, self.subject, self.predicate, self.object
             )
         }
-    }
-}
-
-impl TryFrom<QuadPattern> for GroundQuadPattern {
-    type Error = ();
-
-    #[inline]
-    fn try_from(pattern: QuadPattern) -> Result<Self, Self::Error> {
-        Ok(Self {
-            subject: pattern.subject.try_into()?,
-            predicate: pattern.predicate,
-            object: pattern.object.try_into()?,
-            graph_name: pattern.graph_name,
-        })
     }
 }

--- a/lib/spargebra/src/update.rs
+++ b/lib/spargebra/src/update.rs
@@ -210,8 +210,8 @@ impl From<DeleteDataOperation> for GraphUpdateOperation {
 /// The [delete insert](https://www.w3.org/TR/sparql11-update/#defn_deleteInsertOperation) update operation.
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct DeleteInsertOperation {
-    pub delete: Vec<GroundQuadPattern>,
-    pub insert: Vec<QuadPattern>,
+    pub delete: Vec<QuadPattern>,
+    pub insert: Vec<QuadTemplate>,
     pub using: Option<QueryDatasetSpecification>,
     pub pattern: Box<QueryExpression>,
 }

--- a/lib/sparopt/src/algebra.rs
+++ b/lib/sparopt/src/algebra.rs
@@ -8,15 +8,14 @@ use spargebra::algebra::{
     AggregateExpression as AlAggregateExpression, Expression as AlExpression,
     OrderExpression as AlOrderExpression, QueryExpression as AlQueryExpression,
 };
-use spargebra::term::{BlankNode, TermPattern, TriplePattern};
-pub use spargebra::term::{
-    GroundTerm, GroundTermPattern, Literal, NamedNode, NamedNodePattern, Variable,
-};
 #[cfg(feature = "sparql-12")]
-use spargebra::term::{GroundTriple, GroundTriplePattern};
+use spargebra::term::GroundTriple;
+pub use spargebra::term::{
+    GroundTerm, Literal, NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
+};
 use spargebra::vocab::sparql;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::{BitAnd, BitOr, Not};
 
@@ -207,51 +206,6 @@ impl Expression {
         }
     }
 
-    fn from_sparql_algebra(expression: &AlExpression) -> Self {
-        match expression {
-            AlExpression::NamedNode(node) => Self::NamedNode(node.clone()),
-            AlExpression::Literal(literal) => Self::Literal(literal.clone()),
-            AlExpression::Variable(variable) => Self::Variable(variable.clone()),
-            AlExpression::Or(left, right) => Self::Or(vec![
-                Self::from_sparql_algebra(left),
-                Self::from_sparql_algebra(right),
-            ]),
-            AlExpression::And(left, right) => Self::And(vec![
-                Self::from_sparql_algebra(left),
-                Self::from_sparql_algebra(right),
-            ]),
-            AlExpression::In(left, right) => {
-                let left = Self::from_sparql_algebra(left);
-                match right.len() {
-                    0 => Self::if_cond(left, false.into(), false.into()),
-                    1 => Self::equal(left, Self::from_sparql_algebra(&right[0])),
-                    _ => Self::Or(
-                        right
-                            .iter()
-                            .map(|e| Self::equal(left.clone(), Self::from_sparql_algebra(e)))
-                            .collect(),
-                    ),
-                }
-            }
-            AlExpression::Exists(inner) => Self::Exists(Box::new(
-                QueryExpression::from_sparql_algebra(inner, &mut HashMap::new()),
-            )),
-            AlExpression::Bound(variable) => Self::Bound(variable.clone()),
-            AlExpression::If(cond, yes, no) => Self::If(
-                Box::new(Self::from_sparql_algebra(cond)),
-                Box::new(Self::from_sparql_algebra(yes)),
-                Box::new(Self::from_sparql_algebra(no)),
-            ),
-            AlExpression::Coalesce(inner) => {
-                Self::Coalesce(inner.iter().map(Self::from_sparql_algebra).collect())
-            }
-            AlExpression::FunctionCall(name, args) => Self::FunctionCall(
-                name.clone(),
-                args.iter().map(Self::from_sparql_algebra).collect(),
-            ),
-        }
-    }
-
     fn returns_boolean(&self) -> bool {
         match self {
             Self::Or(_) | Self::And(_) | Self::Exists(_) | Self::Bound(_) => true,
@@ -317,14 +271,14 @@ impl From<NamedNodePattern> for Expression {
     }
 }
 
-impl From<GroundTermPattern> for Expression {
-    fn from(value: GroundTermPattern) -> Self {
+impl From<TermPattern> for Expression {
+    fn from(value: TermPattern) -> Self {
         match value {
-            GroundTermPattern::NamedNode(value) => value.into(),
-            GroundTermPattern::Literal(value) => value.into(),
+            TermPattern::NamedNode(value) => value.into(),
+            TermPattern::Literal(value) => value.into(),
             #[cfg(feature = "sparql-12")]
-            GroundTermPattern::Triple(value) => (*value).into(),
-            GroundTermPattern::Variable(variable) => variable.into(),
+            TermPattern::Triple(value) => (*value).into(),
+            TermPattern::Variable(variable) => variable.into(),
         }
     }
 }
@@ -344,8 +298,8 @@ impl From<GroundTriple> for Expression {
 }
 
 #[cfg(feature = "sparql-12")]
-impl From<GroundTriplePattern> for Expression {
-    fn from(value: GroundTriplePattern) -> Self {
+impl From<TriplePattern> for Expression {
+    fn from(value: TriplePattern) -> Self {
         Self::FunctionCall(
             sparql::TRIPLE,
             vec![
@@ -366,6 +320,46 @@ impl From<Variable> for Expression {
 impl From<bool> for Expression {
     fn from(value: bool) -> Self {
         Literal::from(value).into()
+    }
+}
+
+impl From<&AlExpression> for Expression {
+    fn from(expression: &AlExpression) -> Self {
+        match expression {
+            AlExpression::NamedNode(node) => Self::NamedNode(node.clone()),
+            AlExpression::Literal(literal) => Self::Literal(literal.clone()),
+            AlExpression::Variable(variable) => Self::Variable(variable.clone()),
+            AlExpression::Or(left, right) => {
+                Self::Or(vec![left.as_ref().into(), right.as_ref().into()])
+            }
+            AlExpression::And(left, right) => {
+                Self::And(vec![left.as_ref().into(), right.as_ref().into()])
+            }
+            AlExpression::In(left, right) => {
+                let left = left.as_ref().into();
+                match right.len() {
+                    0 => Self::if_cond(left, false.into(), false.into()),
+                    1 => Self::equal(left, (&right[0]).into()),
+                    _ => Self::Or(
+                        right
+                            .iter()
+                            .map(|e| Self::equal(left.clone(), e.into()))
+                            .collect(),
+                    ),
+                }
+            }
+            AlExpression::Exists(inner) => Self::Exists(Box::new(QueryExpression::from(&**inner))),
+            AlExpression::Bound(variable) => Self::Bound(variable.clone()),
+            AlExpression::If(cond, yes, no) => Self::If(
+                Box::new(cond.as_ref().into()),
+                Box::new(yes.as_ref().into()),
+                Box::new(no.as_ref().into()),
+            ),
+            AlExpression::Coalesce(inner) => Self::Coalesce(inner.iter().map(Into::into).collect()),
+            AlExpression::FunctionCall(name, args) => {
+                Self::FunctionCall(name.clone(), args.iter().map(Into::into).collect())
+            }
+        }
     }
 }
 
@@ -433,16 +427,16 @@ impl Not for Expression {
 pub enum QueryExpression {
     /// A [basic graph pattern](https://www.w3.org/TR/sparql11-query/#defn_BasicGraphPattern).
     QuadPattern {
-        subject: GroundTermPattern,
+        subject: TermPattern,
         predicate: NamedNodePattern,
-        object: GroundTermPattern,
+        object: TermPattern,
         graph_name: Option<NamedNodePattern>, // None for the default graph
     },
     /// A [property path pattern](https://www.w3.org/TR/sparql11-query/#defn_evalPP_predicate).
     Path {
-        subject: GroundTermPattern,
+        subject: TermPattern,
         path: PropertyPathExpression,
-        object: GroundTermPattern,
+        object: TermPattern,
     },
     /// [Graph](https://www.w3.org/TR/sparql11-query/#defn_evalGraph).
     Graph {
@@ -950,22 +944,37 @@ impl QueryExpression {
         order
     }
 
-    fn from_sparql_algebra(
-        query_expression: &AlQueryExpression,
-        blank_nodes: &mut HashMap<BlankNode, Variable>,
-    ) -> Self {
+    /// Makes sure the expression is a variable, use Extend in the other cases
+    fn algebra_expression_to_constant_or_variable(
+        expression: &AlExpression,
+        query_expression: QueryExpression,
+    ) -> (Variable, QueryExpression) {
+        if let AlExpression::Variable(variable) = expression {
+            (variable.clone(), query_expression)
+        } else {
+            let variable = new_var();
+            (
+                variable.clone(),
+                QueryExpression::Extend {
+                    inner: Box::new(query_expression),
+                    variable,
+                    expression: expression.into(),
+                },
+            )
+        }
+    }
+}
+
+impl From<&AlQueryExpression> for QueryExpression {
+    fn from(query_expression: &AlQueryExpression) -> Self {
         match query_expression {
             AlQueryExpression::Bgp { patterns } => patterns
                 .iter()
-                .map(|p| {
-                    let (subject, predicate, object) =
-                        Self::triple_pattern_from_algebra(p, blank_nodes);
-                    Self::QuadPattern {
-                        subject,
-                        predicate,
-                        object,
-                        graph_name: None,
-                    }
+                .map(|pattern| Self::QuadPattern {
+                    subject: pattern.subject.clone(),
+                    predicate: pattern.predicate.clone(),
+                    object: pattern.object.clone(),
+                    graph_name: None,
                 })
                 .reduce(|a, b| Self::Join {
                     left: Box::new(a),
@@ -978,13 +987,13 @@ impl QueryExpression {
                 path,
                 object,
             } => Self::Path {
-                subject: Self::term_pattern_from_algebra(subject, blank_nodes),
+                subject: subject.clone(),
                 path: path.clone(),
-                object: Self::term_pattern_from_algebra(object, blank_nodes),
+                object: object.clone(),
             },
             AlQueryExpression::Join { left, right } => Self::Join {
-                left: Box::new(Self::from_sparql_algebra(left, blank_nodes)),
-                right: Box::new(Self::from_sparql_algebra(right, blank_nodes)),
+                left: Box::new((&**left).into()),
+                right: Box::new((&**right).into()),
                 algorithm: JoinAlgorithm::default(),
             },
             AlQueryExpression::LeftJoin {
@@ -992,44 +1001,39 @@ impl QueryExpression {
                 right,
                 expression,
             } => Self::LeftJoin {
-                left: Box::new(Self::from_sparql_algebra(left, blank_nodes)),
-                right: Box::new(Self::from_sparql_algebra(right, blank_nodes)),
-                expression: expression
-                    .as_ref()
-                    .map_or_else(|| true.into(), Expression::from_sparql_algebra),
+                left: Box::new((&**left).into()),
+                right: Box::new((&**right).into()),
+                expression: expression.as_ref().map_or_else(|| true.into(), Into::into),
                 algorithm: LeftJoinAlgorithm::default(),
             },
             #[cfg(feature = "sep-0006")]
             AlQueryExpression::Lateral { left, right } => Self::Lateral {
-                left: Box::new(Self::from_sparql_algebra(left, blank_nodes)),
-                right: Box::new(Self::from_sparql_algebra(right, blank_nodes)),
+                left: Box::new((&**left).into()),
+                right: Box::new((&**right).into()),
             },
             AlQueryExpression::Filter { inner, expr } => Self::Filter {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
-                expression: Expression::from_sparql_algebra(expr),
+                inner: Box::new((&**inner).into()),
+                expression: expr.into(),
             },
             AlQueryExpression::Union { left, right } => Self::Union {
-                inner: vec![
-                    Self::from_sparql_algebra(left, blank_nodes),
-                    Self::from_sparql_algebra(right, blank_nodes),
-                ],
+                inner: vec![(&**left).into(), (&**right).into()],
             },
             AlQueryExpression::Graph { inner, name } => Self::Graph {
                 graph_name: name.clone(),
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
+                inner: Box::new((&**inner).into()),
             },
             AlQueryExpression::Extend {
                 inner,
                 expression,
                 variable,
             } => Self::Extend {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
-                expression: Expression::from_sparql_algebra(expression),
+                inner: Box::new((&**inner).into()),
+                expression: expression.into(),
                 variable: variable.clone(),
             },
             AlQueryExpression::Minus { left, right } => Self::Minus {
-                left: Box::new(Self::from_sparql_algebra(left, blank_nodes)),
-                right: Box::new(Self::from_sparql_algebra(right, blank_nodes)),
+                left: Box::new((&**left).into()),
+                right: Box::new((&**right).into()),
                 algorithm: MinusAlgorithm::default(),
             },
             AlQueryExpression::Values {
@@ -1040,7 +1044,7 @@ impl QueryExpression {
                 bindings: bindings.clone(),
             },
             AlQueryExpression::OrderBy { inner, expression } => {
-                let mut inner = Self::from_sparql_algebra(inner, blank_nodes);
+                let mut inner = (&**inner).into();
                 let mut expressions = Vec::with_capacity(expression.len());
                 for e in expression {
                     expressions.push(match e {
@@ -1062,21 +1066,21 @@ impl QueryExpression {
                 }
             }
             AlQueryExpression::Project { inner, variables } => Self::Project {
-                inner: Box::new(Self::from_sparql_algebra(inner, &mut HashMap::new())),
+                inner: Box::new((&**inner).into()),
                 variables: variables.clone(),
             },
             AlQueryExpression::Distinct { inner } => Self::Distinct {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
+                inner: Box::new((&**inner).into()),
             },
             AlQueryExpression::Reduced { inner } => Self::Distinct {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
+                inner: Box::new((&**inner).into()),
             },
             AlQueryExpression::Slice {
                 inner,
                 offset,
                 limit,
             } => Self::Slice {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
+                inner: Box::new((&**inner).into()),
                 offset: *offset,
                 limit: *limit,
             },
@@ -1085,13 +1089,11 @@ impl QueryExpression {
                 variables,
                 aggregates,
             } => Self::Group {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
+                inner: Box::new((&**inner).into()),
                 variables: variables.clone(),
                 aggregates: aggregates
                     .iter()
-                    .map(|(var, expr)| {
-                        (var.clone(), AggregateExpression::from_sparql_algebra(expr))
-                    })
+                    .map(|(var, expr)| (var.clone(), expr.into()))
                     .collect(),
             },
             AlQueryExpression::Service {
@@ -1099,75 +1101,11 @@ impl QueryExpression {
                 name,
                 silent,
             } => Self::Service {
-                inner: Box::new(Self::from_sparql_algebra(inner, blank_nodes)),
+                inner: Box::new((&**inner).into()),
                 name: name.clone(),
                 silent: *silent,
             },
         }
-    }
-
-    fn triple_pattern_from_algebra(
-        pattern: &TriplePattern,
-        blank_nodes: &mut HashMap<BlankNode, Variable>,
-    ) -> (GroundTermPattern, NamedNodePattern, GroundTermPattern) {
-        (
-            Self::term_pattern_from_algebra(&pattern.subject, blank_nodes),
-            pattern.predicate.clone(),
-            Self::term_pattern_from_algebra(&pattern.object, blank_nodes),
-        )
-    }
-
-    fn term_pattern_from_algebra(
-        pattern: &TermPattern,
-        blank_nodes: &mut HashMap<BlankNode, Variable>,
-    ) -> GroundTermPattern {
-        match pattern {
-            TermPattern::NamedNode(node) => node.clone().into(),
-            TermPattern::BlankNode(node) => blank_nodes
-                .entry(node.clone())
-                .or_insert_with(new_var)
-                .clone()
-                .into(),
-            TermPattern::Literal(literal) => literal.clone().into(),
-            #[cfg(feature = "sparql-12")]
-            TermPattern::Triple(pattern) => {
-                let (subject, predicate, object) =
-                    Self::triple_pattern_from_algebra(pattern, blank_nodes);
-                GroundTriplePattern {
-                    subject,
-                    predicate,
-                    object,
-                }
-                .into()
-            }
-            TermPattern::Variable(variable) => variable.clone().into(),
-        }
-    }
-
-    /// Makes sure the expression is a variable, use Extend in the other cases
-    fn algebra_expression_to_constant_or_variable(
-        expression: &AlExpression,
-        query_expression: QueryExpression,
-    ) -> (Variable, QueryExpression) {
-        if let AlExpression::Variable(variable) = expression {
-            (variable.clone(), query_expression)
-        } else {
-            let variable = new_var();
-            (
-                variable.clone(),
-                QueryExpression::Extend {
-                    inner: Box::new(query_expression),
-                    variable,
-                    expression: Expression::from_sparql_algebra(expression),
-                },
-            )
-        }
-    }
-}
-
-impl From<&AlQueryExpression> for QueryExpression {
-    fn from(query_expression: &AlQueryExpression) -> Self {
-        Self::from_sparql_algebra(query_expression, &mut HashMap::new())
     }
 }
 
@@ -1182,9 +1120,9 @@ impl From<&QueryExpression> for AlQueryExpression {
             } => {
                 let pattern = Self::Bgp {
                     patterns: vec![TriplePattern {
-                        subject: subject.clone().into(),
+                        subject: subject.clone(),
                         predicate: predicate.clone(),
-                        object: object.clone().into(),
+                        object: object.clone(),
                     }],
                 };
                 if let Some(graph_name) = graph_name {
@@ -1201,9 +1139,9 @@ impl From<&QueryExpression> for AlQueryExpression {
                 path,
                 object,
             } => Self::Path {
-                subject: subject.clone().into(),
+                subject: subject.clone(),
                 path: path.clone(),
-                object: object.clone().into(),
+                object: object.clone(),
             },
             QueryExpression::Graph { graph_name, inner } => Self::Graph {
                 inner: Box::new(inner.as_ref().into()),
@@ -1394,8 +1332,8 @@ pub enum AggregateExpression {
     },
 }
 
-impl AggregateExpression {
-    fn from_sparql_algebra(expression: &AlAggregateExpression) -> Self {
+impl From<&AlAggregateExpression> for AggregateExpression {
+    fn from(expression: &AlAggregateExpression) -> Self {
         match expression {
             AlAggregateExpression::CountSolutions { distinct } => Self::CountSolutions {
                 distinct: *distinct,
@@ -1407,7 +1345,7 @@ impl AggregateExpression {
                 scalarvals,
             } => Self::FunctionCall {
                 name: name.clone(),
-                expr: Expression::from_sparql_algebra(expr),
+                expr: expr.into(),
                 distinct: *distinct,
                 scalarvals: scalarvals.clone(),
             },
@@ -1474,14 +1412,14 @@ fn hash(v: impl Hash) -> u64 {
 }
 
 fn lookup_term_pattern_variables<'a>(
-    pattern: &'a GroundTermPattern,
+    pattern: &'a TermPattern,
     callback: &mut impl FnMut(&'a Variable),
 ) {
-    if let GroundTermPattern::Variable(v) = pattern {
+    if let TermPattern::Variable(v) = pattern {
         callback(v);
     }
     #[cfg(feature = "sparql-12")]
-    if let GroundTermPattern::Triple(t) = pattern {
+    if let TermPattern::Triple(t) = pattern {
         lookup_term_pattern_variables(&t.subject, callback);
         if let NamedNodePattern::Variable(v) = &t.predicate {
             callback(v);
@@ -1500,9 +1438,9 @@ mod tests {
 
     fn quad_pattern(subject: &str, predicate: &str, object: &str) -> QueryExpression {
         QueryExpression::QuadPattern {
-            subject: GroundTermPattern::Variable(var(subject)),
+            subject: TermPattern::Variable(var(subject)),
             predicate: NamedNodePattern::Variable(var(predicate)),
-            object: GroundTermPattern::Variable(var(object)),
+            object: TermPattern::Variable(var(object)),
             graph_name: None,
         }
     }

--- a/lib/sparopt/src/optimizer.rs
+++ b/lib/sparopt/src/optimizer.rs
@@ -7,7 +7,7 @@ use crate::type_inference::{
 use oxrdf::Variable;
 use oxrdf::vocab::rdf;
 use spargebra::algebra::PropertyPathExpression;
-use spargebra::term::{GroundTermPattern, NamedNodePattern};
+use spargebra::term::{NamedNodePattern, TermPattern};
 use spargebra::vocab::sparql;
 use std::cmp::{max, min};
 
@@ -1152,9 +1152,9 @@ fn is_fit_for_for_loop_join(
 }
 
 fn is_path_fit_for_for_loop_join(
-    subject: &GroundTermPattern,
+    subject: &TermPattern,
     path: &PropertyPathExpression,
-    object: &GroundTermPattern,
+    object: &TermPattern,
     entry_types: &VariableTypes,
 ) -> bool {
     match path {
@@ -1175,7 +1175,7 @@ fn is_path_fit_for_for_loop_join(
         }
         PropertyPathExpression::ZeroOrMorePath(_) | PropertyPathExpression::ZeroOrOnePath(_) => {
             // We don't want to set the left or right side of the zero or ... path because it could be returned in the result set even if it is not supported in the graph
-            if let (GroundTermPattern::Variable(subject), GroundTermPattern::Variable(object)) =
+            if let (TermPattern::Variable(subject), TermPattern::Variable(object)) =
                 (subject, object)
             {
                 entry_types.get(subject) == VariableType::UNDEF
@@ -1449,12 +1449,12 @@ fn estimate_path_size(start_bound: bool, path: &PropertyPathExpression, end_boun
     }
 }
 
-fn is_term_pattern_bound(pattern: &GroundTermPattern, input_types: &VariableTypes) -> bool {
+fn is_term_pattern_bound(pattern: &TermPattern, input_types: &VariableTypes) -> bool {
     match pattern {
-        GroundTermPattern::NamedNode(_) | GroundTermPattern::Literal(_) => true,
-        GroundTermPattern::Variable(v) => !input_types.get(v).undef,
+        TermPattern::NamedNode(_) | TermPattern::Literal(_) => true,
+        TermPattern::Variable(v) => !input_types.get(v).undef,
         #[cfg(feature = "sparql-12")]
-        GroundTermPattern::Triple(t) => {
+        TermPattern::Triple(t) => {
             is_term_pattern_bound(&t.subject, input_types)
                 && is_named_node_pattern_bound(&t.predicate, input_types)
                 && is_term_pattern_bound(&t.object, input_types)

--- a/lib/sparopt/src/type_inference.rs
+++ b/lib/sparopt/src/type_inference.rs
@@ -1,7 +1,7 @@
 use crate::algebra::{Expression, QueryExpression};
 use oxrdf::Variable;
 use oxrdf::vocab::xsd;
-use spargebra::term::{GroundTerm, GroundTermPattern, NamedNodePattern};
+use spargebra::term::{GroundTerm, NamedNodePattern, TermPattern};
 use spargebra::vocab::sparql;
 use std::collections::HashMap;
 use std::ops::{BitAnd, BitOr};
@@ -17,11 +17,11 @@ pub fn infer_query_expression_types(
             object,
             graph_name,
         } => {
-            add_ground_term_pattern_types(subject, &mut types, false);
+            add_term_pattern_types(subject, &mut types, false);
             if let NamedNodePattern::Variable(v) = predicate {
                 types.intersect_variable_with(v.clone(), VariableType::NAMED_NODE)
             }
-            add_ground_term_pattern_types(object, &mut types, true);
+            add_term_pattern_types(object, &mut types, true);
             if let Some(NamedNodePattern::Variable(v)) = graph_name {
                 types.intersect_variable_with(v.clone(), VariableType::NAMED_NODE)
             }
@@ -30,8 +30,8 @@ pub fn infer_query_expression_types(
         QueryExpression::Path {
             subject, object, ..
         } => {
-            add_ground_term_pattern_types(subject, &mut types, false);
-            add_ground_term_pattern_types(object, &mut types, true);
+            add_term_pattern_types(subject, &mut types, false);
+            add_term_pattern_types(object, &mut types, true);
             types
         }
         QueryExpression::Graph { graph_name, inner } => {
@@ -144,12 +144,8 @@ pub fn infer_query_expression_types(
     }
 }
 
-fn add_ground_term_pattern_types(
-    pattern: &GroundTermPattern,
-    types: &mut VariableTypes,
-    is_object: bool,
-) {
-    if let GroundTermPattern::Variable(v) = pattern {
+fn add_term_pattern_types(pattern: &TermPattern, types: &mut VariableTypes, is_object: bool) {
+    if let TermPattern::Variable(v) = pattern {
         types.intersect_variable_with(
             v.clone(),
             if is_object {
@@ -160,12 +156,12 @@ fn add_ground_term_pattern_types(
         )
     }
     #[cfg(feature = "sparql-12")]
-    if let GroundTermPattern::Triple(t) = pattern {
-        add_ground_term_pattern_types(&t.subject, types, false);
+    if let TermPattern::Triple(t) = pattern {
+        add_term_pattern_types(&t.subject, types, false);
         if let NamedNodePattern::Variable(v) = &t.predicate {
             types.intersect_variable_with(v.clone(), VariableType::NAMED_NODE)
         }
-        add_ground_term_pattern_types(&t.object, types, true);
+        add_term_pattern_types(&t.object, types, true);
     }
 }
 

--- a/testsuite/oxigraph-tests/sparql/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql/manifest.ttl
@@ -46,6 +46,7 @@
     :merged_default_graph
     :merged_default_graph_join
     :merged_default_graph_update
+    :repeated_blank_node
     ) .
 
 :merged_default_graph rdf:type mf:QueryEvaluationTest ;
@@ -237,3 +238,8 @@
     mf:name "xsd:string cast edge case testing" ;
     mf:action [ qt:query <xsd_string_cast.rq> ] ;
     mf:result  <xsd_string_cast.srx> .
+
+:repeated_blank_node rdf:type mf:QueryEvaluationTest ;
+    mf:name "same blank node multiple times in the query" ;
+    mf:action [ qt:query <repeated_blank_node.rq> ; qt:data <repeated_blank_node.ttl> ] ;
+    mf:result  <repeated_blank_node.srx> .

--- a/testsuite/oxigraph-tests/sparql/repeated_blank_node.rq
+++ b/testsuite/oxigraph-tests/sparql/repeated_blank_node.rq
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.org/>
+
+SELECT ?o1 ?o2 WHERE {
+    _:a ex:p1 ?o1 .
+    _:a ex:p2 ?o2 .
+}

--- a/testsuite/oxigraph-tests/sparql/repeated_blank_node.srx
+++ b/testsuite/oxigraph-tests/sparql/repeated_blank_node.srx
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="o1"/>
+    <variable name="o2"/>
+  </head>
+  <results>
+    <result>
+      <binding name="o1">
+        <uri>http://example.org/o</uri>
+      </binding>
+      <binding name="o2">
+        <uri>http://example.org/o</uri>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/testsuite/oxigraph-tests/sparql/repeated_blank_node.ttl
+++ b/testsuite/oxigraph-tests/sparql/repeated_blank_node.ttl
@@ -1,0 +1,7 @@
+PREFIX ex: <http://example.org/>
+
+ex:s1 ex:p1 ex:o1 .
+
+ex:s2 ex:p2 ex:o2 .
+
+ex:s ex:p1 ex:o ; ex:p2 ex:o .

--- a/testsuite/src/sparql_evaluator.rs
+++ b/testsuite/src/sparql_evaluator.rs
@@ -98,13 +98,10 @@ pub fn register_sparql_tests(evaluator: &mut TestEvaluator) {
 
 fn evaluate_positive_syntax_test(test: &Test) -> Result<()> {
     let query_file = test.action.as_deref().context("No action found")?;
-    let query = SparqlParser::new()
+    SparqlParser::new()
         .with_base_iri(query_file)?
         .parse_query(&read_file_to_string(query_file)?)
         .context("Not able to parse")?;
-    SparqlParser::new()
-        .parse_query(&query.to_string())
-        .with_context(|| format!("Failure to deserialize \"{query}\""))?;
     Ok(())
 }
 


### PR DESCRIPTION
They are replaced by fresh variables

Follows SPARQL 1.2 draft

The "(Triple|Term)Pattern" structs are renamed "(Triple|Term)Template" and "Ground(Term|Triple)Pattern" structs are now renamed "(Triple|Term)Pattern"