### PR TITLE
Revert "SPARQL internal algebra: restrict the order input to a variable"

### DIFF
--- a/lib/spareval/src/eval.rs
+++ b/lib/spareval/src/eval.rs
@@ -1486,32 +1486,28 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
         let (child, child_stats) = self.query_expression_evaluator(inner, encoded_variables);
         stat_children.push(child_stats);
         let child = child?;
-        let by = expression
+        let (expressions, is_asc) = expression
             .iter()
-            .filter_map(|comp| {
-                Some(match comp {
-                    OrderExpression::Asc(variable) => {
-                        (true, slice_key(encoded_variables, variable)?)
-                    }
-                    OrderExpression::Desc(variable) => {
-                        (false, slice_key(encoded_variables, variable)?)
-                    }
+            .map(|comp| {
+                Ok(match comp {
+                    OrderExpression::Asc(expression) => (
+                        self.expression_evaluator(expression, encoded_variables, stat_children)?,
+                        true,
+                    ),
+                    OrderExpression::Desc(expression) => (
+                        self.expression_evaluator(expression, encoded_variables, stat_children)?,
+                        false,
+                    ),
                 })
             })
-            .collect::<Vec<_>>();
-        let dataset = self.dataset.clone();
+            .collect::<Result<(Vec<_>, Vec<_>), QueryEvaluationError>>()?;
         Ok(Rc::new(move |from| {
             let mut tuples_and_sort_keys = match child(from)
                 .map(|tuple| {
                     let tuple = tuple?;
-                    let sort_terms = by
+                    let sort_terms = expressions
                         .iter()
-                        .map(|(_, variable_key)| {
-                            tuple
-                                .get(*variable_key)
-                                .map(|term| dataset.externalize_expression_term(term.clone()))
-                                .transpose()
-                        })
+                        .map(|expr| expr(&tuple))
                         .collect::<Result<Vec<_>, _>>()?;
                     Ok((tuple, sort_terms))
                 })
@@ -1521,7 +1517,7 @@ impl<'a, D: QueryableDataset<'a>> SimpleEvaluator<'a, D> {
                 Err(error) => return Box::new(once(Err(error))),
             };
             tuples_and_sort_keys.sort_unstable_by(|(_, a), (_, b)| {
-                for ((is_asc, _), (a, b)) in by.iter().zip(a.iter().zip(b)) {
+                for (is_asc, (a, b)) in is_asc.iter().zip(a.iter().zip(b)) {
                     match cmp_terms(a.as_ref(), b.as_ref()) {
                         Ordering::Greater => {
                             return if *is_asc {

--- a/lib/sparopt/src/algebra.rs
+++ b/lib/sparopt/src/algebra.rs
@@ -2,7 +2,6 @@
 
 use oxrdf::vocab::xsd;
 use oxstr::OxString;
-use rand::random;
 pub use spargebra::algebra::PropertyPathExpression;
 use spargebra::algebra::{
     AggregateExpression as AlAggregateExpression, Expression as AlExpression,
@@ -943,26 +942,6 @@ impl QueryExpression {
         });
         order
     }
-
-    /// Makes sure the expression is a variable, use Extend in the other cases
-    fn algebra_expression_to_constant_or_variable(
-        expression: &AlExpression,
-        query_expression: QueryExpression,
-    ) -> (Variable, QueryExpression) {
-        if let AlExpression::Variable(variable) = expression {
-            (variable.clone(), query_expression)
-        } else {
-            let variable = new_var();
-            (
-                variable.clone(),
-                QueryExpression::Extend {
-                    inner: Box::new(query_expression),
-                    variable,
-                    expression: expression.into(),
-                },
-            )
-        }
-    }
 }
 
 impl From<&AlQueryExpression> for QueryExpression {
@@ -1043,28 +1022,10 @@ impl From<&AlQueryExpression> for QueryExpression {
                 variables: variables.clone(),
                 bindings: bindings.clone(),
             },
-            AlQueryExpression::OrderBy { inner, expression } => {
-                let mut inner = (&**inner).into();
-                let mut expressions = Vec::with_capacity(expression.len());
-                for e in expression {
-                    expressions.push(match e {
-                        AlOrderExpression::Asc(e) => {
-                            let v;
-                            (v, inner) = Self::algebra_expression_to_constant_or_variable(e, inner);
-                            OrderExpression::Asc(v)
-                        }
-                        AlOrderExpression::Desc(e) => {
-                            let v;
-                            (v, inner) = Self::algebra_expression_to_constant_or_variable(e, inner);
-                            OrderExpression::Desc(v)
-                        }
-                    });
-                }
-                Self::OrderBy {
-                    inner: Box::new(inner),
-                    expression: expressions,
-                }
-            }
+            AlQueryExpression::OrderBy { inner, expression } => Self::OrderBy {
+                inner: Box::new(Self::from(&**inner)),
+                expression: expression.iter().map(Into::into).collect(),
+            },
             AlQueryExpression::Project { inner, variables } => Self::Project {
                 inner: Box::new((&**inner).into()),
                 variables: variables.clone(),
@@ -1378,22 +1339,27 @@ impl From<&AggregateExpression> for AlAggregateExpression {
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub enum OrderExpression {
     /// Ascending order
-    Asc(Variable),
+    Asc(Expression),
     /// Descending order
-    Desc(Variable),
+    Desc(Expression),
+}
+
+impl From<&AlOrderExpression> for OrderExpression {
+    fn from(expression: &AlOrderExpression) -> Self {
+        match expression {
+            AlOrderExpression::Asc(e) => Self::Asc(e.into()),
+            AlOrderExpression::Desc(e) => Self::Desc(e.into()),
+        }
+    }
 }
 
 impl From<&OrderExpression> for AlOrderExpression {
     fn from(expression: &OrderExpression) -> Self {
         match expression {
-            OrderExpression::Asc(e) => Self::Asc(e.clone().into()),
-            OrderExpression::Desc(e) => Self::Desc(e.clone().into()),
+            OrderExpression::Asc(e) => Self::Asc(e.into()),
+            OrderExpression::Desc(e) => Self::Desc(e.into()),
         }
     }
-}
-
-fn new_var() -> Variable {
-    Variable::new_unchecked(OxString::new_owned(&format!("{:x}", random::<u128>())))
 }
 
 fn order_pair<T: Hash>(a: T, b: T) -> (T, T) {


### PR DESCRIPTION
This reverts commit 145e5d0f

With the new pre-computation of the order key, pre-computing the expressions is less useful