### PR TITLE
SPARQL: fixes wrong filter propagation through projection

### DIFF
--- a/lib/sparopt/src/optimizer.rs
+++ b/lib/sparopt/src/optimizer.rs
@@ -515,10 +515,31 @@ impl Optimizer {
             QueryExpression::Reduced { inner } => {
                 QueryExpression::reduced(Self::push_filters(*inner, filters, input_types))
             }
-            QueryExpression::Project { inner, variables } => QueryExpression::project(
-                Self::push_filters(*inner, filters, input_types),
-                variables,
-            ),
+            QueryExpression::Project { inner, variables } => {
+                let mut inner_filters = Vec::new();
+                let mut final_filters = Vec::new();
+                for filter in filters {
+                    if filter
+                        .used_variables()
+                        .into_iter()
+                        .all(|variable| variables.contains(variable))
+                    {
+                        inner_filters.push(filter);
+                    } else {
+                        // Variables not projected by a subquery are not in scope outside of it.
+                        // Pushing such a filter would make the subquery's hidden bindings visible
+                        // to the filter, in particular for correlated EXISTS expressions.
+                        final_filters.push(filter);
+                    }
+                }
+                QueryExpression::filter(
+                    QueryExpression::project(
+                        Self::push_filters(*inner, inner_filters, input_types),
+                        variables,
+                    ),
+                    Expression::and_all(final_filters),
+                )
+            }
             QueryExpression::OrderBy { inner, expression } => QueryExpression::order_by(
                 Self::push_filters(*inner, filters, input_types),
                 expression,

--- a/testsuite/oxigraph-tests/sparql-optimization/filter_projection_scope_input.rq
+++ b/testsuite/oxigraph-tests/sparql-optimization/filter_projection_scope_input.rq
@@ -1,0 +1,8 @@
+SELECT ?x WHERE {
+    {
+        SELECT ?x WHERE {
+            VALUES (?x ?hidden) { (1 1) }
+        }
+    }
+    FILTER(?hidden = 1)
+}

--- a/testsuite/oxigraph-tests/sparql-optimization/filter_projection_scope_output.rq
+++ b/testsuite/oxigraph-tests/sparql-optimization/filter_projection_scope_output.rq
@@ -1,0 +1,8 @@
+SELECT ?x WHERE {
+    {
+        SELECT ?x WHERE {
+            VALUES (?x ?hidden) { (1 1) }
+        }
+    }
+    FILTER sameTerm(?hidden, 1)
+}

--- a/testsuite/oxigraph-tests/sparql-optimization/manifest.ttl
+++ b/testsuite/oxigraph-tests/sparql-optimization/manifest.ttl
@@ -32,6 +32,7 @@
     :bgp_join_reordering
     :optional_lateral_reordering
     :nested_bind_lateral_reordering
+    :filter_projection_scope
     ) .
 
 
@@ -154,3 +155,8 @@
     mf:name "Nested BGP below BIND is converted to LATERAL" ;
     mf:action <nested_bind_lateral_reordering_input.rq> ;
     mf:result <nested_bind_lateral_reordering_output.rq> .
+
+:filter_projection_scope rdf:type ox:QueryOptimizationTest ;
+    mf:name "Filter pushdown preserves subquery projection scope" ;
+    mf:action <filter_projection_scope_input.rq> ;
+    mf:result <filter_projection_scope_output.rq> .


### PR DESCRIPTION
We only do it if it does not change variable binding